### PR TITLE
cli/cmd/go-encore-wrapper: new command

### DIFF
--- a/cli/cmd/go-encore-wrapper/main.go
+++ b/cli/cmd/go-encore-wrapper/main.go
@@ -1,0 +1,56 @@
+// Command go-encore-wrapper provides a wrapper around the go command
+// that invokes the "encore" binary instead for certain commands, like running tests.
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// EncoreBinary is the name of the encore binary to use.
+// It's a variable to be able to override it for development purposes.
+var EncoreBinary = "encore"
+
+func main() {
+	dst := "go"
+
+	// If this is running "go test" inside an Encore app, rewrite it to "encore test".
+	if len(os.Args) > 1 && os.Args[1] == "test" && isEncoreApp() {
+		dst = EncoreBinary
+	}
+
+	cmd := exec.Command(dst, os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			os.Exit(ee.ExitCode())
+		}
+		os.Exit(1)
+	}
+}
+
+// isEncoreApp reports whether the working directory is within an Encore app.
+func isEncoreApp() bool {
+	wd, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+
+	curr := wd
+	for i := 0; i < 100; i++ {
+		candidate := filepath.Join(curr, "encore.app")
+		if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
+			return true
+		}
+		parent := filepath.Dir(curr)
+		if parent == curr {
+			break
+		}
+		curr = parent
+	}
+
+	return false
+}

--- a/pkg/make-release/make-release.go
+++ b/pkg/make-release/make-release.go
@@ -85,6 +85,14 @@ func (b *Builder) BuildBinaries() error {
 		return fmt.Errorf("go build git-remote-encore failed: %s (%v)", out, err)
 	}
 
+	cmd = exec.Command("go", "build",
+		"-o", join(b.dst, "bin", "go-encore-wrapper"),
+		"./cli/cmd/go-encore-wrapper")
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go build go-encore-wrapper failed: %s (%v)", out, err)
+	}
+
 	return nil
 }
 

--- a/pkg/make-release/windows/build.bat
+++ b/pkg/make-release/windows/build.bat
@@ -74,6 +74,7 @@ if exist .deps\prepared goto :build
 	echo [+] Building
 	go build -tags load_wintun_from_rsrc -ldflags "-X 'encr.dev/cli/internal/version.Version=v%ENCORE_VERSION%'" -o "%DST%\bin\encore.exe" "%ROOT%\cli\cmd\encore" || exit /b 1
 	go build -trimpath -o "%DST%\bin\git-remote-encore.exe" "%ROOT%\cli\cmd\git-remote-encore" || exit /b 1
+	go build -trimpath -o "%DST%\bin\go-encore-wrapper.exe" "%ROOT%\cli\cmd\go-encore-wrapper" || exit /b 1
 	goto :eof
 
 :copy_artifacts


### PR DESCRIPTION
This adds a new command, go-encore-wrapper, that is designed
to wrap the "go" command and forward certain commands to
the "encore" CLI, like running tests.

The purpose is to build a better integration with tools like
vscode-go that only support replacing the "go" tool with
another tool that has the same command structure.

With this change, users will be able to configure vscode-go
to use Encore when appropriate simply by defining:

    "go.alternateTools": {"go": "go-encore-wrapper"}