### PR TITLE
cli/daemon/dash/dashapp: add required `baseUrl` to tsconfig

### DIFF
--- a/cli/daemon/dash/dashapp/tsconfig.json
+++ b/cli/daemon/dash/dashapp/tsconfig.json
@@ -15,6 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
+    "baseUrl": ".",
     "paths": {
       "~c/*": ["./src/components/*"],
       "~lib/*": ["./src/lib/*"],


### PR DESCRIPTION
Using this is required as per [TypeScript docs](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping). Having no `baseUrl` also broke intellisense in my editor (Webstorm).