### PR TITLE
compiler/internal/codegen: Add support for named struct auth params

### DIFF
--- a/cli/daemon/run/run_test.go
+++ b/cli/daemon/run/run_test.go
@@ -61,6 +61,10 @@ type NonBasicResponse struct {
 	PathString string
 	PathInt    int
 	PathWild   string
+
+	//Auth
+	AuthHeader string
+	AuthQuery  []int
 }
 
 func TestMain(m *testing.M) {
@@ -176,11 +180,14 @@ func TestEndToEndWithApp(t *testing.T) {
 				PathString:   "shoebill",
 				PathInt:      55,
 				PathWild:     "toucan/crane/vulture/78/",
+				AuthHeader:   "header",
+				AuthQuery:    []int{5, 6},
 			}
 			body, err := json.Marshal(&input)
 			c.Assert(err, qt.IsNil)
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("POST", "/NonBasicEcho/shoebill/55/toucan/crane/vulture/78/?string=robin&no=33", bytes.NewReader(body))
+			req := httptest.NewRequest("POST", "/NonBasicEcho/shoebill/55/toucan/crane/vulture/78/?string=robin&no=33&query=5&query=6", bytes.NewReader(body))
+			req.Header.Add("X-Header", "header")
 			req.Header.Add("X-Header-String", "starling")
 			req.Header.Add("X-Header-Number", "10")
 			req.Header.Add("Authorization", "Bearer tokendata")

--- a/cli/daemon/run/testdata/echo_client/client.ts
+++ b/cli/daemon/run/testdata/echo_client/client.ts
@@ -152,6 +152,12 @@ export namespace echo {
 
         PathInt: number
         PathWild: string
+        /**
+         * Auth Parameters
+         */
+        AuthHeader: string
+
+        AuthQuery: number[]
     }
 
     export class ServiceClient {

--- a/cli/daemon/run/testdata/echo_client/client/client.go
+++ b/cli/daemon/run/testdata/echo_client/client/client.go
@@ -151,6 +151,8 @@ type EchoNonBasicData struct {
 	PathString  string `query:"-"` // Path Parameters
 	PathInt     int    `query:"-"`
 	PathWild    string `query:"-"`
+	AuthHeader  string `query:"-"` // Auth Parameters
+	AuthQuery   []int  `query:"-"`
 }
 
 // EchoClient Provides you access to call public and authenticated APIs on echo. The concrete implementation is echoClient.
@@ -357,6 +359,8 @@ func (c *echoClient) NonBasicEcho(ctx context.Context, pathString string, pathIn
 		PathString  string                    `json:"PathString"`
 		PathInt     int                       `json:"PathInt"`
 		PathWild    string                    `json:"PathWild"`
+		AuthHeader  string                    `json:"AuthHeader"`
+		AuthQuery   []int                     `json:"AuthQuery"`
 	}{}
 
 	// Now make the actual call to the API
@@ -384,6 +388,8 @@ func (c *echoClient) NonBasicEcho(ctx context.Context, pathString string, pathIn
 	resp.PathString = respBody.PathString
 	resp.PathInt = respBody.PathInt
 	resp.PathWild = respBody.PathWild
+	resp.AuthHeader = respBody.AuthHeader
+	resp.AuthQuery = respBody.AuthQuery
 
 	if respDecoder.LastError != nil {
 		err = fmt.Errorf("unable to unmarshal headers: %w", respDecoder.LastError)

--- a/cli/daemon/run/testdata/echo_client/main.go
+++ b/cli/daemon/run/testdata/echo_client/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	// Test auth handlers
 	_, err = api.Test.TestAuthHandler(ctx)
-	assertStructuredError(err, client.ErrUnauthenticated, "missing auth token")
+	assertStructuredError(err, client.ErrUnauthenticated, "invalid token")
 
 	// Test with basic auth token
 	{

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -1,0 +1,304 @@
+// main code
+package main
+
+import (
+	"context"
+	"encore.app/svc"
+	auth "encore.dev/beta/auth"
+	"encore.dev/beta/errs"
+	"encore.dev/runtime"
+	"encore.dev/runtime/config"
+	serde "encore.dev/runtime/serde"
+	"errors"
+	"fmt"
+	"github.com/json-iterator/go"
+	"github.com/julienschmidt/httprouter"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	_ "unsafe"
+)
+
+var json = jsoniter.Config{
+	EscapeHTML:             false,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: true,
+}.Froze()
+
+func __encore_svc_Eight(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	ctx := req.Context()
+	runtime.BeginOperation()
+	defer runtime.FinishOperation()
+
+	var err error
+	dec := &marshaller{}
+	// Decode request
+	p0 := dec.ToString("bar", ps[0].Value, true)
+	p1 := dec.ToString("baz", ps[1].Value, true)
+	inputs, _ := runtime.SerializeInputs(p0, p1)
+
+	params := &svc.FooParams{}
+	switch m := req.Method; m {
+	case "POST":
+		// Decode JSON Body
+		payload := dec.Body(req.Body)
+		iter := jsoniter.ParseBytes(json, payload)
+
+		for iter.ReadObjectCB(func(_ *jsoniter.Iterator, key string) bool {
+			switch strings.ToLower(key) {
+			case "name":
+				dec.ParseJSON("Name", iter, &params.Name)
+			default:
+				_ = iter.SkipAndReturnBytes()
+			}
+			return true
+		}) {
+		}
+
+	default:
+		panic("HTTP method is not supported")
+	}
+	// Add trace info
+	jsonParams, err := json.Marshal(params)
+	if err != nil {
+		errs.HTTPError(w, errs.B().Code(errs.Internal).Msg("internal error").Err())
+		return
+	}
+	inputs = append(inputs, jsonParams)
+
+	uid, authData, proceed := __encore_authenticate(w, req, true, "svc", "Eight")
+	if !proceed {
+		return
+	}
+
+	err = runtime.BeginRequest(ctx, runtime.RequestData{
+		AuthData:        authData,
+		Endpoint:        "Eight",
+		EndpointExprIdx: 2,
+		Inputs:          inputs,
+		Path:            req.URL.Path,
+		PathSegments:    ps,
+		Service:         "svc",
+		Type:            runtime.RPCCall,
+		UID:             uid,
+	})
+	if err != nil {
+		errs.HTTPError(w, errs.B().Code(errs.Internal).Msg("internal error").Err())
+		return
+	}
+	if dec.LastError != nil {
+		err := dec.LastError
+		runtime.FinishRequest(nil, err)
+		errs.HTTPError(w, err)
+		return
+	}
+
+	// Call the endpoint
+	defer func() {
+		// Catch handler panic
+		if e := recover(); e != nil {
+			err := errs.B().Code(errs.Internal).Msgf("panic handling request: %v", e).Err()
+			runtime.FinishRequest(nil, err)
+			errs.HTTPError(w, err)
+		}
+	}()
+	resp, respErr := svc.Eight(req.Context(), p0, p1, params)
+	if respErr != nil {
+		respErr = errs.Convert(respErr)
+		runtime.FinishRequest(nil, respErr)
+		errs.HTTPError(w, respErr)
+		return
+	}
+
+	// Serialize the response
+	var respData []byte
+
+	// Encode JSON body
+	respData, err = serde.SerializeJSONFunc(json, func(ser *serde.JSONSerializer) {
+		ser.WriteField("Message", resp.Message, false)
+	})
+	if err != nil {
+		marshalErr := errs.WrapCode(err, errs.Internal, "failed to marshal response")
+		runtime.FinishRequest(nil, marshalErr)
+		errs.HTTPError(w, marshalErr)
+		return
+	}
+
+	// Record tracing data
+	respData = append(respData, '\n')
+	output := [][]byte{respData}
+	runtime.FinishRequest(output, nil)
+
+	// Write response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	w.Write(respData)
+}
+
+// loadConfig registers the Encore services.
+//go:linkname loadConfig encore.dev/runtime/config.loadConfig
+func loadConfig() (*config.Config, error) {
+	services := []*config.Service{{
+		Endpoints: []*config.Endpoint{{
+			Access:  config.Auth,
+			Handler: __encore_svc_Eight,
+			Methods: []string{"POST"},
+			Name:    "Eight",
+			Path:    "/eight/:bar/:baz",
+			Raw:     false,
+		}},
+		Name:    "svc",
+		RelPath: "svc",
+	}}
+	static := &config.Static{
+		AppCommit: config.CommitInfo{
+			Revision:    "",
+			Uncommitted: false,
+		},
+		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
+		EncoreCompiler: "test",
+		Services:       services,
+		TestService:    "",
+		Testing:        false,
+	}
+	return &config.Config{
+		Runtime: config.ParseRuntime(getAndClearEnv("ENCORE_RUNTIME_CONFIG")),
+		Secrets: config.ParseSecrets(getAndClearEnv("ENCORE_APP_SECRETS")),
+		Static:  static,
+	}, nil
+}
+
+func main() {
+	if err := runtime.ListenAndServe(); err != nil {
+		runtime.Logger().Fatal().Err(err).Msg("could not listen and serve")
+	}
+}
+
+// getAndClearEnv gets an env variable and unsets it.
+func getAndClearEnv(env string) string {
+	val := os.Getenv(env)
+	os.Unsetenv(env)
+	return val
+}
+
+type validationDetails struct {
+	Field string `json:"field"`
+	Err   string `json:"err"`
+}
+
+func (validationDetails) ErrDetails() {}
+
+// __encore_authenticate authenticates a request.
+// It reports the user id, user data, and whether or not to proceed with the request.
+// If requireAuth is false, it reports ("", nil, true) on authentication failure.
+func __encore_authenticate(w http.ResponseWriter, req *http.Request, requireAuth bool, svcName, rpcName string) (uid auth.UID, authData interface{}, proceed bool) {
+	param, err := __encore_resolveAuthParam(req)
+	if err != nil {
+		if requireAuth {
+			runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth")
+			errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err())
+			return "", nil, false
+		}
+		return "", nil, true
+	}
+
+	uid, authData, err = __encore_validateToken(req.Context(), param)
+	if errs.Code(err) == errs.Unauthenticated && !requireAuth {
+		return "", nil, true
+	} else if err != nil {
+		errs.HTTPError(w, err)
+		return "", nil, false
+	}
+	return uid, authData, true
+}
+
+// __encore_resolveAuthParam resolves the auth parameters from the http request
+//  or returns an error if auth params cannot be found
+func __encore_resolveAuthParam(req *http.Request) (param string, err error) {
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		for _, prefix := range [...]string{"Bearer ", "Token "} {
+			if strings.HasPrefix(auth, prefix) {
+				if t := auth[len(prefix):]; t != "" {
+					return t, nil
+				}
+			}
+		}
+	}
+	return "", errors.New("missing auth token")
+}
+
+// __encore_validateToken validates an auth token.
+func __encore_validateToken(ctx context.Context, param string) (uid auth.UID, authData interface{}, authErr error) {
+	done := make(chan struct{})
+	call, err := runtime.BeginAuth(3, param)
+	if err != nil {
+		return "", nil, err
+	}
+
+	go func() {
+		defer close(done)
+		authErr = call.BeginReq(ctx, runtime.RequestData{
+			Endpoint:        "AuthHandler",
+			EndpointExprIdx: 3,
+			Inputs:          [][]byte{[]byte(strconv.Quote(param))},
+			Service:         "svc",
+			Type:            runtime.AuthHandler,
+		})
+		if authErr != nil {
+			return
+		}
+		defer func() {
+			if err2 := recover(); err2 != nil {
+				authErr = errs.B().Code(errs.Internal).Msgf("auth handler panicked: %v", err2).Err()
+				call.FinishReq(nil, authErr)
+			}
+		}()
+		uid, authData, authErr = svc.AuthHandler(ctx, param)
+		serialized, _ := runtime.SerializeInputs(uid, authData)
+		if authErr != nil {
+			call.FinishReq(nil, authErr)
+		} else {
+			call.FinishReq(serialized, nil)
+		}
+	}()
+	<-done
+	call.Finish(uid, authErr)
+	return uid, authData, authErr
+}
+
+// marshaller is used to serialize request data into strings and deserialize response data from strings
+type marshaller struct {
+	LastError error // The last error that occurred
+}
+
+func (e *marshaller) ToString(field string, s string, required bool) (v string) {
+	if !required && s == "" {
+		return
+	}
+	return s
+}
+
+// setErr sets the last error within the object if one is not already set
+func (e *marshaller) setErr(msg, field string, err error) {
+	if err != nil && e.LastError == nil {
+		e.LastError = fmt.Errorf("%s: %s: %w", field, msg, err)
+	}
+}
+
+func (d *marshaller) Body(body io.Reader) (payload []byte) {
+	payload, err := ioutil.ReadAll(body)
+	if err == nil && len(payload) == 0 {
+		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
+	} else if err != nil {
+		d.setErr("could not parse request body", "request_body", err)
+	}
+	return payload
+}
+func (d *marshaller) ParseJSON(field string, iter *jsoniter.Iterator, dst interface{}) {
+	iter.ReadVal(dst)
+	d.setErr("invalid json parameter", field, iter.Error)
+}

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -865,48 +865,58 @@ func (validationDetails) ErrDetails() {}
 // It reports the user id, user data, and whether or not to proceed with the request.
 // If requireAuth is false, it reports ("", nil, true) on authentication failure.
 func __encore_authenticate(w http.ResponseWriter, req *http.Request, requireAuth bool, svcName, rpcName string) (uid auth.UID, authData interface{}, proceed bool) {
-	var token string
-	if auth := req.Header.Get("Authorization"); auth != "" {
-	TokenLoop:
-		for _, prefix := range [...]string{"Bearer ", "Token "} {
-			if strings.HasPrefix(auth, prefix) {
-				if t := auth[len(prefix):]; t != "" {
-					token = t
-					break TokenLoop
-				}
-			}
-		}
-	}
-
-	if token != "" {
-		var err error
-		uid, authData, err = __encore_validateToken(req.Context(), token)
-		if errs.Code(err) == errs.Unauthenticated && !requireAuth {
-			return "", nil, true
-		} else if err != nil {
-			errs.HTTPError(w, err)
+	param, err := __encore_resolveAuthParam(req)
+	if err != nil {
+		if requireAuth {
+			runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth")
+			errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err())
 			return "", nil, false
-		} else {
-			return uid, authData, true
 		}
-	}
-
-	if requireAuth {
-		runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth token")
-		errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("missing auth token").Err())
-		return "", nil, false
-	} else {
 		return "", nil, true
 	}
+
+	uid, authData, err = __encore_validateToken(req.Context(), param)
+	if errs.Code(err) == errs.Unauthenticated && !requireAuth {
+		return "", nil, true
+	} else if err != nil {
+		errs.HTTPError(w, err)
+		return "", nil, false
+	}
+	return uid, authData, true
+}
+
+// __encore_resolveAuthParam resolves the auth parameters from the http request
+//  or returns an error if auth params cannot be found
+func __encore_resolveAuthParam(req *http.Request) (param *svc.AuthParams, err error) {
+	params := &svc.AuthParams{}
+	dec := &marshaller{}
+	// Decode Headers
+	h := req.Header
+	params.Header1 = h.Get("one")
+	params.Header2 = dec.ToInt("two", h.Get("two"), false)
+	params.Header3 = dec.ToUint("three", h.Get("three"), false)
+
+	// Decode Query String
+	qs := req.URL.Query()
+	params.Query1 = qs.Get("one")
+	params.Query2 = qs["two"]
+	params.Query3 = dec.ToTime("three", qs.Get("three"), false)
+
+	if dec.LastError != nil {
+		return nil, dec.LastError
+	}
+
+	return params, nil
 }
 
 // __encore_validateToken validates an auth token.
-func __encore_validateToken(ctx context.Context, token string) (uid auth.UID, authData interface{}, authErr error) {
-	if token == "" {
-		return "", nil, nil
-	}
+func __encore_validateToken(ctx context.Context, param *svc.AuthParams) (uid auth.UID, authData interface{}, authErr error) {
 	done := make(chan struct{})
-	call, err := runtime.BeginAuth(24, token)
+	paramStr, err := json.MarshalToString(param)
+	if err != nil {
+		return "", nil, err
+	}
+	call, err := runtime.BeginAuth(24, paramStr)
 	if err != nil {
 		return "", nil, err
 	}
@@ -916,7 +926,7 @@ func __encore_validateToken(ctx context.Context, token string) (uid auth.UID, au
 		authErr = call.BeginReq(ctx, runtime.RequestData{
 			Endpoint:        "AuthHandler",
 			EndpointExprIdx: 24,
-			Inputs:          [][]byte{[]byte(strconv.Quote(token))},
+			Inputs:          [][]byte{[]byte(paramStr)},
 			Service:         "svc",
 			Type:            runtime.AuthHandler,
 		})
@@ -929,7 +939,7 @@ func __encore_validateToken(ctx context.Context, token string) (uid auth.UID, au
 				call.FinishReq(nil, authErr)
 			}
 		}()
-		uid, authData, authErr = svc.AuthHandler(ctx, token)
+		uid, authData, authErr = svc.AuthHandler(ctx, param)
 		serialized, _ := runtime.SerializeInputs(uid, authData)
 		if authErr != nil {
 			call.FinishReq(nil, authErr)
@@ -1021,6 +1031,15 @@ func (e *marshaller) ToTimeList(field string, s []string, required bool) (v []ti
 		v = append(v, e.ToTime(field, x, required))
 	}
 	return v
+}
+
+func (e *marshaller) ToInt(field string, s string, required bool) (v int) {
+	if !required && s == "" {
+		return
+	}
+	x, err := strconv.ParseInt(s, 10, 64)
+	e.setErr("invalid parameter", field, err)
+	return int(x)
 }
 
 // setErr sets the last error within the object if one is not already set

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__token_auth.golden
@@ -1,0 +1,32 @@
+// pkg svc
+package svc_test
+
+import (
+	"encore.app/svc"
+	_ "encore.dev/runtime"
+	"encore.dev/runtime/config"
+	"os"
+	"reflect"
+	_ "unsafe"
+)
+
+//go:linkname loadConfig encore.dev/runtime/config.loadConfig
+func loadConfig() (*config.Config, error) {
+	services := []*config.Service{{
+		Endpoints: nil,
+		Name:      "svc",
+		RelPath:   "svc",
+	}}
+	static := &config.Static{
+		AuthData:    reflect.TypeOf((*svc.AuthData)(nil)),
+		Services:    services,
+		TestService: "svc",
+		Testing:     true,
+	}
+	return &config.Config{
+		Runtime: config.ParseRuntime(os.Getenv("ENCORE_RUNTIME_CONFIG")),
+		Secrets: config.ParseSecrets(os.Getenv("ENCORE_APP_SECRETS")),
+		Static:  static,
+	}, nil
+}
+

--- a/compiler/internal/codegen/testdata/token_auth.txt
+++ b/compiler/internal/codegen/testdata/token_auth.txt
@@ -1,0 +1,35 @@
+-- svc/svc.go --
+package svc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"encore.dev/beta/auth"
+	"encore.dev/rlog"
+	"encore.dev/cron"
+	"encore.dev/types/uuid"
+)
+
+type FooParams struct {
+	Name string
+}
+
+type Response struct {
+	Message string
+}
+
+//encore:api auth path=/eight/:bar/:baz
+func Eight(ctx context.Context, bar, baz string, p *FooParams) (*Response, error) {
+	rlog.Info("eight", "bar", bar, "baz", baz)
+	return &Response{Message: bar}, nil
+}
+
+type AuthData struct{}
+
+//encore:authhandler
+func AuthHandler(ctx context.Context, token string) (auth.UID, *AuthData, error) {
+	return "", nil, nil
+}

--- a/compiler/internal/codegen/testdata/variants.txt
+++ b/compiler/internal/codegen/testdata/variants.txt
@@ -97,7 +97,16 @@ func Query(ctx context.Context, p *QueryParams) error {
 
 type AuthData struct{}
 
+type AuthParams struct {
+    Header1 string `header:"one"`
+    Header2 int `header:"two"`
+    Header3 uint `header:"three"`
+    Query1 string `query:"one"`
+    Query2 []string `query:"two"`
+    Query3 time.Time `query:"three"`
+
+}
 //encore:authhandler
-func AuthHandler(ctx context.Context, token string) (auth.UID, *AuthData, error) {
+func AuthHandler(ctx context.Context, params *AuthParams) (auth.UID, *AuthData, error) {
 	return "", nil, nil
 }


### PR DESCRIPTION
This commit adds support for using custom structs instead of the authorization token as input to the encore auth handler, e.g.

```
type AuthParams struct {
	Header string `header:"X-Header"`
	Query  string `query:"query"`
}

//encore:authhandler
func AuthHandler(ctx context.Context, params *AuthParams) (auth.UID, *AuthParams, error) {
	return "user", params, nil
}
```

In this example, the request handler will attempt to parse the `Header` field from the request header and the
`Query` field from the request query string.