### PR TITLE
Documentation: Add test and deploy to rest-api tutorial

### DIFF
--- a/docs/tutorials/rest-api.md
+++ b/docs/tutorials/rest-api.md
@@ -187,3 +187,64 @@ $ curl http://localhost:4000/url/zr6RmZc4
 ```
 
 And there you have it! That's how you build REST APIs in Encore.
+
+## Add a test and deploy
+
+Before deployment, it is good practice to have tests to assure that
+the service works properly. Such tests including database access
+are easy to write.
+
+For this tutorial a test to check that the whole cycle of shortening
+the URL, storing and then retrieving the original URL could look like:
+
+```go
+package url
+
+import (
+	"context"
+	"testing"
+)
+
+// TestShortenAndRetrieve - test that the shortened URL is stored and retrieved from database.
+func TestShortenAndRetrieve(t *testing.T) {
+	testURL := "https://github.com/encoredev/encore"
+	sp := ShortenParams{URL: testURL}
+	resp, err := Shorten(context.Background(), &sp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantURL := testURL
+	if resp.URL != wantURL {
+		t.Errorf("got %q, want %q", resp.URL, wantURL)
+	}
+
+	firstURL := resp
+	gotURL, err := Get(context.Background(), firstURL.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *gotURL != *firstURL {
+		t.Errorf("got %v, want %v", *gotURL, *firstURL)
+	}
+}
+```
+
+Store this in a separate file `url/url_test.go` and run
+`encore test ./...`.
+
+A final step before you deploy is to commit all changes
+to the project repo. Do this by committing the new files to the
+project's git repo.
+
+```bash
+$ git add url
+$ git commit -m 'working service including test'
+```
+
+Then you can finally deploy as
+
+```bash
+$ encore push encore
+```
+
+Now your service is running in the cloud. Hooray!


### PR DESCRIPTION
If you type `git push encore` without having committed your files, you get an error that tells that there are no tests, but the actual issue is that there are no new go packages. It would be nice to get a better message, but to avoid getting there it would be good if was mentioned somewhere that you should do this extra step of committing the new files.

Anyway, that triggered me to write a test and extend the rest-api tutorial to include writing a test, commit files and then push to commit.

Hopefully, you view this as an improvement to the tutorial.

