### PR TITLE
internal/gocodegen/marshalling remove dependency on go 1.18

### DIFF
--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -1042,7 +1042,7 @@ func (d *marshaller) Body(body io.Reader) (payload []byte) {
 	}
 	return payload
 }
-func (d *marshaller) ParseJSON(field string, iter *jsoniter.Iterator, dst any) {
+func (d *marshaller) ParseJSON(field string, iter *jsoniter.Iterator, dst interface{}) {
 	iter.ReadVal(dst)
 	d.setErr("invalid json parameter", field, iter.Error)
 }

--- a/internal/gocodegen/marshalling.go
+++ b/internal/gocodegen/marshalling.go
@@ -136,7 +136,7 @@ func (g *MarshallingCodeGenerator) WriteToFile(f *File) {
 	}
 
 	if g.usedJson {
-		f.Func().Params(Id("d").Op("*").Id(g.structName)).Id("ParseJSON").Params(Id("field").String(), Id("iter").Op("*").Qual("github.com/json-iterator/go", "Iterator"), Id("dst").Any()).Block(
+		f.Func().Params(Id("d").Op("*").Id(g.structName)).Id("ParseJSON").Params(Id("field").String(), Id("iter").Op("*").Qual("github.com/json-iterator/go", "Iterator"), Id("dst").Interface()).Block(
 			Id("iter").Dot("ReadVal").Call(Id("dst")),
 			Id("d").Dot("setErr").Call(Lit("invalid json parameter"), Id("field"), Id("iter").Dot("Error")),
 		)


### PR DESCRIPTION
`any` can only be used in > go 1.18.