### PR TITLE
compiler: fix potential circular import in tests

### DIFF
--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -707,15 +707,15 @@ func (b *Builder) typeName(param *est.Param, skipPtr bool) Code {
 }
 
 func (b *Builder) authDataType() Code {
+	s := ""
 	if ah := b.res.App.AuthHandler; ah != nil && ah.AuthData != nil {
 		t := ah.AuthData
+		s = t.Decl.Loc.PkgPath + "." + t.Decl.Name
 		if t.IsPtr {
-			return Qual("reflect", "TypeOf").Call(Parens(b.typeName(t, false)).Call(Nil()))
-		} else {
-			return Qual("reflect", "TypeOf").Call(Parens(Op("*").Add(b.typeName(t, false))).Call(Nil())).Dot("Elem").Call()
+			s = "*" + s
 		}
 	}
-	return Nil()
+	return Lit(s)
 }
 
 func buildErr(code, msg string) *Statement {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
@@ -25,7 +25,7 @@ func main() {
 	services := []*config.Service{}
 
 	cfg := &config.ServerConfig{
-		AuthData: nil,
+		AuthData: "",
 		Services: services,
 		Testing:  false,
 	}

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -17,7 +17,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 )
@@ -556,7 +555,7 @@ func main() {
 	}}
 
 	cfg := &config.ServerConfig{
-		AuthData: reflect.TypeOf((*svc.AuthData)(nil)),
+		AuthData: "*encore.app/svc.AuthData",
 		Services: services,
 		Testing:  false,
 	}

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
@@ -6,7 +6,6 @@ import (
 	"encore.dev/runtime/config"
 	"encore.dev/storage/sqldb"
 	"os"
-	"reflect"
 	"testing"
 )
 
@@ -21,7 +20,7 @@ func TestMain(m *testing.M) {
 
 	// Set up the Encore runtime
 	cfg := &config.ServerConfig{
-		AuthData: reflect.TypeOf((*AuthData)(nil)),
+		AuthData: "*encore.app/svc.AuthData",
 		Services: services,
 		Testing:  true,
 	}

--- a/compiler/runtime/runtime/config/config.go
+++ b/compiler/runtime/runtime/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"net/http"
-	"reflect"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -10,8 +9,8 @@ import (
 type ServerConfig struct {
 	Testing  bool
 	Services []*Service
-	// AuthData is the custom auth data type, or nil
-	AuthData reflect.Type
+	// AuthData is the custom auth data type, or "" if none
+	AuthData string
 }
 
 type Service struct {

--- a/compiler/runtime/runtime/request.go
+++ b/compiler/runtime/runtime/request.go
@@ -423,12 +423,19 @@ func checkAuthData(uid UID, userData interface{}) error {
 		return fmt.Errorf("invalid API call options: empty uid and non-empty auth data")
 	}
 
-	if Config.AuthData != nil {
+	if Config.AuthData != "" {
 		if uid != "" && userData == nil {
 			return fmt.Errorf("invalid API call options: missing auth data")
 		} else if userData != nil {
-			if tt := reflect.TypeOf(userData); tt != Config.AuthData {
-				return fmt.Errorf("invalid API call options: wrong type for auth data (got %s, expected %s)", tt, Config.AuthData)
+			tt := reflect.TypeOf(userData)
+			var name string
+			for tt.Kind() == reflect.Ptr {
+				name += "*"
+				tt = tt.Elem()
+			}
+			name += tt.PkgPath() + "." + tt.Name()
+			if name != Config.AuthData {
+				return fmt.Errorf("invalid API call options: wrong type for auth data (got %s, expected %s)", name, Config.AuthData)
 			}
 		}
 	} else {


### PR DESCRIPTION
Since we were using reflect.Type to track the auth data type
we inadvertently caused tests to import other packages.
Work around this by using the string representation instead.