### PR TITLE
Add missing `// +build` tags

### DIFF
--- a/cli/internal/codegen/client_test.go
+++ b/cli/internal/codegen/client_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18
+// +build go1.18
 
 package codegen
 

--- a/compiler/internal/codegen/type_resolver_go118_test.go
+++ b/compiler/internal/codegen/type_resolver_go118_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18
+// +build go1.18
 
 package codegen
 


### PR DESCRIPTION
This commit adds two missing `// +build` tags so we can build with older go versions still (1.16) which don't have `//go:build` support yet