### PR TITLE
cli/daemon/sqldb: increase shared mem cap

### DIFF
--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -101,6 +101,7 @@ func (c *Cluster) Start(log runlog.Log) error {
 				"run",
 				"-d",
 				"-p", "5432",
+				"--shm-size=1gb",
 				"-e", "POSTGRES_USER=encore",
 				"-e", "POSTGRES_PASSWORD=" + c.ID,
 				"-e", "POSTGRES_DB=postgres",


### PR DESCRIPTION
The local development database was provisioned with
a very conservative, default memory limit of 16MB.

Change this to 1GB to support larger databases and
more complex queries.

Thanks to @vilhelmmelkstam for the report!