### PR TITLE
runtime/storage/sqldb: support tls certs, max connection config

### DIFF
--- a/runtime/runtime/config/config.go
+++ b/runtime/runtime/config/config.go
@@ -88,6 +88,17 @@ type SQLDatabase struct {
 	Host         string `json:"host"`
 	User         string `json:"user"`
 	Password     string `json:"password"`
+
+	// MaxConnections is the maximum number of open connections to use
+	// for this database. If zero it defaults to 30.
+	MaxConnections int `json:"max_connections"`
+
+	// ServerCACert is the PEM-encoded server CA cert, or "" if not required.
+	ServerCACert string `json:"server_ca_cert"`
+	// ClientCert is the PEM-encoded client cert, or "" if not required.
+	ClientCert string `json:"client_cert"`
+	// ClientKey is the PEM-encoded client key, or "" if not required.
+	ClientKey string `json:"client_key"`
 }
 
 // ParseRuntime parses the Encore runtime config.

--- a/runtime/storage/sqldb/sqldb_test.go
+++ b/runtime/storage/sqldb/sqldb_test.go
@@ -9,42 +9,49 @@ import (
 
 func TestDBConf(t *testing.T) {
 	tests := []struct {
-		DB   *config.SQLDatabase
-		Host string
-		Port uint16
+		DB       *config.SQLDatabase
+		Host     string
+		Port     uint16
+		MaxConns uint32
 	}{
 		{
 			DB: &config.SQLDatabase{
-				EncoreName:   "ignore",
-				DatabaseName: "dbname",
-				Host:         "/cloudsql/foo",
-				User:         "user",
-				Password:     "password",
+				EncoreName:     "ignore",
+				DatabaseName:   "dbname",
+				Host:           "/cloudsql/foo",
+				User:           "user",
+				Password:       "password",
+				MaxConnections: 10,
 			},
-			Host: "/cloudsql/foo",
-			Port: 5432,
+			Host:     "/cloudsql/foo",
+			Port:     5432,
+			MaxConns: 10,
 		},
 		{
 			DB: &config.SQLDatabase{
-				EncoreName:   "ignore",
-				DatabaseName: "dbname",
-				Host:         "test:123",
-				User:         "user",
-				Password:     "password",
+				EncoreName:     "ignore",
+				DatabaseName:   "dbname",
+				Host:           "test:123",
+				User:           "user",
+				Password:       "password",
+				MaxConnections: 0,
 			},
-			Host: "test",
-			Port: 123,
+			Host:     "test",
+			Port:     123,
+			MaxConns: 30,
 		},
 		{
 			DB: &config.SQLDatabase{
-				EncoreName:   "ignore",
-				DatabaseName: "dbname",
-				Host:         "hostname",
-				User:         "user",
-				Password:     "password",
+				EncoreName:     "ignore",
+				DatabaseName:   "dbname",
+				Host:           "hostname",
+				User:           "user",
+				Password:       "password",
+				MaxConnections: 100,
 			},
-			Host: "hostname",
-			Port: 5432,
+			Host:     "hostname",
+			Port:     5432,
+			MaxConns: 100,
 		},
 	}
 


### PR DESCRIPTION
To support additional flexibility in how Encore works with Cloud Run
add the ability to customize whether Encore should use TLS certs
when connecting, as well as tweaking the connection pool sizes.
