### PR TITLE
Fix BASE64 Secrets encoding

### DIFF
--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -626,7 +626,7 @@ func encodeSecretsEnv(secrets map[string]string) string {
 
 		buf.WriteString(k)
 		buf.WriteByte('=')
-		buf.WriteString(base64.RawStdEncoding.EncodeToString([]byte(secrets[k])))
+		buf.WriteString(base64.RawURLEncoding.EncodeToString([]byte(secrets[k])))
 	}
 	return buf.String()
 }


### PR DESCRIPTION
This commit fixes the base64 encoding of secrets between the daemon and
run command to both use `RawURLEncoding`. Previously the run command encoded
using `RawStdEncoding` which caused an issue when the secret contained certain control
characters.