### PR TITLE
Generated Clients: Error on missing response headers

### DIFF
--- a/cli/daemon/run/testdata/echo_client/client/client.go
+++ b/cli/daemon/run/testdata/echo_client/client/client.go
@@ -275,7 +275,7 @@ func (c *echoClient) HeadersEcho(ctx context.Context, params EchoHeadersData) (r
 	// Copy the unmarshalled response body into our response struct
 	respDecoder := &serde{}
 
-	resp.Int = respDecoder.ToInt("Int", respHeaders.Get("x-int"), false)
+	resp.Int = respDecoder.ToInt("Int", respHeaders.Get("x-int"), true)
 	resp.String = respHeaders.Get("x-string")
 
 	if respDecoder.LastError != nil {
@@ -374,7 +374,7 @@ func (c *echoClient) NonBasicEcho(ctx context.Context, pathString string, pathIn
 	respDecoder := &serde{}
 
 	resp.HeaderString = respHeaders.Get("x-header-string")
-	resp.HeaderNumber = respDecoder.ToInt("HeaderNumber", respHeaders.Get("x-header-number"), false)
+	resp.HeaderNumber = respDecoder.ToInt("HeaderNumber", respHeaders.Get("x-header-number"), true)
 	resp.Struct = respBody.Struct
 	resp.StructPtr = respBody.StructPtr
 	resp.StructSlice = respBody.StructSlice
@@ -614,13 +614,13 @@ func (c *testClient) MarshallerTestHandler(ctx context.Context, params TestMarsh
 	// Copy the unmarshalled response body into our response struct
 	respDecoder := &serde{}
 
-	resp.HeaderBoolean = respDecoder.ToBool("HeaderBoolean", respHeaders.Get("x-boolean"), false)
-	resp.HeaderInt = respDecoder.ToInt("HeaderInt", respHeaders.Get("x-int"), false)
-	resp.HeaderFloat = respDecoder.ToFloat64("HeaderFloat", respHeaders.Get("x-float"), false)
+	resp.HeaderBoolean = respDecoder.ToBool("HeaderBoolean", respHeaders.Get("x-boolean"), true)
+	resp.HeaderInt = respDecoder.ToInt("HeaderInt", respHeaders.Get("x-int"), true)
+	resp.HeaderFloat = respDecoder.ToFloat64("HeaderFloat", respHeaders.Get("x-float"), true)
 	resp.HeaderString = respHeaders.Get("x-string")
-	resp.HeaderBytes = respDecoder.ToBytes("HeaderBytes", respHeaders.Get("x-bytes"), false)
-	resp.HeaderTime = respDecoder.ToTime("HeaderTime", respHeaders.Get("x-time"), false)
-	resp.HeaderJson = respDecoder.ToJSON("HeaderJson", respHeaders.Get("x-json"), false)
+	resp.HeaderBytes = respDecoder.ToBytes("HeaderBytes", respHeaders.Get("x-bytes"), true)
+	resp.HeaderTime = respDecoder.ToTime("HeaderTime", respHeaders.Get("x-time"), true)
+	resp.HeaderJson = respDecoder.ToJSON("HeaderJson", respHeaders.Get("x-json"), true)
 	resp.HeaderUUID = respHeaders.Get("x-uuid")
 	resp.HeaderUserID = respHeaders.Get("x-user-id")
 	resp.QueryBoolean = respBody.QueryBoolean

--- a/cli/internal/codegen/golang.go
+++ b/cli/internal/codegen/golang.go
@@ -642,7 +642,7 @@ func (g *golang) rpcCallSite(rpc *meta.RPC) (code []Code, err error) {
 				field.SrcName,
 				Id(headersId).Dot("Get").Call(Lit(field.Name)),
 				Id(headersId).Dot("Values").Call(Lit(field.Name)),
-				false,
+				true,
 			)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to convert %s to string in response header", field.Name)

--- a/cli/internal/codegen/testdata/expected_golang.go
+++ b/cli/internal/codegen/testdata/expected_golang.go
@@ -287,13 +287,13 @@ func (c *svcClient) GetRequestWithAllInputTypes(ctx context.Context, params SvcA
 	// Copy the unmarshalled response body into our response struct
 	respDecoder := &serde{}
 
-	resp.Boolean = respDecoder.ToBool("Boolean", respHeaders.Get("x-boolean"), false)
-	resp.Int = respDecoder.ToInt("Int", respHeaders.Get("x-int"), false)
-	resp.Float = respDecoder.ToFloat64("Float", respHeaders.Get("x-float"), false)
+	resp.Boolean = respDecoder.ToBool("Boolean", respHeaders.Get("x-boolean"), true)
+	resp.Int = respDecoder.ToInt("Int", respHeaders.Get("x-int"), true)
+	resp.Float = respDecoder.ToFloat64("Float", respHeaders.Get("x-float"), true)
 	resp.String = respHeaders.Get("x-string")
-	resp.Bytes = respDecoder.ToBytes("Bytes", respHeaders.Get("x-bytes"), false)
-	resp.Time = respDecoder.ToTime("Time", respHeaders.Get("x-time"), false)
-	resp.Json = respDecoder.ToJSON("Json", respHeaders.Get("x-json"), false)
+	resp.Bytes = respDecoder.ToBytes("Bytes", respHeaders.Get("x-bytes"), true)
+	resp.Time = respDecoder.ToTime("Time", respHeaders.Get("x-time"), true)
+	resp.Json = respDecoder.ToJSON("Json", respHeaders.Get("x-json"), true)
 	resp.UUID = respHeaders.Get("x-uuid")
 	resp.UserID = respHeaders.Get("x-user-id")
 
@@ -374,7 +374,7 @@ func (c *svcClient) RequestWithAllInputTypes(ctx context.Context, params SvcAllI
 	// Copy the unmarshalled response body into our response struct
 	respDecoder := &serde{}
 
-	resp.A = respDecoder.ToTime("A", respHeaders.Get("x-alice"), false)
+	resp.A = respDecoder.ToTime("A", respHeaders.Get("x-alice"), true)
 	resp.B = respBody.B
 	resp.C = respBody.C
 	resp.Dave = respBody.Dave

--- a/cli/internal/codegen/typescript.go
+++ b/cli/internal/codegen/typescript.go
@@ -57,9 +57,10 @@ type typescript struct {
 	currDecl         *schema.Decl
 	generatorVersion tsGenVersion
 
-	seenJSON        bool // true if a JSON type was seen
-	seenQueryString bool // true if a query string was seen
-	seenRawEndpoint bool // true if we've seen a raw endpoint
+	seenJSON           bool // true if a JSON type was seen
+	seenQueryString    bool // true if a query string was seen
+	seenRawEndpoint    bool // true if we've seen a raw endpoint
+	seenHeaderResponse bool // true if we've seen a header used in a response object
 }
 
 func (ts *typescript) Version() int {
@@ -411,7 +412,8 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 	w.WriteString("\n")
 
 	for _, headerField := range respEnc.HeaderParameters {
-		fieldValue := fmt.Sprintf("(resp.headers.get(\"%s\") ?? \"\")", headerField.Name)
+		ts.seenHeaderResponse = true
+		fieldValue := fmt.Sprintf("mustBeSet(\"Header `%s`\", resp.headers.get(\"%s\"))", headerField.Name, headerField.Name)
 
 		w.WriteStringf("%s = %s\n", ts.Dot("rtn", headerField.SrcName), ts.convertStringToBuiltin(headerField.Type.GetBuiltin(), fieldValue))
 	}
@@ -719,6 +721,25 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
     }
     return pairs.join("&")
 }`)
+	}
+
+	if ts.seenHeaderResponse {
+		ts.WriteString(`
+
+// mustBeSet will throw an APIError with the Data Loss code if value is null or undefined
+function mustBeSet<A>(field: string, value: A | null | undefined): A {
+    if (value === null || value === undefined) {
+        throw new APIError(
+            500,
+            {
+                code: ErrCode.DataLoss,
+                message: ` + "`${field} was unexpectedly ${value}`" + `, // ${value} will create the string "null" or "undefined"
+            },
+        )
+    }
+    return value
+}
+`)
 	}
 }
 


### PR DESCRIPTION
This commit changes the generated clients, so when a header
is not sent by the server, but is expected by the client - rather
than providing a default value, the client will instead raise an
error.

This aligns with the behaviour when JSON payloads are not able
to be unmarshalled into the correct types and provides a more
fail-safe behaviour on the clients.