### PR TITLE
Generated Clients: Query Strings in Raw Endpoints

### DIFF
--- a/cli/daemon/run/testdata/echo/test/endpoints.go
+++ b/cli/daemon/run/testdata/echo/test/endpoints.go
@@ -42,7 +42,6 @@ func SimpleBodyEcho(ctx context.Context, body *BodyEcho) (*BodyEcho, error) {
 
 var lastMessage = make(map[string]string)
 
-
 // UpdateMessage allows us to test an API which takes parameters,
 // but doesn't return anything
 //encore:api public method=PUT path=/last_message/:clientID
@@ -54,7 +53,7 @@ func UpdateMessage(ctx context.Context, clientID string, message *BodyEcho) erro
 // GetMessage allows us to test an API which takes no parameters,
 // but returns data. It also tests two API's on the same path with different HTTP methods
 //encore:api public method=GET path=/last_message/:clientID
-func GetMessage(ctx context.Context, clientID string,) (*BodyEcho, error) {
+func GetMessage(ctx context.Context, clientID string) (*BodyEcho, error) {
 	return &BodyEcho{
 		Message: lastMessage[clientID],
 	}, nil
@@ -68,7 +67,7 @@ type RestParams struct {
 	Nested struct {
 		Key   string `json:"Alice"`
 		Value int    `json:"bOb"`
-		Ok    bool	 `json:"charile"`
+		Ok    bool   `json:"charile"`
 	}
 }
 
@@ -85,9 +84,9 @@ func RestStyleAPI(ctx context.Context, objType int, name string, params *RestPar
 			Value int    `json:"bOb"`
 			Ok    bool   `json:"charile"`
 		}{
-			Key: name + " + " + params.Nested.Key,
+			Key:   name + " + " + params.Nested.Key,
 			Value: objType + params.Nested.Value,
-			Ok: params.Nested.Ok,
+			Ok:    params.Nested.Ok,
 		},
 	}, nil
 }
@@ -131,7 +130,6 @@ func MarshallerTestHandler(ctx context.Context, params *MarshallerTest[int]) (*M
 	return params, nil
 }
 
-
 // TestAuthHandler allows us to test the clients ability to add tokens to requests
 //encore:api auth
 func TestAuthHandler(ctx context.Context) (*BodyEcho, error) {
@@ -143,9 +141,10 @@ func TestAuthHandler(ctx context.Context) (*BodyEcho, error) {
 }
 
 type response struct {
-	Body      string
-	Header    string
-	PathParam string
+	Body        string
+	Header      string
+	PathParam   string
+	QueryString string
 }
 
 // RawEndpoint allows us to test the clients' ability to send raw requests
@@ -161,9 +160,10 @@ func RawEndpoint(w http.ResponseWriter, req *http.Request) {
 	req.Body.Close()
 
 	b, err := json.Marshal(&response{
-		Body: string(bytes),
-		Header: req.Header.Get("X-Test-Header"),
-		PathParam: encore.CurrentRequest().PathParams.Get("id"),
+		Body:        string(bytes),
+		Header:      req.Header.Get("X-Test-Header"),
+		PathParam:   encore.CurrentRequest().PathParams.Get("id"),
+		QueryString: req.URL.Query().Get("foo"),
 	})
 	if err != nil {
 		panic(err)

--- a/cli/daemon/run/testdata/echo_client/client.ts
+++ b/cli/daemon/run/testdata/echo_client/client.ts
@@ -231,12 +231,12 @@ export namespace echo {
          */
         public async MuteEcho(params: Data<string, string>): Promise<void> {
             // Convert our params into the objects we need for the request
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 key:   params.Key,
                 value: params.Value,
             }
 
-            await this.baseClient.callAPI("GET", `/echo.MuteEcho`, false, undefined, {queryFields})
+            await this.baseClient.callAPI("GET", `/echo.MuteEcho`, false, undefined, {query})
         }
 
         /**
@@ -249,7 +249,7 @@ export namespace echo {
                 "x-header-string": params.HeaderString,
             }
 
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 no:     String(params.QueryNumber),
                 string: params.QueryString,
             }
@@ -267,7 +267,7 @@ export namespace echo {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/NonBasicEcho/${pathString}/${pathInt}/${pathWild}`, true, JSON.stringify(body), {headers, queryFields})
+            const resp = await this.baseClient.callAPI("POST", `/NonBasicEcho/${pathString}/${pathInt}/${pathWild}`, true, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as NonBasicData
@@ -377,7 +377,7 @@ export namespace test {
                 "x-uuid":    String(params.HeaderUUID),
             }
 
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 boolean:   String(params.QueryBoolean),
                 bytes:     String(params.QueryBytes),
                 float:     String(params.QueryFloat),
@@ -405,7 +405,7 @@ export namespace test {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/test.MarshallerTestHandler`, false, JSON.stringify(body), {headers, queryFields})
+            const resp = await this.baseClient.callAPI("POST", `/test.MarshallerTestHandler`, false, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as MarshallerTest<number>
@@ -453,7 +453,7 @@ export namespace test {
                 "some-key": params.HeaderValue,
             }
 
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 "Some-Key": params.QueryValue,
             }
 
@@ -464,7 +464,7 @@ export namespace test {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("PUT", `/rest/object/${objType}/${name}`, false, JSON.stringify(body), {headers, queryFields})
+            const resp = await this.baseClient.callAPI("PUT", `/rest/object/${objType}/${name}`, false, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as RestParams
@@ -521,7 +521,7 @@ type CallParameters = Omit<RequestInit, "method" | "body"> & {
     headers?: Record<string, string>;
 
     /** Any query parameters to be sent with the request */
-    queryFields?: Record<string, string | string[]>
+    query?: Record<string, string | string[]>
 }
 
 // TokenGenerator is a function that returns a token
@@ -588,7 +588,7 @@ class BaseClient {
         }
 
         // Make the actual request
-        const query = params?.queryFields ? '?' + encodeQuery(params.queryFields) : ''
+        const query = params?.query ? '?' + encodeQuery(params.query) : ''
         const response = await this.fetcher(this.baseURL+path+query, init)
 
         // handle any error responses

--- a/cli/daemon/run/testdata/echo_client/client/client.go
+++ b/cli/daemon/run/testdata/echo_client/client/client.go
@@ -661,15 +661,27 @@ func (c *testClient) NoopWithError(ctx context.Context) error {
 // RawEndpoint allows us to test the clients' ability to send raw requests
 // under auth
 func (c *testClient) RawEndpoint(ctx context.Context, id string, request *http.Request) (*http.Response, error) {
+	request = request.WithContext(ctx)
+
+	// Check the request has the method set, as we can't guess what method is required
+	if request.Method == "" {
+		return nil, errors.New("request.Method must be set")
+	}
+
+	// Set the relative URL for the API call
 	path, err := url.Parse(fmt.Sprintf("/raw/%s", id))
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse api url: %w", err)
 	}
-	request = request.WithContext(ctx)
-	if request.Method == "" {
-		return nil, errors.New("request.Method must be set")
+	if request.URL != nil {
+		// If the request already has a URL associated, we'll keep any fields set inside it, and just override the schema,
+		// host and path to ensure the final URL which hit the right BaseURL
+		request.URL.Scheme = path.Scheme
+		request.URL.Host = path.Host
+		request.URL.Path = path.Path
+	} else {
+		request.URL = path
 	}
-	request.URL = path
 
 	return c.base.Do(request)
 }

--- a/cli/daemon/run/testdata/echo_client/main.go
+++ b/cli/daemon/run/testdata/echo_client/main.go
@@ -181,13 +181,9 @@ func main() {
 		)
 		assert(err, nil, "Wanted no error from client creation")
 
-		req := &http.Request{
-			Method: "PUT",
-			Header: http.Header{
-				"X-Test-Header": []string{"test"},
-			},
-			Body: io.NopCloser(strings.NewReader("this is a test body")),
-		}
+		req, err := http.NewRequest("PUT", "?foo=bar", strings.NewReader("this is a test body"))
+		assert(err, nil, "unable to create request for raw endpoint")
+		req.Header.Add("X-Test-Header", "test")
 
 		rsp, err := api.Test.RawEndpoint(ctx, "hello", req)
 		assert(err, nil, "expected no error from the raw socket")
@@ -196,9 +192,10 @@ func main() {
 		assert(rsp.StatusCode, http.StatusCreated, "expected the status code to be 201")
 
 		type responseType struct {
-			Body      string
-			Header    string
-			PathParam string
+			Body        string
+			Header      string
+			PathParam   string
+			QueryString string
 		}
 		response := &responseType{}
 
@@ -208,7 +205,7 @@ func main() {
 		err = json.Unmarshal(bytes, response)
 		assert(err, nil, "expected no error when unmarshalling the response body")
 
-		assert(response, &responseType{"this is a test body", "test", "hello"}, "expected the response to match")
+		assert(response, &responseType{"this is a test body", "test", "hello", "bar"}, "expected the response to match")
 
 	}
 

--- a/cli/daemon/run/testdata/echo_client/main.ts
+++ b/cli/daemon/run/testdata/echo_client/main.ts
@@ -99,7 +99,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
 {
   const api = new Client(
     "http://" + process.argv[2] as BaseURL,
-    { bearerToken: "tokendata"}
+    {bearerToken: "tokendata"},
   )
 
   const resp = await api.test.TestAuthHandler()
@@ -111,7 +111,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
   let tokenToReturn = "tokendata"
   const api = new Client(
     "http://" + process.argv[2] as BaseURL,
-    { bearerToken: () => tokenToReturn }
+    {bearerToken: () => tokenToReturn},
   )
 
   // With a valid token
@@ -127,7 +127,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
 {
   const api = new Client(
     "http://" + process.argv[2] as BaseURL,
-    { bearerToken: "tokendata"}
+    {bearerToken: "tokendata"},
   )
 
   const resp = await api.test.RawEndpoint(
@@ -135,8 +135,9 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
     "hello",
     "this is a test body",
     {
-      headers: { "X-Test-Header": "test" }
-    }
+      headers:     {"X-Test-Header": "test"},
+      queryFields: {"foo": "bar"},
+    },
   )
 
   deepEqual(resp.status, 201, "expected the status code to be 201")
@@ -144,9 +145,10 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
   const response = await resp.json()
 
   deepEqual(response, {
-    Body: "this is a test body",
-    Header: "test",
-    PathParam: "hello"
+    Body:        "this is a test body",
+    Header:      "test",
+    PathParam:   "hello",
+    QueryString: "bar",
   }, "expected the response to match")
 }
 

--- a/cli/daemon/run/testdata/echo_client/main.ts
+++ b/cli/daemon/run/testdata/echo_client/main.ts
@@ -136,7 +136,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
     "this is a test body",
     {
       headers:     {"X-Test-Header": "test"},
-      queryFields: {"foo": "bar"},
+      query: {"foo": "bar"},
     },
   )
 

--- a/cli/daemon/run/testdata/echo_client/package.json
+++ b/cli/daemon/run/testdata/echo_client/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --experimental-specifier-resolution=node --loader ts-node/esm ./main.ts",
+    "test": "node --trace-warnings --experimental-specifier-resolution=node --loader ts-node/esm ./main.ts",
     "lint": "tsc --noEmit && eslint \"**/*.ts\""
   },
   "devDependencies": {

--- a/cli/internal/codegen/testdata/expected_typescript.ts
+++ b/cli/internal/codegen/testdata/expected_typescript.ts
@@ -237,11 +237,11 @@ export namespace svc {
 
         public async Get(params: GetRequest): Promise<void> {
             // Convert our params into the objects we need for the request
-            const query: Record<string, string | string[]> = {
+            const queryFields: Record<string, string | string[]> = {
                 boo: String(params.Baz),
             }
 
-            await this.baseClient.callAPI("GET", `/svc.Get?${encodeQuery(query)}`, false)
+            await this.baseClient.callAPI("GET", `/svc.Get`, false, undefined, {queryFields})
         }
 
         public async GetRequestWithAllInputTypes(params: AllInputTypes<number>): Promise<HeaderOnlyStruct> {
@@ -250,14 +250,14 @@ export namespace svc {
                 "x-alice": String(params.A),
             }
 
-            const query: Record<string, string | string[]> = {
+            const queryFields: Record<string, string | string[]> = {
                 Bob:  params.B.map((v) => String(v)),
                 c:    String(params["Charlies-Bool"]),
                 dave: String(params.Dave),
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes?${encodeQuery(query)}`, false, undefined, {headers})
+            const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, false, undefined, {headers, queryFields})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as HeaderOnlyStruct
@@ -300,7 +300,7 @@ export namespace svc {
                 "x-alice": String(params.A),
             }
 
-            const query: Record<string, string | string[]> = {
+            const queryFields: Record<string, string | string[]> = {
                 Bob: params.B.map((v) => String(v)),
             }
 
@@ -311,7 +311,7 @@ export namespace svc {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/svc.RequestWithAllInputTypes?${encodeQuery(query)}`, false, JSON.stringify(body), {headers})
+            const resp = await this.baseClient.callAPI("POST", `/svc.RequestWithAllInputTypes`, false, JSON.stringify(body), {headers, queryFields})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as AllInputTypes<number>
@@ -350,7 +350,13 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
     return pairs.join("&")
 }
 // CallParameters is the type of the parameters to a method call, but require headers to be a Record type
-type CallParameters = Omit<RequestInit, "method" | "body"> & { headers?: Record<string, string> }
+type CallParameters = Omit<RequestInit, "method" | "body"> & {
+    /** Any headers to be sent with the request */
+    headers?: Record<string, string>;
+
+    /** Any query parameters to be sent with the request */
+    queryFields?: Record<string, string | string[]>
+}
 
 // TokenGenerator is a function that returns a token
 export type TokenGenerator = () => string
@@ -416,7 +422,8 @@ class BaseClient {
         }
 
         // Make the actual request
-        const response = await this.fetcher(this.baseURL + path, init)
+        const query = params?.queryFields ? '?' + encodeQuery(params.queryFields) : ''
+        const response = await this.fetcher(this.baseURL+path+query, init)
 
         // handle any error responses
         if (!response.ok) {

--- a/cli/internal/codegen/testdata/expected_typescript.ts
+++ b/cli/internal/codegen/testdata/expected_typescript.ts
@@ -237,11 +237,11 @@ export namespace svc {
 
         public async Get(params: GetRequest): Promise<void> {
             // Convert our params into the objects we need for the request
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 boo: String(params.Baz),
             }
 
-            await this.baseClient.callAPI("GET", `/svc.Get`, false, undefined, {queryFields})
+            await this.baseClient.callAPI("GET", `/svc.Get`, false, undefined, {query})
         }
 
         public async GetRequestWithAllInputTypes(params: AllInputTypes<number>): Promise<HeaderOnlyStruct> {
@@ -250,14 +250,14 @@ export namespace svc {
                 "x-alice": String(params.A),
             }
 
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 Bob:  params.B.map((v) => String(v)),
                 c:    String(params["Charlies-Bool"]),
                 dave: String(params.Dave),
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, false, undefined, {headers, queryFields})
+            const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, false, undefined, {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as HeaderOnlyStruct
@@ -300,7 +300,7 @@ export namespace svc {
                 "x-alice": String(params.A),
             }
 
-            const queryFields: Record<string, string | string[]> = {
+            const query: Record<string, string | string[]> = {
                 Bob: params.B.map((v) => String(v)),
             }
 
@@ -311,7 +311,7 @@ export namespace svc {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/svc.RequestWithAllInputTypes`, false, JSON.stringify(body), {headers, queryFields})
+            const resp = await this.baseClient.callAPI("POST", `/svc.RequestWithAllInputTypes`, false, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as AllInputTypes<number>
@@ -355,7 +355,7 @@ type CallParameters = Omit<RequestInit, "method" | "body"> & {
     headers?: Record<string, string>;
 
     /** Any query parameters to be sent with the request */
-    queryFields?: Record<string, string | string[]>
+    query?: Record<string, string | string[]>
 }
 
 // TokenGenerator is a function that returns a token
@@ -422,7 +422,7 @@ class BaseClient {
         }
 
         // Make the actual request
-        const query = params?.queryFields ? '?' + encodeQuery(params.queryFields) : ''
+        const query = params?.query ? '?' + encodeQuery(params.query) : ''
         const response = await this.fetcher(this.baseURL+path+query, init)
 
         // handle any error responses

--- a/cli/internal/codegen/typescript.go
+++ b/cli/internal/codegen/typescript.go
@@ -59,6 +59,7 @@ type typescript struct {
 
 	seenJSON        bool // true if a JSON type was seen
 	seenQueryString bool // true if a query string was seen
+	seenRawEndpoint bool // true if we've seen a raw endpoint
 }
 
 func (ts *typescript) Version() int {
@@ -273,6 +274,8 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 	// Raw end points just pass through the request
 	// and need no further code generation
 	if rpc.Proto == meta.RPC_RAW {
+		ts.seenRawEndpoint = true
+
 		w.WriteStringf(
 			"return this.baseClient.callAPI(method, `%s`, %s, body, options)\n",
 			rpcPath,
@@ -283,6 +286,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 
 	// Work out how we encode the Request Schema
 	headers := ""
+	query := ""
 	body := ""
 
 	if rpc.RequestSchema != nil {
@@ -309,8 +313,8 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 
 		// Generate the query string
 		if len(reqEnc.QueryParameters) > 0 {
+			query = "queryFields"
 			ts.seenQueryString = true
-			rpcPath += "?${encodeQuery(query)}"
 
 			dict := make(map[string]string)
 			for _, field := range reqEnc.QueryParameters {
@@ -325,7 +329,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 				}
 			}
 
-			w.WriteString("const query: Record<string, string | string[]> = ")
+			w.WriteString("const queryFields: Record<string, string | string[]> = ")
 			ts.Values(w, dict)
 			w.WriteString("\n")
 		}
@@ -359,15 +363,26 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 		rpcPath,
 		strconv.FormatBool(rpc.AccessType == meta.RPC_AUTH),
 	)
-	if body != "" || headers != "" {
+	if body != "" || headers != "" || query != "" {
 		if body == "" {
 			callAPI += ", undefined"
 		} else {
 			callAPI += ", " + body
 		}
 
-		if headers != "" {
-			callAPI += ", {" + headers + "}"
+		if headers != "" || query != "" {
+			callAPI += ", {" + headers
+
+			if headers != "" && query != "" {
+				callAPI += ", "
+			}
+
+			if query != "" {
+				callAPI += query
+			}
+
+			callAPI += "}"
+
 		}
 	}
 	callAPI += ")"
@@ -569,7 +584,13 @@ func (ts *typescript) writeBaseClient(appSlug string) {
 
 	ts.WriteString(`
 // CallParameters is the type of the parameters to a method call, but require headers to be a Record type
-type CallParameters = Omit<RequestInit, "method" | "body"> & { headers?: Record<string, string> }
+type CallParameters = Omit<RequestInit, "method" | "body"> & {
+    /** Any headers to be sent with the request */
+    headers?: Record<string, string>;
+
+    /** Any query parameters to be sent with the request */
+    queryFields?: Record<string, string | string[]>
+}
 
 // TokenGenerator is a function that returns a token
 export type TokenGenerator = () => string
@@ -635,7 +656,16 @@ class BaseClient {
         }
 
         // Make the actual request
-        const response = await this.fetcher(this.baseURL + path, init)
+        `)
+
+	if ts.seenRawEndpoint || ts.seenQueryString {
+		ts.WriteString(`const query = params?.queryFields ? '?' + encodeQuery(params.queryFields) : ''
+        const response = await this.fetcher(this.baseURL+path+query, init)`)
+	} else {
+		ts.WriteString("const response = await this.fetcher(this.baseURL+path, init)")
+	}
+
+	ts.WriteString(`
 
         // handle any error responses
         if (!response.ok) {
@@ -676,7 +706,7 @@ export type JSONValue = string | number | boolean | null | JSONValue[] | {[key: 
 `)
 	}
 
-	if ts.seenQueryString {
+	if ts.seenQueryString || ts.seenRawEndpoint {
 		ts.WriteString(`
 
 function encodeQuery(parts: Record<string, string | string[]>): string {

--- a/cli/internal/codegen/typescript.go
+++ b/cli/internal/codegen/typescript.go
@@ -313,7 +313,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 
 		// Generate the query string
 		if len(reqEnc.QueryParameters) > 0 {
-			query = "queryFields"
+			query = "query"
 			ts.seenQueryString = true
 
 			dict := make(map[string]string)
@@ -329,7 +329,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 				}
 			}
 
-			w.WriteString("const queryFields: Record<string, string | string[]> = ")
+			w.WriteString("const query: Record<string, string | string[]> = ")
 			ts.Values(w, dict)
 			w.WriteString("\n")
 		}
@@ -589,7 +589,7 @@ type CallParameters = Omit<RequestInit, "method" | "body"> & {
     headers?: Record<string, string>;
 
     /** Any query parameters to be sent with the request */
-    queryFields?: Record<string, string | string[]>
+    query?: Record<string, string | string[]>
 }
 
 // TokenGenerator is a function that returns a token
@@ -659,7 +659,7 @@ class BaseClient {
         `)
 
 	if ts.seenRawEndpoint || ts.seenQueryString {
-		ts.WriteString(`const query = params?.queryFields ? '?' + encodeQuery(params.queryFields) : ''
+		ts.WriteString(`const query = params?.query ? '?' + encodeQuery(params.query) : ''
         const response = await this.fetcher(this.baseURL+path+query, init)`)
 	} else {
 		ts.WriteString("const response = await this.fetcher(this.baseURL+path, init)")


### PR DESCRIPTION
This commit adds support for query strings fields to be used in
requests made to raw endpoints.