### PR TITLE
Set console mode for stdout and stderr in windows. Fixes #56

### DIFF
--- a/cli/cmd/encore/init_windows.go
+++ b/cli/cmd/encore/init_windows.go
@@ -1,0 +1,21 @@
+// +build windows
+
+package main
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// init activates virtual terminal feature on "windows", this enables colored
+// terminal output.
+func init() {
+	setConsoleMode(windows.Stdout, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	setConsoleMode(windows.Stderr, windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+}
+
+// setConsoleMode enables VT processing on stout and stderr.
+func setConsoleMode(handle windows.Handle, flag uint32) {
+	var mode uint32
+	windows.GetConsoleMode(handle, &mode)
+	windows.SetConsoleMode(handle, mode|flag)
+}

--- a/cli/cmd/encore/init_windows.go
+++ b/cli/cmd/encore/init_windows.go
@@ -16,6 +16,7 @@ func init() {
 // setConsoleMode enables VT processing on stout and stderr.
 func setConsoleMode(handle windows.Handle, flag uint32) {
 	var mode uint32
-	windows.GetConsoleMode(handle, &mode)
-	windows.SetConsoleMode(handle, mode|flag)
+	if err := windows.GetConsoleMode(handle, &mode); err == nil {
+		windows.SetConsoleMode(handle, mode|flag)
+	}
 }


### PR DESCRIPTION
Please refer https://github.com/encoredev/encore/issues/56 

Git bash:
<img width="468" alt="git-bash" src="https://user-images.githubusercontent.com/22986964/129476255-8457a5fa-abe2-4c39-9528-3450ba6074a7.PNG">

Cmd:
<img width="487" alt="cmd" src="https://user-images.githubusercontent.com/22986964/129476262-5777d099-6e94-443b-ab7b-7dec3250ee7e.PNG">

Powershell:
<img width="488" alt="ps" src="https://user-images.githubusercontent.com/22986964/129476274-2493d181-0f01-4544-95b8-f41ca9c8e65a.PNG">

