### PR TITLE
cli/internal/xos: fix fd inheritance on Windows

### DIFF
--- a/cli/internal/xos/xos_windows.go
+++ b/cli/internal/xos/xos_windows.go
@@ -42,6 +42,12 @@ func SameSocket(a, b interface{}) bool {
 }
 
 func ArrangeExtraFiles(cmd *exec.Cmd, files ...*os.File) error {
+	attr := cmd.SysProcAttr
+	if attr == nil {
+		attr = &syscall.SysProcAttr{}
+		cmd.SysProcAttr = attr
+	}
+
 	// Flag the files to bbe inherited by the child process
 	var fds []string
 	for _, f := range files {
@@ -51,6 +57,7 @@ func ArrangeExtraFiles(cmd *exec.Cmd, files ...*os.File) error {
 		if err != nil {
 			return fmt.Errorf("xos.ArrangeExtraFiles: SetHandleInformation: %v", err)
 		}
+		atr.AdditionalInheritedHandles = append(attr.AdditionalInheritedHandles, syscall.Handle(fd))
 	}
 	// If the env hasn't been set, copy over this process' env so we preserve the cmd.Env semantics.
 	if cmd.Env == nil {


### PR DESCRIPTION
As of Go 1.17 exec.Cmd no longer passes all inherited handles
to child processes, but only ones added to the SysProcAttr struct.
This broke our way of passing on file descriptors to Windows
since we recently upgraded to Go 1.18.
