### PR TITLE
cli/daemon/sqldb: improve handling when docker is not installed

### DIFF
--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -356,6 +356,8 @@ func ImageExists(ctx context.Context) (ok bool, err error) {
 		return true, nil
 	case bytes.Contains(out, []byte("No such image")):
 		return false, nil
+	case errors.Is(err, exec.ErrNotFound):
+		return false, nil
 	default:
 		return false, err
 	}


### PR DESCRIPTION
If docker was not installed ImageExists would report an error.
This is a bit unnecessary: it's better to report that later
if we're actually trying to pull the image.
