### PR TITLE
compiler: fix static linking toggle

### DIFF
--- a/compiler/build.go
+++ b/compiler/build.go
@@ -283,7 +283,7 @@ func (b *builder) buildMain() error {
 		"-o=" + filepath.Join(b.workdir, "out"+exe),
 	}
 	if b.cfg.StaticLink {
-		args = append(args, `-ldflags '-extldflags "-static"'`)
+		args = append(args, "-ldflags", `-extldflags "-static"`)
 	}
 
 	args = append(args, "./"+mainPkgName)


### PR DESCRIPTION
It needs to be broken up into two separate arguments
for the go tool to understand it properly.
