### PR TITLE
cli/internal/codegen: fix Go client code generator

### DIFF
--- a/cli/internal/codegen/testdata/expected_typescript.ts
+++ b/cli/internal/codegen/testdata/expected_typescript.ts
@@ -53,13 +53,13 @@ export namespace svc {
             this.baseClient = baseClient
         }
 
+        /**
+         * DummyAPI is a dummy endpoint.
+         */
         public DummyAPI(params: Request): Promise<void> {
             return this.baseClient.doVoid("POST", `/svc.DummyAPI`, params)
         }
 
-        /**
-         * Get returns some stuff
-         */
         public Get(params: GetRequest): Promise<void> {
             const query: any[] = [
                 "boo", params.Baz,

--- a/cli/internal/codegen/testdata/input.go
+++ b/cli/internal/codegen/testdata/input.go
@@ -41,6 +41,10 @@ type GetRequest struct {
 
 type Foo int
 
+type Nested struct {
+    Value string
+}
+
 -- svc/api.go --
 package svc
 
@@ -49,12 +53,12 @@ import (
     "net/http"
 )
 
+// DummyAPI is a dummy endpoint.
 //encore:api public
 func DummyAPI(ctx context.Context, req *Request) error {
     return nil
 }
 
-// Get returns some stuff
 //encore:api public method=GET
 func Get(ctx context.Context, req *GetRequest) error {
     return nil


### PR DESCRIPTION
For endpoints that only return an error we were still trying
to decode the response.
