### PR TITLE
Improve local postgres setup

### DIFF
--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -124,7 +124,7 @@ func (c *Cluster) Start(log runlog.Log) error {
 				"-d",
 				"-p", "5432",
 				"--shm-size=1gb",
-				"-e", "POSTGRES_USER=encore",
+				"-e", "POSTGRES_USER=postgres",
 				"-e", "POSTGRES_PASSWORD=" + c.ID,
 				"-e", "POSTGRES_DB=postgres",
 				"--name", cname,

--- a/cli/daemon/sqldb/db.go
+++ b/cli/daemon/sqldb/db.go
@@ -198,7 +198,7 @@ func (db *DB) connectAdminDB(ctx context.Context) (*pgx.Conn, error) {
 	var err error
 	for i := 0; i < 40; i++ {
 		var conn *pgx.Conn
-		conn, err = pgx.Connect(ctx, "postgresql://encore:"+db.Cluster.ID+"@"+hostPort+"/postgres?sslmode=disable")
+		conn, err = pgx.Connect(ctx, "postgresql://postgres:"+db.Cluster.ID+"@"+hostPort+"/postgres?sslmode=disable")
 		if err == nil {
 			return conn, nil
 		} else if ctx.Err() != nil {

--- a/cli/daemon/sqldb/manager.go
+++ b/cli/daemon/sqldb/manager.go
@@ -108,4 +108,4 @@ func (cm *ClusterManager) Delete(ctx context.Context, clusterID string) error {
 	return nil
 }
 
-const dockerImage = "postgres:11-alpine"
+const dockerImage = "klemmster/encore-postgres:14-alpine"


### PR DESCRIPTION
I've had a surprising failure trying to deploy my code with Postgres RowLevelSecurity(RLS) to encore cloud.

Since locally the encore user was running with super user privileges, where row level security is ignored, I created a new user/role which each connection would switch to, so that RLS would work.
Pushing this code to the cloud failed because the user running the migration isn't allowed to create users/roles.

This PR changes the local setup to closer the cloud based behavior:
a) there are two users now in the local setup: The `postgres` superuser and the `encore` 'create db' user
b) the version of postgres is updated to allow users with 'create db' permission to install trusted extensions. That feature was introduced in postgres 13, the cloud is running 14, local env was running 11

I don't expect this to be merged as this stage:
~~a) it's not the cleanest, the user creation code should only be run once, and not 'piggy backed' on the create db call.~~
b) the current migration path is: stop the cluster and delete the volumes, re-create the cluster with the encore cli so the permissions are in sync with the code. As is, it's not a hands-off experience, but rather breaking experience. The init scripts in the dockerfile won't run if a data directory is already present, so the encore user might or might not be there.

for a) ~~I'd think a cleaner solution would be a thin wrapper around the postgres image that contains an initialization script ( as described in https://hub.docker.com/_/postgres) to create the encore user during the `docker run` phase of the cluster creation.~~
The code is there already: https://github.com/klemmster/encore-postgres, also manually pushed it to dockerhub.
You seem to have a docker registry already, so I've created the PR to get the conversation rolling.

Please let me know what your thoughts are on this topic or if there are open questions.