### PR TITLE
Disable generic tests when not Go 1.18

### DIFF
--- a/cli/internal/codegen/client_test.go
+++ b/cli/internal/codegen/client_test.go
@@ -1,3 +1,5 @@
+//go:build go1.18
+
 package codegen
 
 import (

--- a/compiler/internal/codegen/type_resolver_go118_test.go
+++ b/compiler/internal/codegen/type_resolver_go118_test.go
@@ -1,0 +1,11 @@
+//go:build go1.18
+
+package codegen
+
+import . "encr.dev/proto/encore/parser/schema/v1"
+
+func init() {
+	schemaTypeToGoTypeTestCases = append(schemaTypeToGoTypeTestCases, schemaTypeToGoTypeTestCase{
+		"generic named types", &Type{Typ: &Type_Named{Named: &Named{Id: 0, TypeArguments: []*Type{intType, uuidType}}}}, "codegentest.UserAge[int, uuid.UUID]",
+	})
+}

--- a/compiler/internal/codegen/type_resolver_test.go
+++ b/compiler/internal/codegen/type_resolver_test.go
@@ -12,46 +12,47 @@ import (
 	. "encr.dev/proto/encore/parser/schema/v1"
 )
 
+var intType = &Type{Typ: &Type_Builtin{Builtin: Builtin_INT}}
+var uuidType = &Type{Typ: &Type_Builtin{Builtin: Builtin_UUID}}
+var structType = &Type{Typ: &Type_Struct{Struct: &Struct{Fields: []*Field{
+	{Name: "Age", Typ: intType, Doc: "age at sign up"},
+	{Name: "DateOfBirth", Typ: &Type{Typ: &Type_Builtin{Builtin: Builtin_TIME}}, Doc: "date of birth", JsonName: "dob", Optional: true},
+	{Name: "Id", Typ: uuidType, JsonName: "-"},
+}}}}
+
+type schemaTypeToGoTypeTestCase struct {
+	name string
+	typ  *Type
+	want string
+}
+
+// This has been extracted out of the test below so for now we can use a build tag to add a Go 1.18 specific test
+var schemaTypeToGoTypeTestCases = []schemaTypeToGoTypeTestCase{
+	{"any", &Type{Typ: &Type_Builtin{Builtin: Builtin_ANY}}, "any"},
+	{"base language type", intType, "int"},
+	{"byte slices", &Type{Typ: &Type_Builtin{Builtin: Builtin_BYTES}}, "[]byte"},
+	{"standard library type", &Type{Typ: &Type_Builtin{Builtin: Builtin_TIME}}, "time.Time"},
+	{"encore types", &Type{Typ: &Type_Builtin{Builtin: Builtin_UUID}}, "uuid.UUID"},
+	{"map types", &Type{Typ: &Type_Map{Map: &Map{
+		Key:   intType,
+		Value: uuidType,
+	}}}, "map[int]uuid.UUID"},
+	{"struct types", structType,
+		`struct {
+	Age         int       // age at sign up
+	DateOfBirth time.Time ` + "`encore:\"optional\" json:\"dob,omitEmpty\"`" + ` // date of birth
+	Id          uuid.UUID ` + "`json:\"-\"`" + `
+}`,
+	},
+	{
+		"basic named types", &Type{Typ: &Type_Named{Named: &Named{Id: 0}}}, "codegentest.UserAge",
+	},
+}
+
 func Test_schemaTypeToGoType(t *testing.T) {
 	t.Parallel()
 
-	intType := &Type{Typ: &Type_Builtin{Builtin: Builtin_INT}}
-	uuidType := &Type{Typ: &Type_Builtin{Builtin: Builtin_UUID}}
-	structType := &Type{Typ: &Type_Struct{Struct: &Struct{Fields: []*Field{
-		{Name: "Age", Typ: intType, Doc: "age at sign up"},
-		{Name: "DateOfBirth", Typ: &Type{Typ: &Type_Builtin{Builtin: Builtin_TIME}}, Doc: "date of birth", JsonName: "dob", Optional: true},
-		{Name: "Id", Typ: uuidType, JsonName: "-"},
-	}}}}
-
-	tests := []struct {
-		name string
-		typ  *Type
-		want string
-	}{
-		{"any", &Type{Typ: &Type_Builtin{Builtin: Builtin_ANY}}, "any"},
-		{"base language type", intType, "int"},
-		{"byte slices", &Type{Typ: &Type_Builtin{Builtin: Builtin_BYTES}}, "[]byte"},
-		{"standard library type", &Type{Typ: &Type_Builtin{Builtin: Builtin_TIME}}, "time.Time"},
-		{"encore types", &Type{Typ: &Type_Builtin{Builtin: Builtin_UUID}}, "uuid.UUID"},
-		{"map types", &Type{Typ: &Type_Map{Map: &Map{
-			Key:   intType,
-			Value: uuidType,
-		}}}, "map[int]uuid.UUID"},
-		{"struct types", structType,
-			`struct {
-	Age         int       // age at sign up
-	DateOfBirth time.Time ` + "`json:\"dob,omitEmpty\"`" + ` // date of birth
-	Id          uuid.UUID ` + "`json:\"-\"`" + `
-}`,
-		},
-		{
-			"basic named types", &Type{Typ: &Type_Named{Named: &Named{Id: 0}}}, "codegentest.UserAge",
-		},
-		{
-			"generic named types", &Type{Typ: &Type_Named{Named: &Named{Id: 0, TypeArguments: []*Type{intType, uuidType}}}}, "codegentest.UserAge[int, uuid.UUID]",
-		},
-	}
-	for _, tt := range tests {
+	for _, tt := range schemaTypeToGoTypeTestCases {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit uses Go build tags to disable two tests which now
rely on Go 1.18 generics which are causing test failures when we
test on Go 1.17 or below.