### PR TITLE
docs: various improvements

### DIFF
--- a/docs/docs.cue
+++ b/docs/docs.cue
@@ -89,6 +89,7 @@ sections: [
 		docs: [
 			{title: "Debug with Delve", segment: "debug"},
 			{title: "Change SQL database schema", segment: "change-db-schema"},
+			{title: "Connect to an existing database", segment: "connect-existing-db"},
 			{title: "Share SQL databases between services", segment: "share-db-between-services"},
 			{title: "Receive webhooks", segment: "webhooks"},
 			{title: "Integrate with a web frontend", segment: "integrate-frontend"},

--- a/docs/how-to/connect-existing-db.md
+++ b/docs/how-to/connect-existing-db.md
@@ -1,0 +1,78 @@
+---
+title: Connect to an existing database
+---
+
+When you create an Encore service and add a database to it, Encore will automatically setup the necessary infrastructure for you.
+That's usually what you want, but for some use cases you want to connect to an existing database that you've already setup:
+- To gradually migrate your backend over to using Encore
+- To use Encore for prototyping a replacement of an existing service
+
+In those cases, it's easy to integrate Encore with the existing database. 
+
+## Example
+
+Let's say you have an external database hosted by DigitalOcean that you would like to connect to.
+The simplest approach is to create a dedicated package that lazily instantiates a database connection pool.
+We can store the password using Encore's [secrets support](/docs/develop/secrets) to make it even easier.
+
+The connection string is something like `postgresql://user:password@externaldb-do-user-1234567-0.db.ondigitalocean.com:25010/externaldb?sslmode=require`, so we write something like:
+
+**`pkg/externaldb/externaldb.go`**
+
+```go
+package externaldb
+
+import (
+    "fmt"
+
+    "go4.org/syncutil"
+    "github.com/jackc/pgx/v4/pgxpool"
+)
+
+// Get returns a database connection pool to the external database.
+// It is lazily created on first use.
+func Get(ctx context.Context) (*pgxpool.Pool, error) {
+    // Attempt to setup the database connection pool if it hasn't
+    // already been successfully setup.
+    err := once.Do(func() error {
+        var err error
+        pool, err = setup(ctx)
+        return err
+    })
+    return pool, err
+}
+
+var (
+    // once is like sync.Once except it re-arms itself on failure
+    once syncutil.Once
+    // pool is the successfully created database connection pool,
+    // or nil when no such pool has been setup yet.
+    pool *pgxpool.Pool
+)
+
+var secrets struct {
+    // ExternalDBPassword is the database password for authenticating
+    // with the external database hosted on DigitalOcean.
+    ExternalDBPassword string
+}
+
+// setup attempts to set up a database connection pool.
+func setup(ctx context.Context) (*pgxpool.Pool, error) {
+    connString := fmt.Sprintf("postgresql://%s:%s@externaldb-do-user-1234567-0.db.ondigitalocean.com:25010/externaldb?sslmode=require",
+        "user", secrets.ExternalDBPassword)
+    return pgxpool.Connect(ctx, connString)
+}
+```
+
+Before running, remember to use `encore secrets set` to store the `ExternalDBPassword` to use. (But don't worry, Encore will remind you if you forget.)
+
+## Other infrastructure
+
+The same pattern can easily be adapted to other infrastructure components that Encore doesn't yet provide built-in support for:
+
+- Horizontally scalable databases like Cassandra, DynamoDB, BigTable, and so on
+- Document or graph databases like MongoDB or Neo4j
+- Other cloud primitives like queues, object storage buckets, and more
+- Or really any cloud services or APIs you can think of
+
+In this way you can easily integrate Encore with anything you want.

--- a/docs/how-to/share-db-between-services.md
+++ b/docs/how-to/share-db-between-services.md
@@ -2,9 +2,14 @@
 title: Share SQL databases between services
 ---
 
-By default, each service in an Encore app has its own database, running in its own isolated environment. This approach has huge benefits: load balancing between services and making failure of the whole app almost absolutely impossible to name a few.
+By default, each service in an Encore app has its own database. This approach has many benefits: 
+- Which database is used and how it works is abstracted away from other services
+- The database is more isolated, making changes to it smaller and safer
+- By making the services more independent your application becomes more reliable by being able to more gracefully handle partial outages, such as if your database is temporarily overloaded or offline.
 
-But in some cases you might want to get access to a database, that belongs to another service. Since the release of v0.17 we can now reference databases by name with `sqldb.Named("name")`, enabling multiple services to reference a single database.
+But like everything else in software engineering, there are trade-offs involved, and sometimes it's simpler and more reliable to use a single database that's accessed by multiple services. Encore makes this easy to do.
+
+Each database in Encore is defined within a service. That service's name becomes the name of the database. Other services can then access that database by creating a database reference with `sqldb.Named("dbname")`.
 
 ## Example
 
@@ -20,9 +25,7 @@ CREATE TABLE todo_item (
 );
 ```
 
-If you decide to create a `report` service, generating reports in different formats or whatnot.
-Let's say you would like to generate a report, showing the amount of completed todo items.
-You could do it the following way:
+You want to create a `report` service that produces various reports for internal business processes, but for simplicity you decide it makes sense to directly access the `todo` database. All that's needed is to define the `todoDB` variable like so:
 
 **`report/report.go`**
 
@@ -35,21 +38,24 @@ import (
 	"encore.dev/storage/sqldb"
 )
 
+// todoDB connects to the "todo" service's database.
+var todoDB = sqldb.Named("todo")
+
 type ReportResponse struct {
     Total int
 }
 
-var todoDB = sqldb.Named("todo")
-
-//CountCompletedTodo generates a report with the number of completed todo items.
+// CountCompletedTodos generates a report with the number of completed todo items.
 //encore:api method=GET path=/report/todo
-func CountCompletedTodo(ctx context.Context) (*ReportResponse, error){
+func CountCompletedTodos(ctx context.Context) (*ReportResponse, error) {
     var report ReportResponse
     err := todoDB.QueryRow(ctx,`
-           SELECT COUNT(*)
-           FROM todo_item
-           WHERE completed = TRUE
-           `).Scan(&report.Total)
+        SELECT COUNT(*)
+        FROM todo_item
+        WHERE completed = TRUE
+    `).Scan(&report.Total)
     return &report, err
 }
 ```
+
+With that, Encore understands that the `report` service depends on the `todo` service's database, and orchestrates the necessary connections to make that happen. And like everything else with Encore, it works exactly the same regardless of where it's running: for local development as well as in the cloud.


### PR DESCRIPTION
Improve database documentation across the board:

- docs/develop: document how to handle migration errors
- docs/how-to/share-db-between-services: minor tweaks
- docs/how-to: document how to connect to external dbs
