### PR TITLE
compiler/runtime/cron: remove (cron.Job).Doc

### DIFF
--- a/compiler/runtime/cron/cron.go
+++ b/compiler/runtime/cron/cron.go
@@ -17,7 +17,6 @@ type JobConfig struct {
 type Job struct {
 	ID       string
 	Name     string
-	Doc      string
 	Every    Duration
 	Schedule string
 	Endpoint interface{}
@@ -27,7 +26,6 @@ func NewJob(id string, jobConfig JobConfig) *Job {
 	return &Job{
 		ID:       id,
 		Name:     jobConfig.Name,
-		Doc:      jobConfig.Name,
 		Every:    jobConfig.Every,
 		Schedule: jobConfig.Schedule,
 		Endpoint: jobConfig.Endpoint,


### PR DESCRIPTION
It's unused and was never fully implemented.
We still store documentation in the export metadata.
