### PR TITLE
parser: improve parsing logic for named databases

### DIFF
--- a/parser/est/est.go
+++ b/parser/est/est.go
@@ -100,6 +100,9 @@ type Node struct {
 	// If Type == SQLDBNode or RLogNode,
 	// Func is the func name being called.
 	Func string
+
+	// Resource this refers to, if any
+	Res Resource
 }
 
 type AuthHandler struct {

--- a/parser/testdata/resource_sqldb_cross_service.txt
+++ b/parser/testdata/resource_sqldb_cross_service.txt
@@ -1,4 +1,5 @@
-parse
+! parse
+stderr 'cannot reference resource svca.Moo outside the service'
 
 -- svca/svca.go --
 package svca

--- a/parser/testdata/resource_sqldb_helper.txt
+++ b/parser/testdata/resource_sqldb_helper.txt
@@ -1,10 +1,12 @@
 parse
+stdout 'resource SQLDBResource svc.Moo db=moo'
 
 -- svc/svc.go --
 package svc
 
 import (
     "context"
+    "test/pkg"
 
     "encore.dev/storage/sqldb"
 )
@@ -13,17 +15,18 @@ var Moo = sqldb.Named("moo")
 
 //encore:api public
 func Foo(ctx context.Context) error {
+    pkg.Foo(Moo)
     return nil
 }
--- svc/pkg/pkg.go --
+-- pkg/pkg.go --
 package pkg
 
 import (
     "context"
-    "test/svc"
+    
+    "encore.dev/storage/sqldb"
 )
 
-func Foo() {
-    _ = svc.Moo
-    _ = svc.Moo.Query
+func Foo(db *sqldb.Database) {
+    _ = db.Query
 }

--- a/parser/testdata/resource_sqldb_outside_ref.txt
+++ b/parser/testdata/resource_sqldb_outside_ref.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'cannot reference resource svc.Moo other than by calling methods on it'
+stderr 'cannot reference variable svc.Moo from outside the service'
 
 -- svc/svc.go --
 package svc
@@ -16,12 +16,14 @@ var Moo = sqldb.Named("moo")
 func Foo(ctx context.Context) error {
     return nil
 }
--- svc/pkg/pkg.go --
+-- pkg/pkg.go --
 package pkg
 
 import (
     "context"
     "test/svc"
+    
+    "encore.dev/storage/sqldb"
 )
 
 func Foo() {

--- a/parser/testdata/resource_sqldb_outside_svc.txt
+++ b/parser/testdata/resource_sqldb_outside_svc.txt
@@ -1,0 +1,13 @@
+! parse
+stderr 'cannot define SQL Database resource in non-service package'
+
+-- pkg/pkg.go --
+package pkg
+
+import (
+    "context"
+
+    "encore.dev/storage/sqldb"
+)
+
+var Moo = sqldb.Named("moo")


### PR DESCRIPTION
This clarifies some of the business rules for referencing database resources, notably around allowing to pass around variables of type `*sqldb.Database`.