### PR TITLE
cli: Improve TypeScript codegen

### DIFF
--- a/cli/internal/codegen/ts.go
+++ b/cli/internal/codegen/ts.go
@@ -253,7 +253,7 @@ func (ts *ts) writeService(svc *meta.Service) {
 		fmt.Fprintf(ts, `("%s", `+"`%s`", method, rpcPath.String())
 		if rpc.RequestSchema != nil && methodHasBody {
 			ts.WriteString(", " + payloadName)
-		} else if methodHasBody {
+		} else if rpc.Proto == meta.RPC_RAW {
 			ts.WriteString(", req")
 		}
 		ts.WriteString(")\n")


### PR DESCRIPTION
- Allows Client methods overload
- Provides support for Raw endpoints

**Breaking changes:**
- Generated TypeScript client methods do not throw an error anymore and return `Result` instead, which either contains `{error: ErrorResponse}` or `data` field with the json from the response body
- Raw endpoint methods return underlying `Response`, without consuming response body
- Void endpoints no longer consume response body, unless they result in an error

Tested on JS & Deno; in order to support NodeJS one needs to either import fetch polyfill or extend `Client` class and override `doRaw` method.

Closes #114,#50