### PR TITLE
runtime/storage/sqldb: set max open conns for stdlib

### DIFF
--- a/runtime/storage/sqldb/sqldb.go
+++ b/runtime/storage/sqldb/sqldb.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -419,6 +420,8 @@ func (db *Database) Stdlib() *sql.DB {
 		c, err := stdlibDriver.(driver.DriverContext).OpenConnector(db.connStr)
 		if err == nil {
 			db.stdlib = sql.OpenDB(c)
+			db.stdlib.SetMaxOpenConns(30)
+			db.stdlib.SetConnMaxIdleTime(2 * time.Second)
 		}
 		openErr = err
 	})


### PR DESCRIPTION
When using the stdlib integration the connection pool settings
must be configured separately.

Thanks @ValeriaVG for reporting!