### PR TITLE
cli/internal/codegen(ts): don't include body for GET requests

### DIFF
--- a/cli/internal/codegen/ts.go
+++ b/cli/internal/codegen/ts.go
@@ -310,7 +310,7 @@ func (ts *ts) writeBaseClient() {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req)
+            body: req && JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()
@@ -323,7 +323,7 @@ func (ts *ts) writeBaseClient() {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req)
+            body: req && JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()

--- a/cli/internal/codegen/ts.go
+++ b/cli/internal/codegen/ts.go
@@ -310,7 +310,7 @@ func (ts *ts) writeBaseClient() {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: req && JSON.stringify(req)
+            body: req !== undefined ? JSON.stringify(req) : undefined
         })
         if (!response.ok) {
             let body = await response.text()
@@ -323,7 +323,7 @@ func (ts *ts) writeBaseClient() {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: req && JSON.stringify(req)
+            body: req !== undefined ? JSON.stringify(req) : undefined
         })
         if (!response.ok) {
             let body = await response.text()

--- a/cli/internal/codegen/ts.go
+++ b/cli/internal/codegen/ts.go
@@ -310,7 +310,7 @@ func (ts *ts) writeBaseClient() {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req || {})
+            body: JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()
@@ -323,7 +323,7 @@ func (ts *ts) writeBaseClient() {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req || {})
+            body: JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()

--- a/cli/internal/codegen/ts_test.go
+++ b/cli/internal/codegen/ts_test.go
@@ -101,7 +101,7 @@ class BaseClient {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: req && JSON.stringify(req)
+            body: req !== undefined ? JSON.stringify(req) : undefined
         })
         if (!response.ok) {
             let body = await response.text()
@@ -114,7 +114,7 @@ class BaseClient {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: req && JSON.stringify(req)
+            body: req !== undefined ? JSON.stringify(req) : undefined
         })
         if (!response.ok) {
             let body = await response.text()

--- a/cli/internal/codegen/ts_test.go
+++ b/cli/internal/codegen/ts_test.go
@@ -101,7 +101,7 @@ class BaseClient {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req || {})
+            body: JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()
@@ -114,7 +114,7 @@ class BaseClient {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req || {})
+            body: JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()

--- a/cli/internal/codegen/ts_test.go
+++ b/cli/internal/codegen/ts_test.go
@@ -101,7 +101,7 @@ class BaseClient {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req)
+            body: req && JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()
@@ -114,7 +114,7 @@ class BaseClient {
         let response = await fetch(this.baseURL + path, {
             method: method,
             headers: this.headers,
-            body: JSON.stringify(req)
+            body: req && JSON.stringify(req)
         })
         if (!response.ok) {
             let body = await response.text()


### PR DESCRIPTION
GET requests don't support body. However, the generated typesciprt api client always includes a body. As a result, you get the error when trying to make a GET request using the generated client: 
```
Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body.
```

I solved it by using the fact that `JSON.stringify(undefined) === undefined`. This means that if `req` is undefined, the request won't have any body.

Encore does complain if there's no body on a POST request. However, this won't be a problem since all POST requests from the API client always include params as body.

I'm of course willing to change the solution if you feel like another approach would fit better.