### PR TITLE
Generated Clients: URI Encode Path Segments

### DIFF
--- a/cli/daemon/run/testdata/echo/test/endpoints.go
+++ b/cli/daemon/run/testdata/echo/test/endpoints.go
@@ -149,7 +149,7 @@ type response struct {
 
 // RawEndpoint allows us to test the clients' ability to send raw requests
 // under auth
-//encore:api public raw method=PUT,POST,DELETE,GET path=/raw/*id
+//encore:api public raw method=PUT,POST,DELETE,GET path=/raw/blah/*id
 func RawEndpoint(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 
@@ -169,4 +169,24 @@ func RawEndpoint(w http.ResponseWriter, req *http.Request) {
 		panic(err)
 	}
 	w.Write(b)
+}
+
+type MultiPathSegment struct {
+	Boolean  bool
+	Int      int
+	String   string
+	UUID     uuid.UUID
+	Wildcard string
+}
+
+// PathMultiSegments allows us to wildcard segments and segment URI encoding
+//encore:api public path=/multi/:bool/:int/:string/:uuid/*wildcard
+func PathMultiSegments(ctx context.Context, bool bool, int int, string string, uuid uuid.UUID, wildcard string) (*MultiPathSegment, error) {
+	return &MultiPathSegment{
+		Boolean:  bool,
+		Int:      int,
+		String:   string,
+		UUID:     uuid,
+		Wildcard: wildcard,
+	}, nil
 }

--- a/cli/daemon/run/testdata/echo_client/main.go
+++ b/cli/daemon/run/testdata/echo_client/main.go
@@ -132,7 +132,7 @@ func main() {
 	assert(err, nil, "unable to marshal response to JSON")
 	reqAsJSON, err := json.Marshal(params)
 	assert(err, nil, "unable to marshal response to JSON")
-	assert(respAsJSON, reqAsJSON, "Expected the same response from the marshaller test")
+	assert(string(respAsJSON), string(reqAsJSON), "Expected the same response from the marshaller test")
 
 	// Test auth handlers
 	_, err = api.Test.TestAuthHandler(ctx)
@@ -185,7 +185,7 @@ func main() {
 		assert(err, nil, "unable to create request for raw endpoint")
 		req.Header.Add("X-Test-Header", "test")
 
-		rsp, err := api.Test.RawEndpoint(ctx, "hello", req)
+		rsp, err := api.Test.RawEndpoint(ctx, []string{"hello"}, req)
 		assert(err, nil, "expected no error from the raw socket")
 		defer rsp.Body.Close()
 
@@ -208,6 +208,15 @@ func main() {
 		assert(response, &responseType{"this is a test body", "test", "hello", "bar"}, "expected the response to match")
 
 	}
+
+	// Test path encoding
+	resp, err := api.Test.PathMultiSegments(ctx, true, 342, "foo/blah/should/get/escaped", "503f4487-1e15-4c37-9a80-7b70f86387bb", []string{"foo/bar", "blah", "seperate/segments = great success"})
+	assert(err, nil, "expected no error from the path multi segments endpoint")
+	assert(resp.Boolean, true, "expected the boolean to be true")
+	assert(resp.Int, 342, "expected the int to be 342")
+	assert(resp.String, "foo/blah/should/get/escaped", "invalid string field returned")
+	assert(resp.UUID, "503f4487-1e15-4c37-9a80-7b70f86387bb", "invalid UUID returned")
+	assert(resp.Wildcard, "foo/bar/blah/seperate/segments = great success", "invalid wildcard field returned")
 
 	// Client test completed
 	os.Exit(0)

--- a/cli/daemon/run/testdata/echo_client/main.ts
+++ b/cli/daemon/run/testdata/echo_client/main.ts
@@ -132,7 +132,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
 
   const resp = await api.test.RawEndpoint(
     "PUT",
-    "hello",
+    ["hello"],
     "this is a test body",
     {
       headers:     {"X-Test-Header": "test"},
@@ -151,6 +151,14 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
     QueryString: "bar",
   }, "expected the response to match")
 }
+
+// Test path encoding
+const resp = await api.test.PathMultiSegments( true, 342, "foo/blah/should/get/escaped", "503f4487-1e15-4c37-9a80-7b70f86387bb", ["foo/bar", "blah", "seperate/segments = great success"])
+deepEqual(resp.Boolean, true, "expected the boolean to be true")
+deepEqual(resp.Int, 342, "expected the int to be 342")
+deepEqual(resp.String, "foo/blah/should/get/escaped", "invalid string field returned")
+deepEqual(resp.UUID, "503f4487-1e15-4c37-9a80-7b70f86387bb", "invalid UUID returned")
+deepEqual(resp.Wildcard, "foo/bar/blah/seperate/segments = great success", "invalid wildcard field returned")
 
 // Client test completed
 process.exit(0)

--- a/cli/internal/codegen/testdata/expected_typescript.ts
+++ b/cli/internal/codegen/testdata/expected_typescript.ts
@@ -291,7 +291,7 @@ export namespace svc {
         }
 
         public async RESTPath(a: string, b: number): Promise<void> {
-            await this.baseClient.callAPI("POST", `/path/${a}/${b}`, false)
+            await this.baseClient.callAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`, false)
         }
 
         public async RequestWithAllInputTypes(params: AllInputTypes<string>): Promise<AllInputTypes<number>> {
@@ -329,8 +329,8 @@ export namespace svc {
             return await resp.json() as Tuple<boolean, Foo>
         }
 
-        public async Webhook(method: string, a: string, b: string, body?: BodyInit, options?: CallParameters): Promise<Response> {
-            return this.baseClient.callAPI(method, `/webhook/${a}/${b}`, false, body, options)
+        public async Webhook(method: string, a: string, b: string[], body?: BodyInit, options?: CallParameters): Promise<Response> {
+            return this.baseClient.callAPI(method, `/webhook/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, false, body, options)
         }
     }
 }

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -16,6 +16,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -37,7 +38,13 @@ func __encore_svc_Eight(w http.ResponseWriter, req *http.Request, ps httprouter.
 	var err error
 	dec := &marshaller{}
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	p0 := dec.ToString("bar", ps[0].Value, true)
+	if value, err := url.PathUnescape(ps[1].Value); err == nil {
+		ps[1].Value = value
+	}
 	p1 := dec.ToString("baz", ps[1].Value, true)
 	inputs, _ := runtime.SerializeInputs(p0, p1)
 

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -18,6 +18,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -88,7 +89,13 @@ func __encore_svc_Eight(w http.ResponseWriter, req *http.Request, ps httprouter.
 	var err error
 	dec := &marshaller{}
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	p0 := dec.ToString("bar", ps[0].Value, true)
+	if value, err := url.PathUnescape(ps[1].Value); err == nil {
+		ps[1].Value = value
+	}
 	p1 := dec.ToString("baz", ps[1].Value, true)
 	inputs, _ := runtime.SerializeInputs(p0, p1)
 
@@ -169,6 +176,9 @@ func __encore_svc_Five(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	var err error
 	dec := &marshaller{}
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	p0 := dec.ToUUID("id", ps[0].Value, true)
 	p1 := dec.ToUint("key", ps[1].Value, true)
 	inputs, _ := runtime.SerializeInputs(p0, p1)
@@ -269,6 +279,9 @@ func __encore_svc_Four(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	ps[0].Value = strings.TrimPrefix(ps[0].Value, "/")
 
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	p0 := dec.ToString("baz", ps[0].Value, true)
 	inputs, _ := runtime.SerializeInputs(p0)
 
@@ -460,7 +473,13 @@ func __encore_svc_Seven(w http.ResponseWriter, req *http.Request, ps httprouter.
 	var err error
 	dec := &marshaller{}
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	_ = dec.ToString("bar", ps[0].Value, true)
+	if value, err := url.PathUnescape(ps[1].Value); err == nil {
+		ps[1].Value = value
+	}
 	_ = dec.ToString("baz", ps[1].Value, true)
 
 	uid, authData, proceed := __encore_authenticate(w, req, false, "svc", "Seven")
@@ -510,7 +529,13 @@ func __encore_svc_Six(w http.ResponseWriter, req *http.Request, ps httprouter.Pa
 	ps[1].Value = strings.TrimPrefix(ps[1].Value, "/")
 
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	p0 := dec.ToUUID("id", ps[0].Value, true)
+	if value, err := url.PathUnescape(ps[1].Value); err == nil {
+		ps[1].Value = value
+	}
 	p1 := dec.ToString("key", ps[1].Value, true)
 	inputs, _ := runtime.SerializeInputs(p0, p1)
 
@@ -605,6 +630,9 @@ func __encore_svc_Three(w http.ResponseWriter, req *http.Request, ps httprouter.
 	var err error
 	dec := &marshaller{}
 	// Decode request
+	if value, err := url.PathUnescape(ps[0].Value); err == nil {
+		ps[0].Value = value
+	}
 	p0 := dec.ToString("id", ps[0].Value, true)
 	inputs, _ := runtime.SerializeInputs(p0)
 


### PR DESCRIPTION
This commit adds URI encoding to path segments when called
from the generated clients. This allows for user input
to be passed directly to the client and through the URL segments
without worrying about segments not aligning.

This work showed a bug where Encore's routing layer was using
the already decoded path, which meant the path:

```
/account/abc%2Fdeposit_usd%2F%2F200
```

Was being routed as:

```
/account/abc/deposit_usd/200
```

This was fixed by using `req.URL.EscapedPath()` in the runtime
and then adding `UnescapePath` to the code which reads the path
segments and passes them to the running application