### PR TITLE
runtime/beta/errs: remove encore_internal build tag

### DIFF
--- a/runtime/beta/errs/errs_internal.go
+++ b/runtime/beta/errs/errs_internal.go
@@ -1,5 +1,3 @@
-//go:build encore_internal
-
 package errs
 
 import (


### PR DESCRIPTION
It's causing annoying build errors when using this module for
use cases outside of building an Encore app, such as referencing
the config structs.

Having this build tag is not important for now as the public API is
still in a separate module. If we go ahead with merging that into this
repo we can revisit this decision.
