### PR TITLE
parser: fix json tag parsing

### DIFF
--- a/parser/schema.go
+++ b/parser/schema.go
@@ -209,7 +209,7 @@ func (p *parser) parseStructTag(tag *ast.BasicLit) structFieldOptions {
 		}
 	}
 	if js, _ := tags.Get("json"); js != nil {
-		if v := js.Value(); v != "" {
+		if v := js.Name; v != "" {
 			opts.JSONName = v
 		}
 	}

--- a/parser/schema_test.go
+++ b/parser/schema_test.go
@@ -1,0 +1,42 @@
+package parser
+
+import (
+	"go/ast"
+	goparser "go/parser"
+	"go/scanner"
+	"go/token"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseStructTag(t *testing.T) {
+	tests := []struct {
+		Tag  string
+		Want structFieldOptions
+	}{
+		{
+			Tag:  `json:"foo"`,
+			Want: structFieldOptions{JSONName: "foo"},
+		},
+		{
+			Tag:  `json:"foo,omitempty"`,
+			Want: structFieldOptions{JSONName: "foo"},
+		},
+		{
+			Tag:  `json:"foo,omitempty" encore:"optional"`,
+			Want: structFieldOptions{JSONName: "foo", Optional: true},
+		},
+	}
+
+	p := &parser{fset: token.NewFileSet()}
+	c := qt.New(t)
+	for _, test := range tests {
+		x, err := goparser.ParseExpr("`" + test.Tag + "`")
+		c.Assert(err, qt.IsNil)
+		lit := x.(*ast.BasicLit)
+		got := p.parseStructTag(lit)
+		c.Assert(p.errors, qt.DeepEquals, scanner.ErrorList(nil))
+		c.Assert(got, qt.DeepEquals, test.Want)
+	}
+}


### PR DESCRIPTION
The JSON struct tag parsing included other options beyond just the name,
leading to bugs when including ",omitempty" and so on.

Fix this by using the Name field and not the Value() method.

Fixes #65