### PR TITLE
internal/gocodegen/marshalling Write marshaller for body and json

### DIFF
--- a/internal/gocodegen/marshalling.go
+++ b/internal/gocodegen/marshalling.go
@@ -75,7 +75,7 @@ func (g *MarshallingCodeGenerator) NewPossibleInstance(instanceName string) *Mar
 
 // WriteToFile writes the full encoder type into the given file.
 func (g *MarshallingCodeGenerator) WriteToFile(f *File) {
-	if !g.used || len(g.builtins) == 0 {
+	if !g.used || (len(g.builtins) == 0 && !g.usedBody && !g.usedJson) {
 		return
 	}
 


### PR DESCRIPTION
The WriteToFile method also writes body and json helper methods which aren't added to the list of builtins