### PR TITLE
runtime: separate sql server config from databases

### DIFF
--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -444,13 +444,16 @@ func (r *Run) startProc(params *startProcParams) (p *Proc, err error) {
 }
 
 func (r *Run) generateConfig(p *Proc, params *startProcParams) *config.Runtime {
+	sqlServer := &config.SQLServer{
+		Host: "localhost:" + strconv.Itoa(params.DBProxyPort),
+	}
+
 	var dbs []*config.SQLDatabase
 	for _, svc := range params.Meta.Svcs {
 		if len(svc.Migrations) > 0 {
 			dbs = append(dbs, &config.SQLDatabase{
 				EncoreName:   svc.Name,
 				DatabaseName: svc.Name,
-				Host:         "localhost:" + strconv.Itoa(params.DBProxyPort),
 				User:         "encore",
 				Password:     params.DBClusterID,
 			})
@@ -463,6 +466,7 @@ func (r *Run) generateConfig(p *Proc, params *startProcParams) *config.Runtime {
 		EnvName:       "local",
 		TraceEndpoint: "http://localhost:" + strconv.Itoa(params.RuntimePort) + "/trace",
 		SQLDatabases:  dbs,
+		SQLServers:    []*config.SQLServer{sqlServer},
 		AuthKeys:      []config.EncoreAuthKey{p.authKey},
 	}
 }

--- a/cli/daemon/run/tests.go
+++ b/cli/daemon/run/tests.go
@@ -85,13 +85,16 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 		secrets = data.Values
 	}
 
+	sqlServer := &config.SQLServer{
+		Host: "localhost:" + strconv.Itoa(mgr.DBProxyPort),
+	}
 	var dbs []*config.SQLDatabase
 	for _, svc := range params.Parse.Meta.Svcs {
 		if len(svc.Migrations) > 0 {
 			dbs = append(dbs, &config.SQLDatabase{
+				ServerID:     0,
 				EncoreName:   svc.Name,
 				DatabaseName: svc.Name,
-				Host:         "localhost:" + strconv.Itoa(mgr.DBProxyPort),
 				User:         "encore",
 				Password:     params.DBClusterID,
 			})
@@ -103,6 +106,7 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 		EnvName:       "local",
 		TraceEndpoint: "http://localhost:" + strconv.Itoa(mgr.RuntimePort) + "/trace",
 		SQLDatabases:  dbs,
+		SQLServers:    []*config.SQLServer{sqlServer},
 	})
 	if err != nil {
 		return err

--- a/cli/daemon/runtime/config/config.go
+++ b/cli/daemon/runtime/config/config.go
@@ -9,6 +9,7 @@ type Runtime struct {
 	TraceEndpoint string          `json:"trace_endpoint"`
 	AuthKeys      []EncoreAuthKey `json:"auth_keys"`
 	SQLDatabases  []*SQLDatabase  `json:"sql_databases"`
+	SQLServers    []*SQLServer    `json:"sql_servers"`
 }
 
 type EncoreAuthKey struct {
@@ -16,10 +17,31 @@ type EncoreAuthKey struct {
 	Data  []byte `json:"data"`
 }
 
+type SQLServer struct {
+	// Host is the host to connect to.
+	// Valid formats are "hostname", "hostname:port", and "/path/to/unix.socket".
+	Host string `json:"host"`
+
+	// MinConnections is the minimum number of open connections to use
+	// for this database. If zero it defaults to 2.
+	MinConnections int `json:"min_connections"`
+
+	// MaxConnections is the maximum number of open connections to use
+	// for this database. If zero it defaults to 30.
+	MaxConnections int `json:"max_connections"`
+
+	// ServerCACert is the PEM-encoded server CA cert, or "" if not required.
+	ServerCACert string `json:"server_ca_cert"`
+	// ClientCert is the PEM-encoded client cert, or "" if not required.
+	ClientCert string `json:"client_cert"`
+	// ClientKey is the PEM-encoded client key, or "" if not required.
+	ClientKey string `json:"client_key"`
+}
+
 type SQLDatabase struct {
+	ServerID     int    `json:"server_id"`     // the index into (*Runtime).SQLServers
 	EncoreName   string `json:"encore_name"`   // the Encore name for the database
 	DatabaseName string `json:"database_name"` // the actual database name as known by the SQL server.
-	Host         string `json:"host"`
 	User         string `json:"user"`
 	Password     string `json:"password"`
 }

--- a/runtime/runtime/config/config.go
+++ b/runtime/runtime/config/config.go
@@ -59,6 +59,7 @@ type Runtime struct {
 	TraceEndpoint string          `json:"trace_endpoint"`
 	AuthKeys      []EncoreAuthKey `json:"auth_keys"`
 	SQLDatabases  []*SQLDatabase  `json:"sql_databases"`
+	SQLServers    []*SQLServer    `json:"sql_servers"`
 
 	// ShutdownTimeout is the duration before non-graceful shutdown is initiated,
 	// meaning connections are closed even if outstanding requests are still in flight.
@@ -88,10 +89,23 @@ func (eak EncoreAuthKey) Copy() EncoreAuthKey {
 	return c
 }
 
+type SQLServer struct {
+	// Host is the host to connect to.
+	// Valid formats are "hostname", "hostname:port", and "/path/to/unix.socket".
+	Host string `json:"host"`
+
+	// ServerCACert is the PEM-encoded server CA cert, or "" if not required.
+	ServerCACert string `json:"server_ca_cert"`
+	// ClientCert is the PEM-encoded client cert, or "" if not required.
+	ClientCert string `json:"client_cert"`
+	// ClientKey is the PEM-encoded client key, or "" if not required.
+	ClientKey string `json:"client_key"`
+}
+
 type SQLDatabase struct {
+	ServerID     int    `json:"server_id"`     // the index into (*Runtime).SQLServers
 	EncoreName   string `json:"encore_name"`   // the Encore name for the database
 	DatabaseName string `json:"database_name"` // the actual database name as known by the SQL server.
-	Host         string `json:"host"`
 	User         string `json:"user"`
 	Password     string `json:"password"`
 
@@ -102,13 +116,6 @@ type SQLDatabase struct {
 	// MaxConnections is the maximum number of open connections to use
 	// for this database. If zero it defaults to 30.
 	MaxConnections int `json:"max_connections"`
-
-	// ServerCACert is the PEM-encoded server CA cert, or "" if not required.
-	ServerCACert string `json:"server_ca_cert"`
-	// ClientCert is the PEM-encoded client cert, or "" if not required.
-	ClientCert string `json:"client_cert"`
-	// ClientKey is the PEM-encoded client key, or "" if not required.
-	ClientKey string `json:"client_key"`
 }
 
 // ParseRuntime parses the Encore runtime config.

--- a/runtime/storage/sqldb/sqldb_test.go
+++ b/runtime/storage/sqldb/sqldb_test.go
@@ -9,16 +9,19 @@ import (
 
 func TestDBConf(t *testing.T) {
 	tests := []struct {
+		Srv      *config.SQLServer
 		DB       *config.SQLDatabase
 		Host     string
 		Port     uint16
 		MaxConns uint32
 	}{
 		{
+			Srv: &config.SQLServer{
+				Host: "/cloudsql/foo",
+			},
 			DB: &config.SQLDatabase{
 				EncoreName:     "ignore",
 				DatabaseName:   "dbname",
-				Host:           "/cloudsql/foo",
 				User:           "user",
 				Password:       "password",
 				MaxConnections: 10,
@@ -28,10 +31,12 @@ func TestDBConf(t *testing.T) {
 			MaxConns: 10,
 		},
 		{
+			Srv: &config.SQLServer{
+				Host: "test:123",
+			},
 			DB: &config.SQLDatabase{
 				EncoreName:     "ignore",
 				DatabaseName:   "dbname",
-				Host:           "test:123",
 				User:           "user",
 				Password:       "password",
 				MaxConnections: 0,
@@ -41,10 +46,12 @@ func TestDBConf(t *testing.T) {
 			MaxConns: 30,
 		},
 		{
+			Srv: &config.SQLServer{
+				Host: "hostname",
+			},
 			DB: &config.SQLDatabase{
 				EncoreName:     "ignore",
 				DatabaseName:   "dbname",
-				Host:           "hostname",
 				User:           "user",
 				Password:       "password",
 				MaxConnections: 100,
@@ -56,7 +63,7 @@ func TestDBConf(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		cfg, err := dbConf(test.DB)
+		cfg, err := dbConf(test.Srv, test.DB)
 		if err != nil {
 			t.Fatalf("test %d: unexpected error: %v", i, err)
 		}


### PR DESCRIPTION
It's common to use the same database server with multiple databases.
In combination with client side TLS certificates this creates an
enormous amount of duplicated data, to the point where the size of the
encoded config can exceed the 64KiB limits imposed by Cloud Run.

Fix this by separating out the SQL Server configuration from the
SQL Database configuration, so that multiple databases on the same
server can use the same TLS configuration.
