### PR TITLE
Add Header support to Go Client Generator

### DIFF
--- a/cli/internal/codegen/client_test.go
+++ b/cli/internal/codegen/client_test.go
@@ -5,7 +5,6 @@ package codegen
 
 import (
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,7 +12,12 @@ import (
 	"github.com/rogpeppe/go-internal/txtar"
 
 	"encr.dev/parser"
+	"encr.dev/pkg/golden"
 )
+
+func TestMain(m *testing.M) {
+	golden.TestMain(m)
+}
 
 func TestClientCodeGeneration(t *testing.T) {
 	t.Helper()
@@ -41,13 +45,10 @@ func TestClientCodeGeneration(t *testing.T) {
 				language, ok := Detect(file.Name())
 				c.Assert(ok, qt.IsTrue, qt.Commentf("Unable to detect language type for %s", file.Name()))
 
-				ts, err := Client(language, "app", res.Meta)
+				generatedClient, err := Client(language, "app", res.Meta)
 				c.Assert(err, qt.IsNil)
 
-				expect, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))
-				c.Assert(err, qt.IsNil)
-
-				c.Assert(strings.Split(string(ts), "\n"), qt.DeepEquals, strings.Split(string(expect), "\n"))
+				golden.TestAgainst(c, file.Name(), string(generatedClient))
 			})
 		}
 	}

--- a/cli/internal/codegen/testdata/README.md
+++ b/cli/internal/codegen/testdata/README.md
@@ -1,0 +1,8 @@
+# Update Golden Tests
+
+Instead of manually updating the golden tests, once you've verified the output of the tests is correct, then you
+can simply update all the `expected output files` files by running
+
+```bash
+go test ./cli/internal/codegen -golden-update
+```

--- a/cli/internal/codegen/testdata/expected_golang.go
+++ b/cli/internal/codegen/testdata/expected_golang.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 )
 
 // Client is an API client for the app Encore application.
@@ -82,15 +84,27 @@ func WithAuthFunc(tokenGenerator func(ctx context.Context) (string, error)) Opti
 	}
 }
 
+type SvcAllInputTypes[A any] struct {
+	A    []time.Time `header:"X-Alice"`         // Specify this comes from a header field
+	B    int         `query:"Bob"`              // Specify this comes from a query string
+	C    bool        `json:"Charile,omitempty"` // This can come from anywhere, but if it comes from the payload in JSON it must be called Charile
+	Dave A           // This generic type complicates the whole thing 🙈
+}
+
 type SvcFoo = int
 
 type SvcGetRequest struct {
 	Baz int `qs:"boo"`
 }
 
