### PR TITLE
runtime: add graceful shutdown support

### DIFF
--- a/runtime/runtime/config/config.go
+++ b/runtime/runtime/config/config.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -58,6 +59,11 @@ type Runtime struct {
 	TraceEndpoint string          `json:"trace_endpoint"`
 	AuthKeys      []EncoreAuthKey `json:"auth_keys"`
 	SQLDatabases  []*SQLDatabase  `json:"sql_databases"`
+
+	// ShutdownTimeout is the duration before non-graceful shutdown is initiated,
+	// meaning connections are closed even if outstanding requests are still in flight.
+	// If zero, it shuts down immediately.
+	ShutdownTimeout time.Duration `json:"shutdown_timeout"`
 }
 
 func (r *Runtime) Copy() *Runtime {

--- a/runtime/runtime/setup_cloud.go
+++ b/runtime/runtime/setup_cloud.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var devMode = false
+
 func listen() (net.Listener, error) {
 	port, _ := strconv.Atoi(os.Getenv("PORT"))
 	if port == 0 {

--- a/runtime/runtime/setup_local.go
+++ b/runtime/runtime/setup_local.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/yamux"
 )
 
+var devMode = true
+
 func listen() (net.Listener, error) {
 	var in, out *os.File
 	if runtime.GOOS == "windows" {

--- a/runtime/runtime/shutdown.go
+++ b/runtime/runtime/shutdown.go
@@ -22,6 +22,16 @@ var shutdown = struct {
 	completed: make(chan struct{}),
 }
 
+// RegisterShutdown registers a shutdown handler that will be called when the server
+// is gracefully shutting down.
+//
+// The given context is closed when the graceful shutdown window is closed and it's
+// time to forcefully shut down. force.Deadline() can be inspected to learn when this
+// will happen in advance.
+//
+// The shutdown is cooperative: the process will not exit until all shutdown handlers
+// have returned, unless the process is forcefully killed by a signal (which may happen
+// in certain cloud environments if the graceful shutdown takes longer than its timeout).
 func RegisterShutdown(fn func(force context.Context)) {
 	shutdown.mu.Lock()
 	shutdown.handlers = append(shutdown.handlers, fn)

--- a/runtime/runtime/shutdown.go
+++ b/runtime/runtime/shutdown.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"context"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"encore.dev/runtime/config"
+)
+
+var shutdown = struct {
+	initiated chan struct{} // closed when graceful shutdown is initiated
+	completed chan struct{} // closed when graceful shutdown is completed
+	once      sync.Once     // to trigger shutdown logic only once
+
+	mu       sync.Mutex
+	handlers []func(force context.Context)
+}{
+	initiated: make(chan struct{}),
+	completed: make(chan struct{}),
+}
+
+func RegisterShutdown(fn func(force context.Context)) {
+	shutdown.mu.Lock()
+	shutdown.handlers = append(shutdown.handlers, fn)
+	shutdown.mu.Unlock()
+}
+
+func init() {
+	graceful, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-graceful.Done()
+		doShutdown()
+	}()
+}
+
+// doShutdown triggers the shutdown logic.
+// If it has already been triggered, it does nothing and returns immediately.
+func doShutdown() {
+	shutdown.once.Do(func() {
+		close(shutdown.initiated)
+		if !devMode {
+			defaultServer.logger.Info().Msg("got shutdown signal, initiating graceful shutdown")
+		}
+
+		var maxWait time.Duration
+		if t := config.Cfg.Runtime.ShutdownTimeout; t > 0 {
+			maxWait = t
+		}
+		force, cancel := context.WithTimeout(context.Background(), maxWait)
+		defer cancel()
+
+		shutdown.mu.Lock()
+		handlers := shutdown.handlers
+		shutdown.mu.Unlock()
+
+		// Run our handlers concurrently and wait for them to complete.
+		var wg sync.WaitGroup
+		wg.Add(len(handlers))
+		for _, fn := range handlers {
+			fn := fn
+			go func() {
+				defer wg.Done()
+				fn(force)
+			}()
+		}
+		wg.Wait()
+
+		if !devMode {
+			defaultServer.logger.Info().Msg("shutdown completed")
+		}
+		close(shutdown.completed)
+	})
+}


### PR DESCRIPTION
Serverless environments such as Cloud Run that frequently scale up
and down can cause unclean PostgreSQL connection shutdowns.

The PostgreSQL server can take a long time (many minutes) to detect this
and release the connection slow. This can lead to out-of-connection
errors even when there are no active connections.

Fix this by handling SIGINT/SIGTERM signals and gracefully shutting down
when detected.