### PR TITLE
cli/daemon/dash/dashapp: use "2.3" instead of "fl2.3" for float64

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -127,7 +127,7 @@ class JSONRenderer {
     case BuiltinType.Uint32: return "1"
     case BuiltinType.Uint64: return "1"
     case BuiltinType.Float32: return "2.3"
-    case BuiltinType.Float64: return "fl2.3"
+    case BuiltinType.Float64: return "2.3"
     case BuiltinType.String: return "\"some string\""
     case BuiltinType.Bytes: return "\"base64-encoded-bytes\""
     case BuiltinType.Time: return "\"2009-11-10T23:00:00Z\""


### PR DESCRIPTION
I see no reason why the example for float32 should be "2.3" while it should be "fl2.3" for float64 in the dashboard. If there is any reason, please feel free to discard this PR.