+type SvcHeaderOnlyStruct struct {
+	Foo []int `header:"X-Foo"`
+	Bar bool  `header:"X-Bar"`
+}
+
 type SvcRequest struct {
-	Foo SvcFoo `encore:"optional" json:",omitempty"` // Foo is good
-	Baz string `json:"boo"`                          // Baz is better
+	Foo SvcFoo `encore:"optional"` // Foo is good
+	Baz string `json:"boo"`        // Baz is better
 
 	// This is a multiline
 	// comment on the raw message!
@@ -106,7 +120,9 @@ type SvcTuple[A any, B any] struct {
 
 type SvcWrappedRequest = SvcWrapper[SvcRequest]
 
-type SvcWrapper[T any] T
+type SvcWrapper[T any] struct {
+	Value T
+}
 
 // SvcClient Provides you access to call public and authenticated APIs on svc. The concrete implementation is svcClient.
 // It is setup as an interface allowing you to use GoMock to create mock implementations during tests.
@@ -114,7 +130,9 @@ type SvcClient interface {
 	// DummyAPI is a dummy endpoint.
 	DummyAPI(ctx context.Context, params SvcRequest) error
 	Get(ctx context.Context, params SvcGetRequest) error
+	GetRequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[int]) (SvcHeaderOnlyStruct, error)
 	RESTPath(ctx context.Context, a string, b int) error
+	RequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[string]) (SvcAllInputTypes[float64], error)
 
 	// TupleInputOutput tests the usage of generics in the client generator
 	// and this comment is also multiline, so multiline comments get tested as well.
@@ -130,23 +148,128 @@ var _ SvcClient = (*svcClient)(nil)
 
 // DummyAPI is a dummy endpoint.
 func (c *svcClient) DummyAPI(ctx context.Context, params SvcRequest) error {
-	return callAPI(ctx, c.base, "POST", "/svc.DummyAPI", params, nil)
+	_, err := callAPI(ctx, c.base, "POST", "/svc.DummyAPI", nil, params, nil)
+	return err
 }
 
 func (c *svcClient) Get(ctx context.Context, params SvcGetRequest) error {
-	queryString := url.Values{"boo": []string{fmt.Sprint(params.Baz)}}
-	return callAPI(ctx, c.base, "GET", fmt.Sprintf("/svc.Get?%s", queryString.Encode()), nil, nil)
+	// Convert our params into the objects we need for the request
+	reqEncoder := &ℯ𝓃𝑐ℴ𝑟ℯMarshaller{}
+
+	queryString := url.Values{"boo": []string{reqEncoder.FromInt(params.Baz)}}
+
+	if reqEncoder.LastError != nil {
+		return fmt.Errorf("unable to marshal parameters: %w", reqEncoder.LastError)
+	}
+
+	_, err := callAPI(ctx, c.base, "GET", fmt.Sprintf("/svc.Get?%s", queryString.Encode()), nil, nil, nil)
+	return err
+}
+
+func (c *svcClient) GetRequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[int]) (resp SvcHeaderOnlyStruct, err error) {
+	// Convert our params into the objects we need for the request
+	reqEncoder := &ℯ𝓃𝑐ℴ𝑟ℯMarshaller{}
+
+	headers := map[string][]string{"X-Alice": reqEncoder.FromTimeList(params.A)}
+
+	queryString := url.Values{
+		"Bob":  []string{reqEncoder.FromInt(params.B)},
+		"c":    []string{reqEncoder.FromBool(params.C)},
+		"dave": []string{reqEncoder.FromInt(params.Dave)},
+	}
+
+	if reqEncoder.LastError != nil {
+		err = fmt.Errorf("unable to marshal parameters: %w", reqEncoder.LastError)
+		return
+	}
+
+	// Now make the actual call to the API
+	var respHeaders http.Header
+	respHeaders, err = callAPI(ctx, c.base, "GET", fmt.Sprintf("/svc.GetRequestWithAllInputTypes?%s", queryString.Encode()), headers, nil, nil)
+	if err != nil {
+		return
+	}
+
+	// Copy the unmarshalled response body into our response struct
+	respDecoder := &ℯ𝓃𝑐ℴ𝑟ℯMarshaller{}
+
+	resp.Foo = respDecoder.ToIntList("Foo", respHeaders.Values("X-Foo"), false)
+	resp.Bar = respDecoder.ToBool("Bar", respHeaders.Get("X-Bar"), false)
+	if respDecoder.LastError != nil {
+		err = fmt.Errorf("unable to unmarshal headers: %w", respDecoder.LastError)
+		return
+	}
+
+	return
 }
 
 func (c *svcClient) RESTPath(ctx context.Context, a string, b int) error {
-	return callAPI(ctx, c.base, "GET", fmt.Sprintf("/path/%s/%d", a, b), nil, nil)
+	_, err := callAPI(ctx, c.base, "POST", fmt.Sprintf("/path/%s/%d", a, b), nil, nil, nil)
+	return err
+}
+
+func (c *svcClient) RequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[string]) (resp SvcAllInputTypes[float64], err error) {
+	// Convert our params into the objects we need for the request
+	reqEncoder := &ℯ𝓃𝑐ℴ𝑟ℯMarshaller{}
+
+	headers := map[string][]string{"X-Alice": reqEncoder.FromTimeList(params.A)}
+
+	queryString := url.Values{"Bob": []string{reqEncoder.FromInt(params.B)}}
+
+	if reqEncoder.LastError != nil {
+		err = fmt.Errorf("unable to marshal parameters: %w", reqEncoder.LastError)
+		return
+	}
+
+	// Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
+	body := struct {
+		C    bool   `json:"Charile,omitempty"`
+		Dave string `json:"Dave"`
+	}{
+		C:    params.C,
+		Dave: params.Dave,
+	}
+
+	// We only want the response body to marshal into these fields and none of the header fields,
+	// so we'll construct a new struct with only those fields.
+	respBody := struct {
+		B    int     `json:"B"`
+		C    bool    `json:"Charile,omitempty"`
+		Dave float64 `json:"Dave"`
+	}{}
+
+	// Now make the actual call to the API
+	var respHeaders http.Header
+	respHeaders, err = callAPI(ctx, c.base, "POST", fmt.Sprintf("/svc.RequestWithAllInputTypes?%s", queryString.Encode()), headers, body, nil)
+	if err != nil {
+		return
+	}
+
+	// Copy the unmarshalled response body into our response struct
+	respDecoder := &ℯ𝓃𝑐ℴ𝑟ℯMarshaller{}
+
+	resp.A = respDecoder.ToTimeList("A", respHeaders.Values("X-Alice"), false)
+	resp.B = respBody.B
+	resp.C = respBody.C
+	resp.Dave = respBody.Dave
+	if respDecoder.LastError != nil {
+		err = fmt.Errorf("unable to unmarshal headers: %w", respDecoder.LastError)
+		return
+	}
+
+	return
 }
 
 // TupleInputOutput tests the usage of generics in the client generator
 // and this comment is also multiline, so multiline comments get tested as well.
 func (c *svcClient) TupleInputOutput(ctx context.Context, params SvcTuple[string, SvcWrappedRequest]) (resp SvcTuple[bool, SvcFoo], err error) {
-	err = callAPI(ctx, c.base, "POST", "/svc.TupleInputOutput", params, &resp)
-	return resp, err
+	// Now make the actual call to the API
+	_, err = callAPI(ctx, c.base, "POST", "/svc.TupleInputOutput", nil, params, &resp)
+	if err != nil {
+		return
+	}
+
+	return
 }
 
 func (c *svcClient) Webhook(ctx context.Context, a string, b string, request *http.Request) (*http.Response, error) {
@@ -198,13 +321,13 @@ func (b *baseClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 // callAPI is used by each generated API method to actually make request and decode the responses
-func callAPI(ctx context.Context, client *baseClient, method, path string, body, resp any) error {
+func callAPI(ctx context.Context, client *baseClient, method, path string, headers map[string][]string, body, resp any) (http.Header, error) {
 	// Encode the API body
 	var bodyReader io.Reader
 	if body != nil {
 		bodyBytes, err := json.Marshal(body)
 		if err != nil {
-			return fmt.Errorf("marshal request: %w", err)
+			return nil, fmt.Errorf("marshal request: %w", err)
 		}
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
@@ -212,26 +335,111 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, body,
 	// Create the request
 	req, err := http.NewRequestWithContext(ctx, method, path, bodyReader)
 	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	// Add any headers to the request
+	for header, values := range headers {
+		for _, value := range values {
+			req.Header.Add(header, value)
+		}
 	}
 
 	// Make the request via the base client
 	rawResponse, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() {
 		_ = rawResponse.Body.Close()
 	}()
 	if rawResponse.StatusCode >= 400 {
-		return fmt.Errorf("got error response: %s", rawResponse.Status)
+		return nil, fmt.Errorf("got error response: %s", rawResponse.Status)
 	}
 
 	// Decode the response
 	if resp != nil {
 		if err := json.NewDecoder(rawResponse.Body).Decode(resp); err != nil {
-			return fmt.Errorf("decode response: %w", err)
+			return nil, fmt.Errorf("decode response: %w", err)
 		}
 	}
-	return nil
+	return rawResponse.Header, nil
+}
+
+// ℯ𝓃𝑐ℴ𝑟ℯMarshaller is used to marshal requests to strings and unmarshal responses from strings
+type ℯ𝓃𝑐ℴ𝑟ℯMarshaller struct {
+	LastError error // The last error that occurred
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) FromInt(s int) (v string) {
+	return strconv.FormatInt(int64(s), 10)
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) FromTime(s time.Time) (v string) {
+	return s.Format(time.RFC3339)
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) FromTimeList(s []time.Time) (v []string) {
+	for _, x := range s {
+		v = append(v, e.FromTime(x))
+	}
+	return v
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) FromBool(s bool) (v string) {
+	return strconv.FormatBool(s)
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) ToInt(field string, s string, required bool) (v int) {
+	if !required && s == "" {
+		return
+	}
+	x, err := strconv.ParseInt(s, 10, 64)
+	e.setErr("invalid parameter", field, err)
+	return int(x)
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) ToIntList(field string, s []string, required bool) (v []int) {
+	if !required && len(s) == 0 {
+		return
+	}
+	for _, x := range s {
+		v = append(v, e.ToInt(field, x, required))
+	}
+	return v
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) ToBool(field string, s string, required bool) (v bool) {
+	if !required && s == "" {
+		return
+	}
+	v, err := strconv.ParseBool(s)
+	e.setErr("invalid parameter", field, err)
+	return v
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) ToTime(field string, s string, required bool) (v time.Time) {
+	if !required && s == "" {
+		return
+	}
+	v, err := time.Parse(time.RFC3339, s)
+	e.setErr("invalid parameter", field, err)
+	return v
+}
+
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) ToTimeList(field string, s []string, required bool) (v []time.Time) {
+	if !required && len(s) == 0 {
+		return
+	}
+	for _, x := range s {
+		v = append(v, e.ToTime(field, x, required))
+	}
+	return v
+}
+
+// setErr sets the last error within the object if one is not already set
+func (e *ℯ𝓃𝑐ℴ𝑟ℯMarshaller) setErr(msg, field string, err error) {
+	if err != nil && e.LastError == nil {
+		e.LastError = fmt.Errorf("%s: %s: %w", field, msg, err)
+	}
 }

--- a/cli/internal/codegen/testdata/expected_typescript.ts
+++ b/cli/internal/codegen/testdata/expected_typescript.ts
@@ -8,11 +8,38 @@ export default class Client {
 }
 
 export namespace svc {
+    export interface AllInputTypes<A> {
+        /**
+         * Specify this comes from a header field
+         */
+        A: string[]
+
+        /**
+         * Specify this comes from a query string
+         */
+        B: number
+
+        /**
+         * This can come from anywhere, but if it comes from the payload in JSON it must be called Charile
+         */
+        Charile: boolean
+
+        /**
+         * This generic type complicates the whole thing 🙈
+         */
+        Dave: A
+    }
+
     export type Foo = number
 
     export interface GetRequest {
         Bar: string
         Baz: number
+    }
+
+    export interface HeaderOnlyStruct {
+        Foo: number[]
+        Bar: boolean
     }
 
     export interface Request {
@@ -44,7 +71,9 @@ export namespace svc {
 
     export type WrappedRequest = Wrapper<Request>
 
-    export type Wrapper<T> = T
+    export interface Wrapper<T> {
+        Value: T
+    }
 
     export class ServiceClient {
         private baseClient: BaseClient
@@ -67,8 +96,22 @@ export namespace svc {
             return this.baseClient.doVoid("GET", `/svc.Get?${encodeQuery(query)}`)
         }
 
+        public GetRequestWithAllInputTypes(params: AllInputTypes<number>): Promise<HeaderOnlyStruct> {
+            const query: any[] = [
+                "a", params.A,
+                "b", params.B,
+                "c", params.Charile,
+                "dave", params.Dave,
+            ]
+            return this.baseClient.do<HeaderOnlyStruct>("GET", `/svc.GetRequestWithAllInputTypes?${encodeQuery(query)}`)
+        }
+
         public RESTPath(a: string, b: number): Promise<void> {
             return this.baseClient.doVoid("GET", `/path/${a}/${b}`)
+        }
+
+        public RequestWithAllInputTypes(params: AllInputTypes<string>): Promise<AllInputTypes<number>> {
+            return this.baseClient.do<AllInputTypes<number>>("POST", `/svc.RequestWithAllInputTypes`, params)
         }
 
         /**

--- a/cli/internal/codegen/testdata/input.go
+++ b/cli/internal/codegen/testdata/input.go
@@ -7,13 +7,16 @@ module app
 -- svc/svc.go --
 package svc
 
-import "encoding/json"
+import (
+    "encoding/json"
+    "time"
+)
 
 type UnusedType struct {
 Foo Foo
 }
 
-type Wrapper[T any] = T
+type Wrapper[T any] struct { Value T }
 
 // Tuple is a generic type which allows us to
 // return two values of two different types
@@ -43,6 +46,18 @@ type Foo int
 
 type Nested struct {
     Value string
+}
+
+type AllInputTypes[A any] struct {
+    A []time.Time         `header:"X-Alice"`       // Specify this comes from a header field
+    B int                 `query:"Bob"`              // Specify this comes from a query string
+    C bool                `json:"Charile,omitempty"` // This can come from anywhere, but if it comes from the payload in JSON it must be called Charile
+    Dave A                                           // This generic type complicates the whole thing 🙈
+}
+
+type HeaderOnlyStruct struct {
+    Foo []int `header:"X-Foo"`
+    Bar bool `header:"X-Bar"`
 }
 
 -- svc/api.go --
@@ -78,3 +93,13 @@ func RESTPath(ctx context.Context, a string, b int) error {
 
 //encore:api public raw path=/webhook/:a/*b
 func Webhook(w http.ResponseWriter, req *http.Request) {}
+
+//encore:api public method=POST
+func RequestWithAllInputTypes(ctx context.Context, req *AllInputTypes[string]) (*AllInputTypes[float64], error) {
+    return nil
+}
+
+//encore:api public method=GET
+func GetRequestWithAllInputTypes(ctx context.Context, req *AllInputTypes[int]) (HeaderOnlyStruct, error) {
+    return nil
+}

--- a/cli/internal/codegen/utils.go
+++ b/cli/internal/codegen/utils.go
@@ -1,6 +1,9 @@
 package codegen
 
 import (
+	"github.com/cockroachdb/errors"
+
+	"encr.dev/parser/encoding"
 	meta "encr.dev/proto/encore/parser/meta/v1"
 )
 
@@ -11,4 +14,20 @@ func hasPublicRPC(svc *meta.Service) bool {
 		}
 	}
 	return false
+}
+
+func toFieldLists(fields []*encoding.ParameterEncoding) (header []*encoding.ParameterEncoding, query []*encoding.ParameterEncoding, body []*encoding.ParameterEncoding, err error) {
+	for _, field := range fields {
+		switch field.Location {
+		case encoding.Header:
+			header = append(header, field)
+		case encoding.Query:
+			query = append(query, field)
+		case encoding.Body:
+			body = append(body, field)
+		default:
+			err = errors.Newf("unexpected location: %+v", field.Location)
+		}
+	}
+	return
 }

--- a/pkg/golden/golden.go
+++ b/pkg/golden/golden.go
@@ -15,9 +15,17 @@ var (
 	testMainRan bool // did TestMain get called?
 )
 
-// Test checks the test output against the golden file.
+// Test checks the test output against the golden file where the path to the golden file is
+// based on the test name; i.e. `testName.golden` within the `testdata` folder.
 // If -golden-update was passed to "go test", it writes new golden files instead.
 func Test(t testing.TB, output string) {
+	fn := strings.Replace(t.Name(), "/", "__", -1)
+	TestAgainst(t, fn+".golden", output)
+}
+
+// TestAgainst checks the test output against the golden file.
+// If -golden-update was passed to "go test", it writes new golden files instead.
+func TestAgainst(t testing.TB, goldenFileName string, output string) {
 	if !testMainRan {
 		t.Fatal("golden.TestMain was not called")
 	}
@@ -25,8 +33,7 @@ func Test(t testing.TB, output string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fn := strings.Replace(t.Name(), "/", "__", -1)
-	path := filepath.Join(wd, "testdata", fn+".golden")
+	path := filepath.Join(wd, "testdata", goldenFileName)
 
 	if update {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {


### PR DESCRIPTION
This commit adds header support to the Go Client Generator using the new
DescribeRPC and shared Type Marshaling generator.

The golden package is now being used for the Client Generator to make it easier
to update the expected test files.

It updates the input to the client generator test to include a bunch of new
cases to try and expose as many test edges as possible.