### PR TITLE
Support line comments on request & response fields

### DIFF
--- a/parser/schema.go
+++ b/parser/schema.go
@@ -93,10 +93,17 @@ func (p *parser) resolveType(pkg *est.Package, file *est.File, expr ast.Expr, ty
 			}
 
 			for _, name := range field.Names {
+				// Use the documentation block above the field by default,
+				// however if that is blank, then use the line comment instead
+				docBlock := field.Doc
+				if docBlock == nil || docBlock.Text() == "" {
+					docBlock = field.Comment
+				}
+
 				f := &schema.Field{
 					Typ:             typ,
 					Name:            name.Name,
-					Doc:             field.Doc.Text(),
+					Doc:             docBlock.Text(),
 					Optional:        opts.Optional,
 					JsonName:        opts.JSONName,
 					QueryStringName: opts.QueryStringName,


### PR DESCRIPTION
This commit adds support for line based comments on struct fields and
Encore will now pick those up if there is not a doc comment on the field

```go
type FooBar struct {
    // This is a doc comment on Field
    Field string

    // This doc comment will take presendence over the line comment
    Foo string // This is a line comment will be ignored

    Bar string // This is a line comment will be used as the documentation
}
```

This example will result in the following documentation generation:

> `Field`: This is a doc comment on Field
> `Foo`: This doc comment will take presendence over the line comment
> `Bar`: This is a line comment will be used as the documentation