### PR TITLE
Support in Local Dashboard for new Header Support & Auth Types

### DIFF
--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -107,12 +107,12 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 
 	case "api-call":
 		var params struct {
-			AppID     string
-			Path      string
-			Method    string
-			Payload   []byte
-			AuthToken string
-			Headers   map[string]interface{} `json:"headers,omitempty"`
+			AppID       string
+			Path        string
+			Method      string
+			Payload     []byte
+			AuthPayload []byte `json:"auth_payload,omitempty"`
+			AuthToken   string `json:"auth_token,omitempty"`
 		}
 
 		if err := unmarshal(&params); err != nil {
@@ -131,11 +131,6 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		if err != nil {
 			log.Err(err).Msg("dash: api call failed")
 			return reply(ctx, nil, err)
-		}
-		if len(params.Headers) > 0 {
-			for k, v := range params.Headers {
-				req.Header.Set(k, fmt.Sprintf("%v", v))
-			}
 		}
 		if tok := params.AuthToken; tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -112,6 +112,7 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 			Method    string
 			Payload   []byte
 			AuthToken string
+			Headers   map[string]interface{} `json:"headers,omitempty"`
 		}
 
 		if err := unmarshal(&params); err != nil {
@@ -130,6 +131,11 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		if err != nil {
 			log.Err(err).Msg("dash: api call failed")
 			return reply(ctx, nil, err)
+		}
+		if len(params.Headers) > 0 {
+			for k, v := range params.Headers {
+				req.Header.Set(k, fmt.Sprintf("%v", v))
+			}
 		}
 		if tok := params.AuthToken; tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -108,6 +108,8 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 	case "api-call":
 		var params struct {
 			AppID       string
+			Service     string
+			Endpoint    string
 			Path        string
 			Method      string
 			Payload     []byte

--- a/cli/daemon/dash/dashapp/package-lock.json
+++ b/cli/daemon/dash/dashapp/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/forms": "^0.2.1",
         "codemirror": "^5.65.1",
         "events": "^3.2.0",
+        "hjson": "^3.2.2",
         "json-rpc-protocol": "^0.13.1",
         "luxon": "^1.25.0",
         "react": "^17.0.0",
@@ -22,6 +23,7 @@
       "devDependencies": {
         "@types/codemirror": "^5.60.5",
         "@types/events": "^3.0.0",
+        "@types/hjson": "^2.4.3",
         "@types/luxon": "^1.25.1",
         "@types/node": "^14.14.25",
         "@types/react": "^17.0.0",
@@ -573,6 +575,12 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
       "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
+      "dev": true
+    },
+    "node_modules/@types/hjson": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/hjson/-/hjson-2.4.3.tgz",
+      "integrity": "sha512-EDixutNn3FQwa5HdET+Tx0h7TirP2knJa9TB21ySqr8XVqT/VsvvOwnanTLHUOOpNofcUhkRKhOk0Wh4YD9RSA==",
       "dev": true
     },
     "node_modules/@types/long": {
@@ -1679,6 +1687,14 @@
         "value-equal": "^1.0.1"
       }
     },
+    "node_modules/hjson": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/hjson/-/hjson-3.2.2.tgz",
+      "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q==",
+      "bin": {
+        "hjson": "bin/hjson"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -1964,9 +1980,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/modern-normalize": {
       "version": "1.1.0",
@@ -3311,6 +3327,12 @@
       "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
       "dev": true
     },
+    "@types/hjson": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@types/hjson/-/hjson-2.4.3.tgz",
+      "integrity": "sha512-EDixutNn3FQwa5HdET+Tx0h7TirP2knJa9TB21ySqr8XVqT/VsvvOwnanTLHUOOpNofcUhkRKhOk0Wh4YD9RSA==",
+      "dev": true
+    },
     "@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -4047,6 +4069,11 @@
         "value-equal": "^1.0.1"
       }
     },
+    "hjson": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/hjson/-/hjson-3.2.2.tgz",
+      "integrity": "sha512-MkUeB0cTIlppeSsndgESkfFD21T2nXPRaBStLtf3cAYA2bVEFdXlodZB0TukwZiobPD1Ksax5DK4RTZeaXCI3Q=="
+    },
     "hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -4270,9 +4297,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "modern-normalize": {
       "version": "1.1.0",

--- a/cli/daemon/dash/dashapp/package.json
+++ b/cli/daemon/dash/dashapp/package.json
@@ -11,6 +11,7 @@
     "@tailwindcss/forms": "^0.2.1",
     "codemirror": "^5.65.1",
     "events": "^3.2.0",
+    "hjson": "^3.2.2",
     "json-rpc-protocol": "^0.13.1",
     "luxon": "^1.25.0",
     "react": "^17.0.0",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@types/codemirror": "^5.60.5",
     "@types/events": "^3.0.0",
+    "@types/hjson": "^2.4.3",
     "@types/luxon": "^1.25.1",
     "@types/node": "^14.14.25",
     "@types/react": "^17.0.0",

--- a/cli/daemon/dash/dashapp/src/components/Nav.tsx
+++ b/cli/daemon/dash/dashapp/src/components/Nav.tsx
@@ -10,7 +10,7 @@ const menuItems: {href: string; name: string, external?: boolean}[] = [
   {href: "https://encore.dev/docs", name: "Encore Docs", external: true},
 ]
 
-const Nav: FunctionComponent = (props) => {
+const Nav: FunctionComponent = () => {
   const { appID } = useParams<{appID: string}>()
   const [menuOpen, setMenuOpen] = useState(false)
   const [appsOpen, setAppsOpen] = useState(false)
@@ -49,7 +49,7 @@ const Nav: FunctionComponent = (props) => {
               {menuItems.filter((it) => it.external).map(it => {
                   return <a key={it.href} href={it.href} target="_blank" className="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:text-white focus:outline-none focus:text-white focus:bg-gray-700 inline-block">
                     {it.name}&nbsp;<svg className="w-4 h-4 pb-0.5 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
                   </svg>
                   </a>
               })}
@@ -79,7 +79,7 @@ const Nav: FunctionComponent = (props) => {
             if (it.external) {
               return <a key={it.href} href={it.href} target="_blank" className="block px-2 py-2 rounded-md text-base font-medium text-gray-300 hover:text-white focus:outline-none focus:text-white focus:bg-gray-700">
                 {it.name}&nbsp;<svg className="w-4 h-4 pb-0.5 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
               </svg>
               </a>
             } else {
@@ -144,7 +144,7 @@ const AppDropdown: FunctionComponent<AppDropdownProps> = (props): JSX.Element =>
                     {apps.map(app =>
                       <Link key={app.id} to={"/"+app.id}
                         className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900" role="menuitem"
-                            onClick={(e) => props.setOpen(false)}>
+                            onClick={() => props.setOpen(false)}>
                           <div className="truncate leading-4">{app.name}</div>
                       </Link>
                     )}

--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -332,6 +332,11 @@ const RPCCaller: FC<Props> = ({md, svc, rpc, conn, appID, addr}) => {
                 <div className={`${rpc.request_schema ? "block" : " hidden"}`}>
                     <CM ref={payloadCM} cfg={cfg}/>
                 </div>
+                {md.auth_handler && md.auth_handler.params?.named !== undefined &&
+                    <div className="">
+                        <CM ref={authCM} cfg={cfg}/>
+                    </div>
+                }
             </div>
             <div className={`text-xs mt-1 ${rpc.request_schema ? "hidden" : "block"}`}>
                 This API takes no request data.
@@ -341,11 +346,6 @@ const RPCCaller: FC<Props> = ({md, svc, rpc, conn, appID, addr}) => {
                     <div className="flex-1 min-w-0 mr-1 relative rounded-md shadow-sm">
                         <Input id="" cls="w-full" placeholder="Auth Token" required={rpc.access_type === "AUTH"}
                                value={authToken} onChange={setAuthToken}/>
-                    </div>
-                }
-                {md.auth_handler && md.auth_handler.params?.named !== undefined &&
-                    <div className="text-xs flex-1 min-w-0 mr-1 relative rounded-md shadow-sm">
-                        <CM ref={authCM} cfg={cfg}/>
                     </div>
                 }
                 <APICallButton send={makeRequest} copyCurl={copyCurl}/>

--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -111,7 +111,7 @@ const RPCCaller: FC<Props> = ({md, svc, rpc, conn, appID, addr}) => {
         let path = pathRef.current?.getPath() ?? `/${svc.name}.${rpc.name}`
         let reqBody = ""
         let headers: Record<string, string> = {}
-        
+
         if (rpc.request_schema) {
             const doc = docs.current.get(rpc)
             const headerDoc = headerDocs.current.get(rpc)
@@ -184,6 +184,7 @@ const RPCCaller: FC<Props> = ({md, svc, rpc, conn, appID, addr}) => {
             const render = new JSONDialect(md)
             render.method = method
             render.asResponse = false
+            render.typeArgumentStack.push(rpc.request_schema!.named!.type_arguments)
             const [queryString, headers, js] = render.structBits(md.decls[rpc.request_schema!.named!.id].type.struct!)
 
             setQueryString(queryString)
@@ -203,6 +204,7 @@ const RPCCaller: FC<Props> = ({md, svc, rpc, conn, appID, addr}) => {
             })
             headerDocs.current.set(rpc, headerDoc)
             headersCM.current?.open(headerDoc)
+            headersCM.current.forceUpdate()
         }
 
         setResponse(undefined)

--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -12,523 +12,583 @@ import {Type} from "./schema";
 import {JSONDialect} from "~c/api/SchemaView";
 
 interface Props {
-  conn: JSONRPCConn;
-  appID: string;
-  md: APIMeta;
-  svc: Service;
-  rpc: RPC;
-  addr?: string;
+    conn: JSONRPCConn;
+    appID: string;
+    md: APIMeta;
+    svc: Service;
+    rpc: RPC;
+    addr?: string;
 }
 
 export const cfg: EditorConfiguration = {
-  theme: "encore",
-  mode: "json",
-  lineNumbers: false,
-  lineWrapping: false,
-  indentWithTabs: true,
-  indentUnit: 4,
-  tabSize: 4,
-  autoCloseBrackets: true,
-  matchBrackets: true,
-  styleActiveLine: false,
+    theme:             "encore",
+    mode:              "json",
+    lineNumbers:       false,
+    lineWrapping:      false,
+    indentWithTabs:    true,
+    indentUnit:        4,
+    tabSize:           4,
+    autoCloseBrackets: true,
+    matchBrackets:     true,
+    styleActiveLine:   false,
 }
 
-const APICallButton: FC<{send: () => void; copyCurl: () => void;}> = (props) => {
-  return (
-    <span className="ml-auto flex-none relative z-0 inline-flex shadow-sm rounded-md">
-      <button type="button" className="relative inline-flex items-center px-4 py-2 rounded-l-md border border-purple-700 bg-purple-600 text-sm font-medium text-white hover:bg-purple-500 focus:z-10 focus:outline-none focus:ring-0 focus:border-purple-500"
-        onClick={() => props.send()}>
+const APICallButton: FC<{ send: () => void; copyCurl: () => void; }> = (props) => {
+    return (
+        <span className="ml-auto flex-none relative z-0 inline-flex shadow-sm rounded-md">
+      <button type="button"
+              className="relative inline-flex items-center px-4 py-2 rounded-l-md border border-purple-700 bg-purple-600 text-sm font-medium text-white hover:bg-purple-500 focus:z-10 focus:outline-none focus:ring-0 focus:border-purple-500"
+              onClick={() => props.send()}>
         Call API
       </button>
       <span className="-ml-px relative block z-10">
         <Menu>
-          {({ open }) => (
-            <>
-              <Menu.Button className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-purple-700 bg-purple-600 text-sm font-medium text-white hover:bg-purple-500 focus:z-10 focus:outline-none focus:ring-0">
-                <span className="sr-only">Open options</span>
-                {icons.chevronDown("h-5 w-5")}
-              </Menu.Button>
+          {({open}) => (
+              <>
+                  <Menu.Button
+                      className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-purple-700 bg-purple-600 text-sm font-medium text-white hover:bg-purple-500 focus:z-10 focus:outline-none focus:ring-0">
+                      <span className="sr-only">Open options</span>
+                      {icons.chevronDown("h-5 w-5")}
+                  </Menu.Button>
 
-              <Transition
-                show={open}
-                enter="transition ease-out duration-100"
-                enterFrom="transform opacity-0 scale-95"
-                enterTo="transform opacity-100 scale-100"
-                leave="transition ease-in duration-75"
-                leaveFrom="transform opacity-100 scale-100"
-                leaveTo="transform opacity-0 scale-95"
-              >
-                <Menu.Items
-                  static
-                  className="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
-                >
-                  <div className="py-1">
-                    <Menu.Item>
-                      {({ active }) => (
-                        <button
-                          className={`${
-                            active
-                              ? "bg-gray-100 text-gray-900"
-                              : "text-gray-700"
-                          } flex justify-between w-full px-4 py-2 text-sm leading-5 text-left`}
-                          onClick={() => props.copyCurl()}
-                        >
-                          Copy as curl
-                        </button>
-                      )}
-                    </Menu.Item>
-                  </div>
-                </Menu.Items>
-              </Transition>
-            </>
+                  <Transition
+                      show={open}
+                      enter="transition ease-out duration-100"
+                      enterFrom="transform opacity-0 scale-95"
+                      enterTo="transform opacity-100 scale-100"
+                      leave="transition ease-in duration-75"
+                      leaveFrom="transform opacity-100 scale-100"
+                      leaveTo="transform opacity-0 scale-95"
+                  >
+                      <Menu.Items
+                          static
+                          className="absolute right-0 w-56 mt-2 origin-top-right bg-white border border-gray-200 divide-y divide-gray-100 rounded-md shadow-lg outline-none"
+                      >
+                          <div className="py-1">
+                              <Menu.Item>
+                                  {({active}) => (
+                                      <button
+                                          className={`${
+                                              active
+                                                  ? "bg-gray-100 text-gray-900"
+                                                  : "text-gray-700"
+                                          } flex justify-between w-full px-4 py-2 text-sm leading-5 text-left`}
+                                          onClick={() => props.copyCurl()}
+                                      >
+                                          Copy as curl
+                                      </button>
+                                  )}
+                              </Menu.Item>
+                          </div>
+                      </Menu.Items>
+                  </Transition>
+              </>
           )}
         </Menu>
       </span>
     </span>
-  )
+    )
 }
 
 const RPCCaller: FC<Props> = ({md, svc, rpc, conn, appID, addr}) => {
-  const payloadCM = useRef<CM>(null)
-  const pathRef = useRef<{getPath: () => string | undefined; getMethod: () => string}>(null)
-  const docs = useRef(new Map<RPC, CodeMirror.Doc>())
-  const [authToken, setAuthToken] = useState("")
-  const hasPathParams = rpc.path.segments.findIndex(s => s.type !== "LITERAL") !== -1
+    const headersCM = useRef<CM>(null)
+    const [hasHeaders, setHasHeaders] = useState(false)
+    const payloadCM = useRef<CM>(null)
+    const [hasPayload, setHasPayload] = useState(false)
+    const [queryString, setQueryString] = useState("")
+    const pathRef = useRef<{ getPath: () => string | undefined; getMethod: () => string }>(null)
+    const docs = useRef(new Map<RPC, CodeMirror.Doc>())
+    const headerDocs = useRef(new Map<RPC, CodeMirror.Doc>())
+    const [authToken, setAuthToken] = useState("")
+    const hasPathParams = rpc.path.segments.findIndex(s => s.type !== "LITERAL") !== -1
 
-  const [loading, setLoading] = useState(false)
-  const [respErr, setRespErr] = useState<string | undefined>(undefined)
-  const [response, setResponse] = useState<string | undefined>(undefined)
-  const [method, setMethod] = useState<string>(rpc.http_methods[0])
+    const [loading, setLoading] = useState(false)
+    const [respErr, setRespErr] = useState<string | undefined>(undefined)
+    const [response, setResponse] = useState<string | undefined>(undefined)
+    const [method, setMethod] = useState<string>(rpc.http_methods[0])
 
-  const serializeRequest = () => {
-    let path = pathRef.current?.getPath() ?? `/${svc.name}.${rpc.name}`
-    let reqBody = ""
-    if (rpc.request_schema) {
-      const doc = docs.current.get(rpc)
-      if (doc === undefined) {
-        return ["", ""]
-      }
-      const payload = doc.getValue()
-      if (method === "GET" || method === "HEAD" || method === "DELETE") {
-        if (payload !== "") {
-          try {
-            path += "?" + encodeQuery(md, rpc.request_schema, payload)
-          } catch(err) {
+    const serializeRequest = (): [string, string, Record<string, string>] => {
+        let path = pathRef.current?.getPath() ?? `/${svc.name}.${rpc.name}`
+        let reqBody = ""
+        let headers: Record<string, string> = {}
+        
+        if (rpc.request_schema) {
+            const doc = docs.current.get(rpc)
+            const headerDoc = headerDocs.current.get(rpc)
+            if (doc === undefined || headerDoc == undefined) {
+                return ["", "", {}]
+            }
+
+            const payload = doc.getValue()
+            const headersTxt = headerDoc.getValue()
+
+            if (headersTxt != "") {
+                try {
+                    headers = JSON.parse(headersTxt)
+                } catch (err) {
+                    setResponse(undefined)
+                    setRespErr(`could not parse headers as JSON: ${err}`)
+                    return ["", "", {}]
+                }
+            }
+
+            reqBody = payload
+        }
+        return [path, reqBody, headers]
+    }
+
+    const makeRequest = async () => {
+        const [path, reqBody, headers] = serializeRequest()
+        if (path === "") {
+            return
+        }
+        try {
+            setLoading(true)
             setResponse(undefined)
-            setRespErr(`could not parse payload as JSON: ${err}`)
-            return ["", ""]
-          }
+            setRespErr(undefined)
+            const resp = await conn.request("api-call", {
+                appID,
+                method,
+                path,
+                authToken,
+                headers,
+                payload: encodeBase64(reqBody)
+            }) as any
+            let respBody = ""
+            if (resp.body.length > 0) {
+                respBody = decodeBase64(resp.body)
+            }
+
+            if (resp.status_code !== 200) {
+                setRespErr(`HTTP ${resp.status}: ${respBody}`)
+            } else if (rpc.response_schema) {
+                setResponse(respBody)
+            } else {
+                setResponse("Request completed successfully.")
+            }
+        } catch (err) {
+            setRespErr(`Internal Error: ${err}`)
+        } finally {
+            setLoading(false)
         }
-      } else {
-        reqBody = payload
-      }
-    }
-    return [path, reqBody]
-  }
-
-  const makeRequest = async () => {
-    const [path, reqBody] = serializeRequest()
-    if (path === "") {
-      return
-    }
-    try {
-      setLoading(true)
-      setResponse(undefined)
-      setRespErr(undefined)
-      const resp = await conn.request("api-call", {appID, method, path, authToken, payload: encodeBase64(reqBody)}) as any
-      let respBody = ""
-      if (resp.body.length > 0) {
-        respBody = decodeBase64(resp.body)
-      }
-
-      if (resp.status_code !== 200) {
-        setRespErr(`HTTP ${resp.status}: ${respBody}`)
-      } else if (rpc.response_schema) {
-        setResponse(respBody)
-      } else {
-        setResponse("Request completed successfully.")
-      }
-    } catch(err) {
-      setRespErr(`Internal Error: ${err}`)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (rpc.request_schema) {
-      let doc = docs.current.get(rpc)
-      if (doc === undefined) {
-        const js = new JSONDialect(md).renderAsText(rpc.request_schema!)
-        doc = new CodeMirror.Doc(js, {
-          name: "javascript",
-          json: true
-        })
-        docs.current.set(rpc, doc)
-      }
-      payloadCM.current?.open(doc)
     }
 
-    setResponse(undefined)
-    setRespErr(undefined)
-  }, [rpc])
+    useEffect(() => {
+        if (method !== rpc.http_methods[0]) {
+            setMethod(rpc.http_methods[0])
+        }
+    }, [rpc])
 
-  const copyCurl = () => {
-    let [path, reqBody] = serializeRequest()
-    if (path === "") {
-      return
-    }
-    if (reqBody !== "") {
-      // Convert to JSON and back, if possible, to simplify indentation
-      try {
-        reqBody = JSON.stringify(JSON.parse(reqBody), undefined, " ")
-      } catch(err) { /* do nothing */ }
-      reqBody = reqBody.replaceAll("'", "'\''") // escape single quotes
+    useEffect(() => {
+        if (rpc.request_schema) {
+            const render = new JSONDialect(md)
+            render.method = method
+            render.asResponse = false
+            const [queryString, headers, js] = render.structBits(md.decls[rpc.request_schema!.named!.id].type.struct!)
+
+            setQueryString(queryString)
+
+            setHasPayload(!!js)
+            let doc = new CodeMirror.Doc(js, {
+                name: "javascript",
+                json: true
+            })
+            docs.current.set(rpc, doc)
+            payloadCM.current?.open(doc)
+
+            setHasHeaders(!!headers)
+            let headerDoc = new CodeMirror.Doc(headers, {
+                name: "javascript",
+                json: true
+            })
+            headerDocs.current.set(rpc, headerDoc)
+            headersCM.current?.open(headerDoc)
+        }
+
+        setResponse(undefined)
+        setRespErr(undefined)
+    }, [rpc, method])
+
+    const copyCurl = () => {
+        let [path, reqBody, headers] = serializeRequest()
+        if (path === "") {
+            return
+        }
+        if (reqBody !== "") {
+            // Convert to JSON and back, if possible, to simplify indentation
+            try {
+                reqBody = JSON.stringify(JSON.parse(reqBody), undefined, " ")
+            } catch (err) { /* do nothing */
+            }
+            reqBody = reqBody.replaceAll("'", "'\''") // escape single quotes
+        }
+
+        const defaultMethod = (reqBody !== "" ? "POST" : "GET")
+        let cmd = "curl "
+        if (method !== defaultMethod) {
+            cmd += `-X ${method} `
+        }
+        cmd += `'http://${addr ?? "localhost:4000"}${path}'`
+
+        for (const header in headers) {
+            cmd += ` -H "${header}: ${headers[header]}"`
+        }
+
+        if (reqBody !== "") {
+            cmd += ` -d '${reqBody}'`
+        }
+        copyToClipboard(cmd)
     }
 
-    const defaultMethod = (reqBody !== "" ? "POST" : "GET")
-    let cmd = "curl "
-    if (method !== defaultMethod) {
-      cmd += `-X ${method} `
-    }
-    cmd += `'http://${addr ?? "localhost:4000"}${path}'`
-    if (reqBody !== "") {
-      cmd += ` -d '${reqBody}'`
-    }
-    copyToClipboard(cmd)
-  }
-
-  return (
-    <div>
-      <h4 className="text-base text-bold">
-        Request
-      </h4>
-      <div className={`text-xs mt-1 rounded border border-gray-200 ${rpc.request_schema || hasPathParams ? "block" : "hidden"} p-1 divide-y divide-gray-500`} style={{backgroundColor: "#2d3748"}}>
+    return (
         <div>
-          <RPCPathEditor ref={pathRef} rpc={rpc} method={method} setMethod={setMethod} />
-         </div>
-        <div className={`${rpc.request_schema ? "block" : " hidden"}`}>
-          <CM ref={payloadCM} cfg={cfg} />
-         </div>
-      </div>
-      <div className={`text-xs mt-1 ${rpc.request_schema ? "hidden" : "block"}`}>
-        This API takes no request data.
-      </div>
-      <div className="flex items-center mt-1">
-        {md.auth_handler &&
-          <div className="flex-1 min-w-0 mr-1 relative rounded-md shadow-sm">
-            <Input id="" cls="w-full" placeholder="Auth Token" required={rpc.access_type === "AUTH"}
-              value={authToken} onChange={setAuthToken} />
-          </div>
-        }
-        <APICallButton send={makeRequest} copyCurl={copyCurl} />
+            <h4 className="text-base text-bold">
+                Request
+            </h4>
+            <div
+                className={`text-xs mt-1 rounded border border-gray-200 ${rpc.request_schema || hasPathParams ? "block" : "hidden"} p-1 divide-y divide-gray-500`}
+                style={{backgroundColor: "#2d3748"}}>
+                <div>
+                    <RPCPathEditor ref={pathRef} rpc={rpc} method={method} setMethod={setMethod} queryString={queryString}/>
+                </div>
+                <div className={`${rpc.request_schema && hasHeaders ? "block" : " hidden"}`}>
+                    <div className="text-base text-bold text-white">HTTP Headers:</div>
+                    <CM ref={headersCM} cfg={cfg}/>
+                </div>
+                <div className={`${rpc.request_schema && hasPayload ? "block" : " hidden"}`}>
+                    <div className={"text-base text-bold text-white" + (!hasHeaders ? " hidden" : "")}>JSON Payload:</div>
+                    <CM ref={payloadCM} cfg={cfg}/>
+                </div>
+            </div>
+            <div className={`text-xs mt-1 ${rpc.request_schema ? "hidden" : "block"}`}>
+                This API takes no request data.
+            </div>
+            <div className="flex items-center mt-1">
+                {md.auth_handler &&
+                    <div className="flex-1 min-w-0 mr-1 relative rounded-md shadow-sm">
+                        <Input id="" cls="w-full" placeholder="Auth Token" required={rpc.access_type === "AUTH"}
+                               value={authToken} onChange={setAuthToken}/>
+                    </div>
+                }
+                <APICallButton send={makeRequest} copyCurl={copyCurl}/>
 
-      </div>
+            </div>
 
-      <h4 className="mt-4 mb-1 text-base text-bold flex items-center">
-        Response {loading && icons.loading("ml-1 h-5 w-5", "#A081D9", "transparent", 4)}
-      </h4>
-      {response ? (
-        <pre className="text-xs shadow-inner rounded border border-gray-300 bg-gray-200 p-2 overflow-x-auto response-docs">
+            <h4 className="mt-4 mb-1 text-base text-bold flex items-center">
+                Response {loading && icons.loading("ml-1 h-5 w-5", "#A081D9", "transparent", 4)}
+            </h4>
+            {response ? (
+                <pre
+                    className="text-xs shadow-inner rounded border border-gray-300 bg-gray-200 p-2 overflow-x-auto response-docs">
           <CM
               key={response}
               cfg={{
-                value: response,
-                readOnly: true,
-                theme: "encore",
-                mode: { name: "javascript", json: true },
+                  value:    response,
+                  readOnly: true,
+                  theme:    "encore",
+                  mode:     {name: "javascript", json: true},
               }}
               noShadow={true}
           />
         </pre>
-      ) : respErr ? (
-        <div className="text-xs text-red-600 font-mono">{respErr}</div>
-      ) : (
-        <div className="text-xs text-gray-400">Make a request to see the response.</div>
-      )}
-    </div>
-  )
+            ) : respErr ? (
+                <div className="text-xs text-red-600 font-mono">{respErr}</div>
+            ) : (
+                <div className="text-xs text-gray-400">Make a request to see the response.</div>
+            )}
+        </div>
+    )
 }
 
 export default RPCCaller
 
 export const pathEditorCfg: EditorConfiguration = {
-  theme: "encore",
-  mode: "json",
-  lineNumbers: false,
-  lineWrapping: false,
-  indentWithTabs: true,
-  indentUnit: 4,
-  tabSize: 4,
-  autoCloseBrackets: true,
-  matchBrackets: true,
-  styleActiveLine: false,
-  extraKeys: {
-    Tab: (cm: CodeMirror.Editor) => {
-      const doc = cm.getDoc()
-      const cur = doc.getCursor()
-      if (!cur) { return }
-      const markers = (doc.getAllMarks() as CodeMirror.TextMarker<CodeMirror.MarkerRange>[]).
-        filter(m => !m.readOnly).map(m => m.find()).filter(m => m !== undefined).sort((a, b) => { return a!.from.ch - b!.from.ch})
+    theme:             "encore",
+    mode:              "json",
+    lineNumbers:       false,
+    lineWrapping:      false,
+    indentWithTabs:    true,
+    indentUnit:        4,
+    tabSize:           4,
+    autoCloseBrackets: true,
+    matchBrackets:     true,
+    styleActiveLine:   false,
+    extraKeys:         {
+        Tab:         (cm: CodeMirror.Editor) => {
+            const doc = cm.getDoc()
+            const cur = doc.getCursor()
+            if (!cur) {
+                return
+            }
+            const markers = (doc.getAllMarks() as CodeMirror.TextMarker<CodeMirror.MarkerRange>[]).filter(m => !m.readOnly).map(m => m.find()).filter(m => m !== undefined).sort((a, b) => {
+                return a!.from.ch - b!.from.ch
+            })
 
-      for (let i = 0; i < markers.length; i++) {
-        const m = markers[i]
-        if (m!.from.ch <= cur.ch && m!.to.ch >= cur.ch) {
-          if ((i+1) < markers.length) {
-            const m2 = markers[i+1]
-            doc.setSelection(m2!.from, m2!.to)
-          } else if (i > 0) {
-            const m2 = markers[0]
-            doc.setSelection(m2!.from, m2!.to)
-          }
-          return
-        }
-      }
-    },
-    "Shift-Tab": (cm: CodeMirror.Editor) => {
-      const doc = cm.getDoc()
-      const cur = doc.getCursor()
-      if (!cur) { return }
-      const markers = (doc.getAllMarks() as CodeMirror.TextMarker<CodeMirror.MarkerRange>[]).
-        filter(m => !m.readOnly).map(m => m.find()).filter(m => m !== undefined).sort((a, b) => { return a!.from.ch - b!.from.ch})
+            for (let i = 0; i < markers.length; i++) {
+                const m = markers[i]
+                if (m!.from.ch <= cur.ch && m!.to.ch >= cur.ch) {
+                    if ((i + 1) < markers.length) {
+                        const m2 = markers[i + 1]
+                        doc.setSelection(m2!.from, m2!.to)
+                    } else if (i > 0) {
+                        const m2 = markers[0]
+                        doc.setSelection(m2!.from, m2!.to)
+                    }
+                    return
+                }
+            }
+        },
+        "Shift-Tab": (cm: CodeMirror.Editor) => {
+            const doc = cm.getDoc()
+            const cur = doc.getCursor()
+            if (!cur) {
+                return
+            }
+            const markers = (doc.getAllMarks() as CodeMirror.TextMarker<CodeMirror.MarkerRange>[]).filter(m => !m.readOnly).map(m => m.find()).filter(m => m !== undefined).sort((a, b) => {
+                return a!.from.ch - b!.from.ch
+            })
 
-      for (let i = 0; i < markers.length; i++) {
-        const m = markers[i]
-        if (m!.from.ch <= cur.ch && m!.to.ch >= cur.ch) {
-          if ((i-1) >= 0) {
-            const m2 = markers[i-1]
-            doc.setSelection(m2!.from, m2!.to)
-          } else if (markers.length > 1) {
-            const m2 = markers[markers.length-1]
-            doc.setSelection(m2!.from, m2!.to)
-          }
-          return
+            for (let i = 0; i < markers.length; i++) {
+                const m = markers[i]
+                if (m!.from.ch <= cur.ch && m!.to.ch >= cur.ch) {
+                    if ((i - 1) >= 0) {
+                        const m2 = markers[i - 1]
+                        doc.setSelection(m2!.from, m2!.to)
+                    } else if (markers.length > 1) {
+                        const m2 = markers[markers.length - 1]
+                        doc.setSelection(m2!.from, m2!.to)
+                    }
+                    return
+                }
+            }
         }
-      }
     }
-  }
 }
 
 function classNames(...classes: string[]) {
-  return classes.filter(Boolean).join(' ')
+    return classes.filter(Boolean).join(' ')
 }
 
-const RPCPathEditor = React.forwardRef<{getPath: () => string | undefined}, {
-  rpc: RPC; method: string; setMethod: (m: string) => void;
-}>(({rpc, method, setMethod}, ref) => {
-  interface DocState {
-    rpc: RPC;
-    doc: CodeMirror.Doc;
-    markers: CodeMirror.TextMarker<CodeMirror.MarkerRange>[];
-  }
-  const pathCM = useRef<CM>(null)
-  const docs = useRef(new Map<RPC, DocState>())
-  const docMap = useRef(new Map<CodeMirror.Doc, DocState>())
-  const timeoutHandle = useRef<{id: number | null}>({id: null})
-
-  // Reset the method when the RPC changes
-  useEffect(() => {
-    setMethod(rpc.http_methods[0])
-  }, [rpc])
-
-  useEffect(() => {
-    const segments: string[] = []
-
-    type rwSegment = {from: number; to: number; placeholder: string; seg: PathSegment};
-    const readWrites: rwSegment[] = []
-    let pos = 0
-    for (const s of rpc.path.segments) {
-      segments.push("/")
-      pos += 1
-
-      const placeholder = (s.type === "PARAM" ? ":" : s.type === "WILDCARD" ? "*" : "") + s.value
-      const ln = placeholder.length
-      segments.push(placeholder)
-      if (s.type !== "LITERAL") {
-        readWrites.push({placeholder, seg: s, from: pos, to: pos+ln})
-      }
-      pos += ln
+const RPCPathEditor = React.forwardRef<{ getPath: () => string | undefined }, {
+    rpc: RPC; method: string; queryString: string; setMethod: (m: string) => void;
+}>(({rpc, method, setMethod, queryString}, ref) => {
+    interface DocState {
+        rpc: RPC;
+        doc: CodeMirror.Doc;
+        markers: CodeMirror.TextMarker<CodeMirror.MarkerRange>[];
     }
 
-    const val = segments.join("")
-    const doc = new CodeMirror.Doc(val, )
+    const pathCM = useRef<CM>(null)
+    const docs = useRef(new Map<RPC, DocState>())
+    const docMap = useRef(new Map<CodeMirror.Doc, DocState>())
+    const timeoutHandle = useRef<{ id: number | null }>({id: null})
 
-    let prevEnd = 0
-    let i = 0
-    const markers: CodeMirror.TextMarker<CodeMirror.MarkerRange>[] = []
-    for (const rw of readWrites) {
-      doc.markText({ch: prevEnd, line: 0}, {ch: rw.from, line: 0}, {
-        atomic: true,
-        readOnly: true,
-        clearWhenEmpty: false,
-        clearOnEnter: false,
-        className: "text-gray-400",
-        selectLeft: i>0,
-        selectRight: true,
-      })
-      const m = doc.markText({ch: rw.from, line: 0}, {ch: rw.to, line: 0}, {
-        className: "text-green-400",
-        clearWhenEmpty: false,
-        clearOnEnter: false,
-        inclusiveLeft: true,
-        inclusiveRight: true,
-        attributes: {placeholder: rw.placeholder, segmentType: rw.seg.type},
-      })
-      markers.push(m)
-      m.on("beforeCursorEnter", () => {
-        const r = m.find()
-        const sel = doc.getSelection()
-        if (r) {
-          const text = doc.getRange(r.from, r.to)
-          if (text === m.attributes?.placeholder && sel !== text) {
-            if (timeoutHandle.current.id) {
-              clearTimeout(timeoutHandle.current.id)
+    // Reset the method when the RPC changes
+    useEffect(() => {
+        setMethod(rpc.http_methods[0])
+    }, [rpc])
+
+    useEffect(() => {
+        const segments: string[] = []
+
+        type rwSegment = { from: number; to: number; placeholder: string; seg: PathSegment };
+        const readWrites: rwSegment[] = []
+        let pos = 0
+        for (const s of rpc.path.segments) {
+            segments.push("/")
+            pos += 1
+
+            const placeholder = (s.type === "PARAM" ? ":" : s.type === "WILDCARD" ? "*" : "") + s.value
+            const ln = placeholder.length
+            segments.push(placeholder)
+            if (s.type !== "LITERAL") {
+                readWrites.push({placeholder, seg: s, from: pos, to: pos + ln})
             }
-            timeoutHandle.current.id = setTimeout(() => { doc.setSelection(r.from, r.to) }, 50)
-          }
+            pos += ln
         }
-      })
-      prevEnd = rw.to
-      i++
-    }
 
-    doc.markText({ch: prevEnd, line: 0}, {ch: val.length, line: 0}, {
-      atomic: true,
-      readOnly: true,
-      clearWhenEmpty: false,
-      clearOnEnter: false,
-      className: "text-gray-400",
-      selectLeft: prevEnd > 0,
-      selectRight: false,
+        const val = segments.join("")
+        const doc = new CodeMirror.Doc(val + queryString,)
+
+        let prevEnd = 0
+        let i = 0
+        const markers: CodeMirror.TextMarker<CodeMirror.MarkerRange>[] = []
+        for (const rw of readWrites) {
+            doc.markText({ch: prevEnd, line: 0}, {ch: rw.from, line: 0}, {
+                atomic:         true,
+                readOnly:       true,
+                clearWhenEmpty: false,
+                clearOnEnter:   false,
+                className:      "text-gray-400",
+                selectLeft:     i > 0,
+                selectRight:    true,
+            })
+            const m = doc.markText({ch: rw.from, line: 0}, {ch: rw.to, line: 0}, {
+                className:      "text-green-400",
+                clearWhenEmpty: false,
+                clearOnEnter:   false,
+                inclusiveLeft:  true,
+                inclusiveRight: true,
+                attributes:     {placeholder: rw.placeholder, segmentType: rw.seg.type},
+            })
+            markers.push(m)
+            m.on("beforeCursorEnter", () => {
+                const r = m.find()
+                const sel = doc.getSelection()
+                if (r) {
+                    const text = doc.getRange(r.from, r.to)
+                    if (text === m.attributes?.placeholder && sel !== text) {
+                        if (timeoutHandle.current.id) {
+                            clearTimeout(timeoutHandle.current.id)
+                        }
+                        timeoutHandle.current.id = setTimeout(() => {
+                            doc.setSelection(r.from, r.to)
+                        }, 50)
+                    }
+                }
+            })
+            prevEnd = rw.to
+            i++
+        }
+
+        doc.markText({ch: prevEnd, line: 0}, {ch: val.length, line: 0}, {
+            atomic:         true,
+            readOnly:       true,
+            clearWhenEmpty: false,
+            clearOnEnter:   false,
+            className:      "text-gray-400",
+            selectLeft:     prevEnd > 0,
+            selectRight:    false,
+        })
+
+        CodeMirror.on(doc, "beforeChange", (doc: CodeMirror.Doc, change: CodeMirror.EditorChangeCancellable) => {
+            if (change.text[0].indexOf("/") === -1) {
+                return
+            }
+
+            for (const m of markers) {
+                const r = m.find()
+                if (r && change.from.ch >= r.from.ch && change.from.ch <= r.to.ch) {
+                    const typ = m.attributes?.segmentType
+                    if (typ === "PARAM") {
+                        change.cancel()
+                    }
+                    return
+                }
+            }
+        })
+
+        const ds = {rpc, doc, markers: markers}
+        docs.current.set(rpc, ds)
+        docMap.current.set(doc, ds)
+        pathCM.current?.open(ds!.doc)
+    }, [rpc, method, queryString])
+
+    useImperativeHandle(ref, () => {
+        // noinspection JSUnusedGlobalSymbols
+        return {
+            getPath:   () => pathCM.current?.cm?.getValue(),
+            getMethod: () => method,
+        }
     })
 
-    CodeMirror.on(doc, "beforeChange", (doc: CodeMirror.Doc, change: CodeMirror.EditorChangeCancellable) => {
-      if (change.text[0].indexOf("/") === -1) {
-        return
-      }
-
-      for (const m of markers) {
-        const r = m.find()
-        if (r && change.from.ch >= r.from.ch && change.from.ch <= r.to.ch) {
-          const typ = m.attributes?.segmentType
-          if (typ === "PARAM") {
-            change.cancel()
-          }
-          return
-        }
-      }
-    })
-
-    const ds = {rpc, doc, markers: markers}
-    docs.current.set(rpc, ds)
-    docMap.current.set(doc, ds)
-    pathCM.current?.open(ds!.doc)
-  }, [rpc, method])
-
-  useImperativeHandle(ref, () => {
-    // noinspection JSUnusedGlobalSymbols
-    return {
-      getPath: () => pathCM.current?.cm?.getValue(),
-      getMethod: () => method,
-    }
-  })
-
-  return <div className="flex items-center">
-    {rpc.http_methods.length > 1 ? (
-      <Listbox value={method} onChange={setMethod}>
-        {({ open }) => (
-          <div className="relative">
-            <Listbox.Button className="relative block text-left cursor-default focus:outline-none pl-1 pr-5 py-0.5 text-green-800 bg-green-100 hover:bg-green-200 rounded-sm font-mono font-semibold text-xs">
-              <span className="block truncate">{method}</span>
-              <span className="absolute inset-y-0 right-0 flex items-center pointer-events-none">
+    return <div className="flex items-center">
+        {rpc.http_methods.length > 1 ? (
+            <Listbox value={method} onChange={setMethod}>
+                {({open}) => (
+                    <div className="relative">
+                        <Listbox.Button
+                            className="relative block text-left cursor-default focus:outline-none pl-1 pr-5 py-0.5 text-green-800 bg-green-100 hover:bg-green-200 rounded-sm font-mono font-semibold text-xs">
+                            <span className="block truncate">{method}</span>
+                            <span className="absolute inset-y-0 right-0 flex items-center pointer-events-none">
                 {icons.chevronDown("h-5 w-5 text-green-600")}
               </span>
-            </Listbox.Button>
-            <Transition
-                show={open}
-                leave="transition ease-in duration-100"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-              <Listbox.Options
-                static
-                className="absolute z-10 mt-1 w-32 bg-white shadow-lg max-h-60 rounded py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none text-xs"
-              >
-                {rpc.http_methods.map((m) => (
-                  <Listbox.Option
-                    key={m}
-                    className={({ active }) =>
-                      classNames(
-                        active ? 'text-white bg-green-600' : 'text-gray-900',
-                        'cursor-default select-none relative py-1 pl-3 pr-9'
-                      )
-                    }
-                    value={m}
-                  >
-                    {({ selected, active }) => (
-                      <>
+                        </Listbox.Button>
+                        <Transition
+                            show={open}
+                            leave="transition ease-in duration-100"
+                            leaveFrom="opacity-100"
+                            leaveTo="opacity-0"
+                        >
+                            <Listbox.Options
+                                static
+                                className="absolute z-10 mt-1 w-32 bg-white shadow-lg max-h-60 rounded py-1 ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none text-xs"
+                            >
+                                {rpc.http_methods.map((m) => (
+                                    <Listbox.Option
+                                        key={m}
+                                        className={({active}) =>
+                                            classNames(
+                                                active ? 'text-white bg-green-600' : 'text-gray-900',
+                                                'cursor-default select-none relative py-1 pl-3 pr-9'
+                                            )
+                                        }
+                                        value={m}
+                                    >
+                                        {({selected, active}) => (
+                                            <>
                         <span className={classNames(selected ? 'font-semibold' : 'font-normal', 'block truncate')}>
                           {m}
                         </span>
 
-                        {selected ? (
-                          <span
-                            className={classNames(
-                              active ? 'text-white' : 'text-green-600',
-                              'absolute inset-y-0 right-0 flex items-center pr-4'
-                            )}
-                          >
+                                                {selected ? (
+                                                    <span
+                                                        className={classNames(
+                                                            active ? 'text-white' : 'text-green-600',
+                                                            'absolute inset-y-0 right-0 flex items-center pr-4'
+                                                        )}
+                                                    >
                             {icons.check("h-5 w-5")}
                           </span>
-                        ) : null}
-                      </>
-                    )}
-                  </Listbox.Option>
-                ))}
-              </Listbox.Options>
-            </Transition>
-          </div>
-        )}
-      </Listbox>
-    ) : <div className="text-white font-mono text-xs px-1">{method}</div>}
-    <div className="flex-1">
-      <CM ref={pathCM} cfg={pathEditorCfg} className="overflow-visible" />
-     </div>
-  </div>
+                                                ) : null}
+                                            </>
+                                        )}
+                                    </Listbox.Option>
+                                ))}
+                            </Listbox.Options>
+                        </Transition>
+                    </div>
+                )}
+            </Listbox>
+        ) : <div className="text-white font-mono text-xs px-1">{method}</div>}
+        <div className="flex-1">
+            <CM ref={pathCM} cfg={pathEditorCfg} className="overflow-visible"/>
+        </div>
+    </div>
 })
 
 // encodeQuery encodes a payload matching the given schema as a query string.
 // If the payload can't be parsed as JSON it throws an exception.
 function encodeQuery(md: APIMeta, schema: Type, payload: string): string {
-  const json = JSON.parse(payload)
-  let pairs: string[] = []
+    const json = JSON.parse(payload)
+    let pairs: string[] = []
 
-  if (schema.named) {
-    const declID = schema.named.id
-    const decl = md.decls[declID]
+    if (schema.named) {
+        const declID = schema.named.id
+        const decl = md.decls[declID]
 
-    for (const f of decl.type.struct?.fields ?? []) {
-      let key = f.json_name
-      let qsName = f.query_string_name
-      if (key === "-" || qsName === "-") {
-        continue
-      } else if (key === "") {
-        key = f.name
-      }
+        for (const f of decl.type.struct?.fields ?? []) {
+            let key = f.json_name
+            let qsName = f.query_string_name
+            if (key === "-" || qsName === "-") {
+                continue
+            } else if (key === "") {
+                key = f.name
+            }
 
-      let val = json[key]
-      if (typeof val === "undefined") {
-        continue
-      } else if (!Array.isArray(val)) {
-        val = [val]
-      }
-      for (const v of val) {
-        pairs.push(`${qsName}=${encodeURIComponent(v)}`)
-      }
+            let val = json[key]
+            if (typeof val === "undefined") {
+                continue
+            } else if (!Array.isArray(val)) {
+                val = [val]
+            }
+            for (const v of val) {
+                pairs.push(`${qsName}=${encodeURIComponent(v)}`)
+            }
+        }
+    } else {
+        throw new Error('expected a named type to encode the query');
     }
-  } else {
-    throw new Error('expected a named type to encode the query');
-  }
 
-  return pairs.join("&")
+    return pairs.join("&")
 }

--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -9,7 +9,7 @@ import JSONRPCConn from "~lib/client/jsonrpc";
 import { copyToClipboard } from "~lib/clipboard";
 import { APIMeta, PathSegment, RPC, Service } from "./api";
 import CM from "./cm/CM";
-import { Builtin, FieldLocation, fieldNameAndLocation, NamedType } from "./schema";
+import { Builtin, FieldLocation, fieldNameAndLocation, NamedType, rpcHasBody } from "./schema";
 import { JSONDialect } from "~c/api/SchemaView";
 
 interface Props {
@@ -258,7 +258,8 @@ const RPCCaller: FC<Props> = ({ md, svc, rpc, conn, appID, addr }) => {
 
         reqBody = JSON.stringify(newBody)
 
-        const defaultMethod = (reqBody !== "" ? "POST" : "GET")
+        const hasBody = rpcHasBody(md, rpc, method)
+        const defaultMethod = (hasBody? "POST" : "GET")
         let cmd = "curl "
         if (method !== defaultMethod) {
             cmd += `-X ${method} `
@@ -266,10 +267,10 @@ const RPCCaller: FC<Props> = ({ md, svc, rpc, conn, appID, addr }) => {
         cmd += `'http://${addr ?? "localhost:4000"}${path}${queryString}'`
 
         for (const header in headers) {
-            cmd += ` -H "${header}: ${headers[header]}"`
+            cmd += ` -H '${header}: ${headers[header]}'`
         }
 
-        if (reqBody !== "") {
+        if (hasBody) {
             cmd += ` -d '${reqBody}'`
         }
         copyToClipboard(cmd)

--- a/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
@@ -169,7 +169,7 @@ class GoDialect extends TextBasedDialect {
         this.write(`*${decl.loc.pkg_name}.${decl.name}`)
     }
 
-    renderStruct(t: StructType) {
+    renderStruct(t: StructType, topLevel?: boolean) {
         this.writeln("struct {")
         this.level++
 
@@ -191,7 +191,7 @@ class GoDialect extends TextBasedDialect {
 
             return previous
         }, 0)
-        
+
         const longestSingleLineType = t.fields.reduce<number>((previous: number, current: Field) => {
             const type = typeAsString(current.typ)
             if (type.indexOf("\n") < 0 && type.length > previous) {
@@ -202,8 +202,12 @@ class GoDialect extends TextBasedDialect {
         }, 0)
 
         t.fields.map(f => {
-            const [_, location] = fieldNameAndLocation(f, this.method, this.asResponse)
-            if (location === FieldLocation.UnusedField) {
+            if (topLevel) {
+                const [_, location] = fieldNameAndLocation(f, this.method, this.asResponse)
+                if (location === FieldLocation.UnusedField) {
+                    return
+                }
+            } else if (f.json_name == "-") {
                 return
             }
 
@@ -506,6 +510,11 @@ export class JSONDialect extends TextBasedDialect {
         this.level++
         for (let i = 0; i < t.fields.length; i++) {
             const f = t.fields[i]
+
+            if (f.json_name == "-") {
+                continue
+            }
+
             this.indent()
             this.write(`"${f.json_name !== "" ? f.json_name : f.name}": `)
             this.writeType(f.typ)
@@ -759,7 +768,7 @@ class CurlDialect extends TextBasedDialect {
     }
 
     protected writeSeenDecl(): void {
-        
+
     }
 
 }

--- a/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
@@ -13,6 +13,7 @@ import {
     locationDescription,
     MapType,
     NamedType,
+    rpcHasBody,
     splitFieldsByLocation,
     StructType,
     Type,
@@ -757,7 +758,8 @@ class CurlDialect extends TextBasedDialect {
             space: "  ",
         })
 
-        const defaultMethod = (reqBody !== "" ? "POST" : "GET")
+        const hasBody = this.rpc ? rpcHasBody(this.meta, this.rpc, this.method) : false
+        const defaultMethod = (hasBody ? "POST" : "GET")
         let cmd = "curl "
         if (this.method !== defaultMethod) {
             cmd += `-X ${this.method} `
@@ -765,10 +767,10 @@ class CurlDialect extends TextBasedDialect {
         cmd += `'http://${addr ?? "localhost:4000"}/${path}${queryString}'`
 
         for (const header in headers) {
-            cmd += ` \\\n  -H "${header}: ${headers[header]}"`
+            cmd += ` \\\n  -H '${header}: ${headers[header]}'`
         }
 
-        if (reqBody !== "") {
+        if (hasBody) {
             reqBody = reqBody.split("\n").join("\n  ")
             cmd += ` \\\n  -d '${reqBody}'`
         }

--- a/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
@@ -1,477 +1,624 @@
-import {Builtin, Decl, Field, ListType, MapType, NamedType, StructType, Type, TypeParameterRef } from "./schema";
-import React from "react";
-import {APIMeta} from "./api";
-import CM from "~c/api/cm/CM";
 import {ModeSpec, ModeSpecOptions} from "codemirror"
+import React from "react"
+import CM from "~c/api/cm/CM"
+import {APIMeta} from "./api"
+import {
+    Builtin,
+    Decl,
+    Field,
+    FieldLocation,
+    fieldNameAndLocation,
+    ListType,
+    locationDescription,
+    MapType,
+    NamedType, splitFieldsByLocation,
+    StructType,
+    Type,
+    TypeParameterRef
+} from "./schema"
 
 export type Dialect = "go" | "typescript" | "json" | "table";
 
 interface Props {
-  meta: APIMeta;
-  type: Type;
-  dialect: Dialect;
+    meta: APIMeta;
+    type: Type;
+    dialect: Dialect;
+    method: string;
+    asResponse?: boolean;
 }
 
 export default class extends React.Component<Props> {
-  render() {
-    const d = dialects[this.props.dialect](this.props.meta)
-    return d.render(this.props.type)
-  }
+    render() {
+        const d = dialects[this.props.dialect](this.props.meta)
+        return d.render(this.props.type, this.props.method, this.props.asResponse ?? false)
+    }
 }
 
 abstract class DialectIface {
-  readonly meta: APIMeta;
+    readonly meta: APIMeta;
 
-  constructor(meta: APIMeta) {
-    this.meta = meta
-  }
+    constructor(meta: APIMeta) {
+        this.meta = meta
+    }
 
-  abstract render(d: Type): JSX.Element
+    abstract render(d: Type, method: string, asResponse: boolean): JSX.Element
 }
 
 /** This Text based class allows us simply to build a dialect from raw text and use CodeMirror to render it */
 abstract class TextBasedDialect extends DialectIface {
-  private readonly codeMirrorMode: string | ModeSpec<ModeSpecOptions>
-  seenDecls: Set<number>;
-  typeArgumentStack: Type[][];
-  buf: string[];
-  level: number;
+    private readonly codeMirrorMode: string | ModeSpec<ModeSpecOptions>
+    seenDecls: Set<number>;
+    typeArgumentStack: Type[][];
+    buf: string[];
+    level: number;
+    method: string;
+    asResponse: boolean;
 
-  protected constructor(meta: APIMeta, codeMirrorMode: string | ModeSpec<ModeSpecOptions>) {
-    super(meta)
-    this.codeMirrorMode = codeMirrorMode
-    this.seenDecls = new Set<number>()
-    this.typeArgumentStack = []
-    this.buf = []
-    this.level = 0
-  }
-
-  render(d: Type): JSX.Element {
-    const srcCode = this.renderAsText(d)
-
-    return <CM cfg={{
-      value: srcCode,
-      readOnly: true,
-      theme: "encore",
-      mode: this.codeMirrorMode,
-    }}
-               key={srcCode}
-               noShadow={true}
-    />
-  }
-
-  renderAsText(d: Type): string {
-    this.writeType(d)
-    return this.buf.join("")
-  }
-
-  protected writeType(t: Type) {
-    t.struct ? this.renderStruct(t.struct) :
-    t.map ? this.renderMap(t.map) :
-    t.list ? this.renderList(t.list) :
-    t.builtin ? this.renderBuiltin(t.builtin) :
-    t.named ? this.renderNamed(t.named) :
-    t.type_parameter ? this.renderTypeParameter(t.type_parameter) :
-    this.write("<unknown type>")
-  }
-
-  protected renderNamed(t: NamedType) {
-    if (this.seenDecls.has(t.id)) {
-      this.writeSeenDecl(this.meta.decls[t.id])
-      return
+    protected constructor(meta: APIMeta, codeMirrorMode: string | ModeSpec<ModeSpecOptions>) {
+        super(meta)
+        this.codeMirrorMode = codeMirrorMode
+        this.seenDecls = new Set<number>()
+        this.typeArgumentStack = []
+        this.buf = []
+        this.level = 0
+        this.method = 'POST'
+        this.asResponse = false
     }
 
-    // Add the decl to our map while recursing to avoid infinite recursion.
-    this.seenDecls.add(t.id)
-    const decl = this.meta.decls[t.id]
-    this.typeArgumentStack.push(t.type_arguments)
+    render(d: Type, method: string, asResponse: boolean): JSX.Element {
+        this.method = method
+        this.asResponse = asResponse
+        const srcCode = this.renderAsText(d)
 
-    this.writeType(decl.type)
-
-    this.typeArgumentStack.pop()
-    this.seenDecls.delete(t.id)
-  }
-
-  protected renderTypeParameter(t: TypeParameterRef) {
-    const typeArguments = this.typeArgumentStack[this.typeArgumentStack.length - 1]
-    this.writeType(typeArguments[t.param_idx])
-  }
-
-  protected abstract writeSeenDecl(decl: Decl): void
-  protected abstract renderStruct(t: StructType): void
-  protected abstract renderMap(t: MapType): void
-  protected abstract renderList(t: ListType): void
-  protected abstract renderBuiltin(t: Builtin): void
-
-  protected indent() {
-    this.write(" ".repeat(this.level*4))
-  }
-
-  protected write(...strs: string[]) {
-    for (const s of strs) {
-      this.buf.push(s)
+        return <CM cfg={{
+            value:    srcCode,
+            readOnly: true,
+            theme:    "encore",
+            mode:     this.codeMirrorMode,
+        }}
+                   key={srcCode}
+                   noShadow={true}
+        />
     }
-  }
 
-  protected writeln(...strs: string[]) {
-    this.write(...strs)
-    this.write("\n")
-  }
+    renderAsText(d: Type): string {
+        this.writeType(d, true)
+
+        return this.buf.join("")
+    }
+
+    protected writeType(t: Type, topLevel?: boolean, altValue?: boolean) {
+        t.struct ? this.renderStruct(t.struct, topLevel) :
+            t.map ? this.renderMap(t.map) :
+                t.list ? this.renderList(t.list) :
+                    t.builtin ? this.renderBuiltin(t.builtin, altValue) :
+                        t.named ? this.renderNamed(t.named, topLevel) :
+                            t.type_parameter ? this.renderTypeParameter(t.type_parameter) :
+                                this.write("<unknown type>")
+    }
+
+    protected renderNamed(t: NamedType, topLevel?: boolean) {
+        if (this.seenDecls.has(t.id)) {
+            this.writeSeenDecl(this.meta.decls[t.id])
+            return
+        }
+
+        // Add the decl to our map while recursing to avoid infinite recursion.
+        this.seenDecls.add(t.id)
+        const decl = this.meta.decls[t.id]
+        this.typeArgumentStack.push(t.type_arguments)
+
+        this.writeType(decl.type, topLevel)
+
+        this.typeArgumentStack.pop()
+        this.seenDecls.delete(t.id)
+    }
+
+    protected renderTypeParameter(t: TypeParameterRef) {
+        const typeArguments = this.typeArgumentStack[this.typeArgumentStack.length - 1]
+        this.writeType(typeArguments[t.param_idx])
+    }
+
+    protected abstract writeSeenDecl(decl: Decl): void
+
+    protected abstract renderStruct(t: StructType, topLevel?: boolean): void
+
+    protected abstract renderMap(t: MapType): void
+
+    protected abstract renderList(t: ListType): void
+
+    protected abstract renderBuiltin(t: Builtin, altValue?: boolean): void
+
+    protected indent() {
+        this.write(" ".repeat(this.level * 4))
+    }
+
+    protected write(...strs: string[]) {
+        for (const s of strs) {
+            this.buf.push(s)
+        }
+    }
+
+    protected writeln(...strs: string[]) {
+        this.write(...strs)
+        this.write("\n")
+    }
 }
 
 class GoDialect extends TextBasedDialect {
-  constructor(meta: APIMeta) {
-    super(meta, "go")
-    this.seenDecls = new Set()
-  }
-
-  writeSeenDecl(decl: Decl) {
-    this.write(`*${decl.loc.pkg_name}.${decl.name}`)
-  }
-
-  renderStruct(t: StructType) {
-    this.writeln("struct {")
-    this.level++
-
-    // Calculate the longest field name so we can align the types
-    const longestFieldName = t.fields.reduce<number>((previous: number, current: Field) => {
-      if (current.name.length > previous) {
-        return current.name.length
-      }
-
-      return previous
-    }, 0)
-
-    t.fields.map(f => {
-      this.indent()
-      this.write(f.name)
-      this.write(" ".repeat(longestFieldName - f.name.length + 1))
-      this.writeType(f.typ)
-      this.renderTag(f)
-
-      this.writeln()
-    })
-
-    this.level--
-
-    this.indent()
-    this.write("}")
-  }
-
-  renderMap(t: MapType,) {
-    this.write("map[")
-    this.writeType(t.key)
-    this.write("]")
-    this.writeType(t.value)
-  }
-
-  renderList(t: ListType) {
-    this.write("[]")
-    this.writeType(t.elem)
-  }
-
-  renderBuiltin(t: Builtin) {
-    switch (t) {
-    case Builtin.ANY: return this.write("interface{}")
-    case Builtin.BOOL: return this.write("bool")
-    case Builtin.INT: return this.write("int")
-    case Builtin.INT8: return this.write("int8")
-    case Builtin.INT16: return this.write("int16")
-    case Builtin.INT32: return this.write("int32")
-    case Builtin.INT64: return this.write("int64")
-    case Builtin.UINT: return this.write("uint")
-    case Builtin.UINT8: return this.write("uint8")
-    case Builtin.UINT16: return this.write("uint16")
-    case Builtin.UINT32: return this.write("uint32")
-    case Builtin.UINT64: return this.write("uint64")
-    case Builtin.FLOAT32: return this.write("float32")
-    case Builtin.FLOAT64: return this.write("float64")
-    case Builtin.STRING: return this.write("string")
-    case Builtin.BYTES: return this.write("[]byte")
-    case Builtin.TIME: return this.write("time.Time")
-    case Builtin.UUID: return this.write("uuid.UUID")
-    case Builtin.JSON: return this.write("json.RawMessage")
-    case Builtin.USER_ID:return  this.write("auth.UID")
-    case Builtin.UNRECOGNIZED: return this.write("<unknown>")
+    constructor(meta: APIMeta) {
+        super(meta, "go")
+        this.seenDecls = new Set()
     }
 
-    return unreachableUnknownType(t)
-  }
-
-  renderTag(f: Field){
-    let parts = []
-    if (f.optional) {
-      parts.push(`encore:"optional"`)
-    }
-    if (f.json_name !== "") {
-      parts.push(`json:"${f.json_name}"`)
-    }
-    if (parts.length === 0) {
-      return
+    writeSeenDecl(decl: Decl) {
+        this.write(`*${decl.loc.pkg_name}.${decl.name}`)
     }
 
-    this.write(" `" + parts.join(" ") + "`")
-  }
+    renderStruct(t: StructType) {
+        this.writeln("struct {")
+        this.level++
+
+        // Calculate the longest field name so we can align the types
+        const longestFieldName = t.fields.reduce<number>((previous: number, current: Field) => {
+            if (current.name.length > previous) {
+                return current.name.length
+            }
+
+            return previous
+        }, 0)
+
+        t.fields.map(f => {
+            this.indent()
+            this.write(f.name)
+            this.write(" ".repeat(longestFieldName - f.name.length + 1))
+            this.writeType(f.typ)
+
+            if (f.raw_tag) {
+                this.write(" `", f.raw_tag, "`")
+            }
+
+            this.writeln()
+        })
+
+        this.level--
+
+        this.indent()
+        this.write("}")
+    }
+
+    renderMap(t: MapType,) {
+        this.write("map[")
+        this.writeType(t.key)
+        this.write("]")
+        this.writeType(t.value)
+    }
+
+    renderList(t: ListType) {
+        this.write("[]")
+        this.writeType(t.elem)
+    }
+
+    renderBuiltin(t: Builtin) {
+        switch (t) {
+            case Builtin.ANY:
+                return this.write("interface{}")
+            case Builtin.BOOL:
+                return this.write("bool")
+            case Builtin.INT:
+                return this.write("int")
+            case Builtin.INT8:
+                return this.write("int8")
+            case Builtin.INT16:
+                return this.write("int16")
+            case Builtin.INT32:
+                return this.write("int32")
+            case Builtin.INT64:
+                return this.write("int64")
+            case Builtin.UINT:
+                return this.write("uint")
+            case Builtin.UINT8:
+                return this.write("uint8")
+            case Builtin.UINT16:
+                return this.write("uint16")
+            case Builtin.UINT32:
+                return this.write("uint32")
+            case Builtin.UINT64:
+                return this.write("uint64")
+            case Builtin.FLOAT32:
+                return this.write("float32")
+            case Builtin.FLOAT64:
+                return this.write("float64")
+            case Builtin.STRING:
+                return this.write("string")
+            case Builtin.BYTES:
+                return this.write("[]byte")
+            case Builtin.TIME:
+                return this.write("time.Time")
+            case Builtin.UUID:
+                return this.write("uuid.UUID")
+            case Builtin.JSON:
+                return this.write("json.RawMessage")
+            case Builtin.USER_ID:
+                return this.write("auth.UID")
+            case Builtin.UNRECOGNIZED:
+                return this.write("<unknown>")
+        }
+
+        return unreachableUnknownType(t)
+    }
 }
 
 class TypescriptDialect extends TextBasedDialect {
-  constructor(meta: APIMeta) {
-    super(meta, { name: "javascript", typescript: true})
-  }
-
-  renderStruct(t: StructType) {
-    this.writeln("{")
-    this.level++
-
-    t.fields.map(f => {
-      this.indent()
-      this.write(f.json_name !== "" ? f.json_name : f.name)
-      this.write(": ")
-      this.writeType(f.typ)
-
-      if (f.optional) {
-        this.write(" | undefined")
-      }
-
-      this.writeln(";")
-    })
-
-    this.level--
-    this.indent()
-    this.write("}")
-  }
-
-  renderMap(t: MapType) {
-    this.write("{ [key: ")
-    this.writeType(t.key)
-    this.write("]: ")
-    this.writeType(t.value)
-    this.write("}")
-  }
-
-  renderList(t: ListType) {
-    this.writeType(t.elem)
-    this.write("[]")
-  }
-
-  renderBuiltin(t: Builtin) {
-    switch (t) {
-      case Builtin.ANY: return this.write("any")
-      case Builtin.BOOL: return this.write("boolean")
-      case Builtin.INT: return this.write("int")
-      case Builtin.INT8: return this.write("int8")
-      case Builtin.INT16: return this.write("int16")
-      case Builtin.INT32: return this.write("int32")
-      case Builtin.INT64: return this.write("int64")
-      case Builtin.UINT: return this.write("uint")
-      case Builtin.UINT8: return this.write("uint8")
-      case Builtin.UINT16: return this.write("uint16")
-      case Builtin.UINT32: return this.write("uint32")
-      case Builtin.UINT64: return this.write("uint64")
-      case Builtin.FLOAT32: return this.write("float32")
-      case Builtin.FLOAT64: return this.write("float64")
-      case Builtin.STRING: return this.write("string")
-      case Builtin.BYTES: return this.write("[]byte")
-      case Builtin.TIME: return this.write("Time")
-      case Builtin.UUID: return this.write("UUID")
-      case Builtin.JSON: return this.write("any")
-      case Builtin.USER_ID: return this.write("UserID")
-      case Builtin.UNRECOGNIZED: return this.write("<unknown>")
+    constructor(meta: APIMeta) {
+        super(meta, {name: "javascript", typescript: true})
     }
 
-    return unreachableUnknownType(t)
-  }
+    renderStruct(t: StructType) {
+        this.writeln("{")
+        this.level++
 
-  protected writeSeenDecl(decl: Decl): void {
-    this.write("null")
-  }
+        t.fields.map(f => {
+            this.indent()
+            this.write(f.json_name !== "" ? f.json_name : f.name)
+            this.write(": ")
+            this.writeType(f.typ)
+
+            if (f.optional) {
+                this.write(" | undefined")
+            }
+
+            this.writeln(";")
+        })
+
+        this.level--
+        this.indent()
+        this.write("}")
+    }
+
+    renderMap(t: MapType) {
+        this.write("{ [key: ")
+        this.writeType(t.key)
+        this.write("]: ")
+        this.writeType(t.value)
+        this.write("}")
+    }
+
+    renderList(t: ListType) {
+        this.writeType(t.elem)
+        this.write("[]")
+    }
+
+    renderBuiltin(t: Builtin) {
+        switch (t) {
+            case Builtin.ANY:
+                return this.write("any")
+            case Builtin.BOOL:
+                return this.write("boolean")
+            case Builtin.INT:
+                return this.write("int")
+            case Builtin.INT8:
+                return this.write("int8")
+            case Builtin.INT16:
+                return this.write("int16")
+            case Builtin.INT32:
+                return this.write("int32")
+            case Builtin.INT64:
+                return this.write("int64")
+            case Builtin.UINT:
+                return this.write("uint")
+            case Builtin.UINT8:
+                return this.write("uint8")
+            case Builtin.UINT16:
+                return this.write("uint16")
+            case Builtin.UINT32:
+                return this.write("uint32")
+            case Builtin.UINT64:
+                return this.write("uint64")
+            case Builtin.FLOAT32:
+                return this.write("float32")
+            case Builtin.FLOAT64:
+                return this.write("float64")
+            case Builtin.STRING:
+                return this.write("string")
+            case Builtin.BYTES:
+                return this.write("[]byte")
+            case Builtin.TIME:
+                return this.write("Time")
+            case Builtin.UUID:
+                return this.write("UUID")
+            case Builtin.JSON:
+                return this.write("any")
+            case Builtin.USER_ID:
+                return this.write("UserID")
+            case Builtin.UNRECOGNIZED:
+                return this.write("<unknown>")
+        }
+
+        return unreachableUnknownType(t)
+    }
+
+    protected writeSeenDecl(decl: Decl): void {
+        this.write("null")
+    }
 }
 
 export class JSONDialect extends TextBasedDialect {
-  constructor(md: APIMeta) {
-    super(md, { name: "javascript", json: true })
-  }
-
-  writeSeenDecl(decl: Decl) {
-    this.write("null")
-  }
-
-  protected renderStruct(t: StructType) {
-    this.writeln("{")
-    this.level++
-    for (let i = 0; i < t.fields.length; i++) {
-      const f = t.fields[i]
-      this.indent()
-      this.write(`"${f.json_name !== "" ? f.json_name : f.name}": `)
-      this.writeType(f.typ)
-      if (i < (t.fields.length-1)) {
-        this.write(",")
-      }
-      this.writeln()
-    }
-    this.level--
-    this.indent()
-    this.write("}")
-  }
-
-  protected renderMap(t: MapType) {
-    this.writeln("{")
-    this.level++
-    this.indent()
-    this.writeType(t.key)
-    this.write(": ")
-    this.writeType(t.value)
-    this.writeln()
-    this.write("}")
-  }
-
-  protected renderList(t: ListType) {
-    this.write("[")
-    this.writeType(t.elem)
-    this.write("]")
-  }
-
-  protected renderBuiltin(t: Builtin) {
-    switch (t) {
-      case Builtin.ANY: return this.write("<any data>")
-      case Builtin.BOOL: return this.write("true")
-      case Builtin.INT: return this.write("1")
-      case Builtin.INT8: return this.write("1")
-      case Builtin.INT16: return this.write("1")
-      case Builtin.INT32: return this.write("1")
-      case Builtin.INT64: return this.write("1")
-      case Builtin.UINT: return this.write("1")
-      case Builtin.UINT8: return this.write("1")
-      case Builtin.UINT16: return this.write("1")
-      case Builtin.UINT32: return this.write("1")
-      case Builtin.UINT64: return this.write("1")
-      case Builtin.FLOAT32: return this.write("2.3")
-      case Builtin.FLOAT64: return this.write("2.3")
-      case Builtin.STRING: return this.write("\"some string\"")
-      case Builtin.BYTES: return this.write("\"YmFzZTY0Cg==\"") // base64
-      case Builtin.TIME: return this.write("\"2009-11-10T23:00:00Z\"")
-      case Builtin.UUID: return this.write("\"7d42f515-3517-4e76-be13-30880443546f\"")
-      case Builtin.JSON: return this.write("{\"some json data\": true}")
-      case Builtin.USER_ID: return this.write("\"userID\"")
-      case Builtin.UNRECOGNIZED: return this.write("<unknown>")
+    constructor(md: APIMeta) {
+        super(md, {name: "javascript", json: true})
     }
 
-    return unreachableUnknownType(t)
-  }
+    writeSeenDecl(decl: Decl) {
+        this.write("null")
+    }
+
+    protected renderStruct(t: StructType, topLevel?: boolean) {
+        const writeObj = (fields: Field[]) => {
+            this.writeln("{")
+            this.level++
+            for (let i = 0; i < fields.length; i++) {
+                const f = fields[i]
+                this.indent()
+                this.write(`"${f.json_name !== "" ? f.json_name : f.name}": `)
+                this.writeType(f.typ)
+                if (i < (fields.length - 1)) {
+                    this.write(",")
+                }
+                this.writeln()
+            }
+            this.level--
+            this.indent()
+            this.write("}")
+        }
+
+        if (topLevel) {
+            const fields = splitFieldsByLocation(t, this.method, this.asResponse)
+            let previousSection = false
+
+            if (fields[FieldLocation.Query].length > 0) {
+                this.writeln("// Query String")
+                this.write("?")
+
+                let firstField = true
+                for (const field of fields[FieldLocation.Query]) {
+                    if (firstField) {
+                        firstField = false
+                    } else {
+                        this.write("&")
+                    }
+                    
+                    this.write(field.name, "=")
+                    
+                    if (field.typ.builtin) {
+                        this.renderBuiltin(field.typ.builtin)
+                    } else if (field.typ.list) {
+                        this.renderBuiltin(field.typ.list.elem.builtin!)
+
+                        // show it's a list by duplicating :-)
+                        this.write("&", field.name, "=")
+                        this.renderBuiltin(field.typ.list.elem.builtin!, true)
+                    }
+                }
+                previousSection = true
+            }
+
+            if (fields[FieldLocation.Header].length > 0) {
+                if (previousSection) {
+                    this.writeln("\n\n")
+                }
+                this.writeln("// HTTP Headers")
+                writeObj(fields[FieldLocation.Header])
+                previousSection = true
+            }
+
+            if (fields[FieldLocation.Body].length > 0) {
+                if (previousSection) {
+                    this.writeln("\n\n// JSON Payload")
+                }
+                writeObj(fields[FieldLocation.Body])
+            }
+        } else {
+            writeObj(t.fields)
+        }
+    }
+
+    protected renderMap(t: MapType) {
+        this.writeln("{")
+        this.level++
+        this.indent()
+        this.writeType(t.key)
+        this.write(": ")
+        this.writeType(t.value)
+        this.writeln()
+        this.write("}")
+    }
+
+    protected renderList(t: ListType) {
+        this.write("[")
+        this.writeType(t.elem, false, false)
+        this.write(", ")
+        this.writeType(t.elem, false, true)
+        this.write("]")
+    }
+
+    protected renderBuiltin(t: Builtin, alt? :boolean) {
+        switch (t) {
+            case Builtin.ANY:
+                return this.write("<any data>")
+            case Builtin.BOOL:
+                return this.write(alt ? "false" : "true")
+            case Builtin.INT:
+            case Builtin.INT8:
+            case Builtin.INT16:
+            case Builtin.INT32:
+            case Builtin.INT64:
+            case Builtin.UINT:
+            case Builtin.UINT8:
+            case Builtin.UINT16:
+            case Builtin.UINT32:
+            case Builtin.UINT64:
+                return this.write(alt ? "2" : "1")
+            case Builtin.FLOAT32:
+            case Builtin.FLOAT64:
+                return this.write(alt ? "42.9" : "2.3")
+            case Builtin.STRING:
+                return this.write(alt ? "\"another string\"" : "\"some string\"")
+            case Builtin.BYTES:
+                return this.write("\"YmFzZTY0Cg==\"") // base64
+            case Builtin.TIME:
+                return this.write("\"2009-11-10T23:00:00Z\"")
+            case Builtin.UUID:
+                return this.write("\"7d42f515-3517-4e76-be13-30880443546f\"")
+            case Builtin.JSON:
+                return this.write("{\"some json data\": true}")
+            case Builtin.USER_ID:
+                return this.write("\"userID\"")
+            case Builtin.UNRECOGNIZED:
+                return this.write("<unknown>")
+        }
+
+        return unreachableUnknownType(t)
+    }
 }
 
 class TableDialect extends DialectIface {
-  typeArgumentStack: Type[][] = [];
+    typeArgumentStack: Type[][] = [];
 
-  render(d: Type) {
-    if (!d?.named) {
-      throw new Error("TableDialect can only rendered named structs")
-    }
-
-    const st = this.meta.decls[d.named.id].type.struct
-    if (!st) {
-      throw new Error("TableDialect can only render named structs")
-    }
-
-    this.typeArgumentStack.push(d.named.type_arguments)
-    return this.renderStruct(st, 0)
-  }
-
-  renderStruct(t: StructType, level: number): JSX.Element {
-    return (
-      <div className={level !== 0 ? "rounded-sm border-gray-200" : ""}>
-          {t.fields.map((f, i) =>
-            <div key={f.name} className={i > 0 ? "border-t border-gray-200" : ""}>
-              <div className="flex leading-6 font-mono">
-                <div className="font-bold text-gray-900 text-sm">
-                  {f.name}
-                </div>
-                <div className="ml-2 text-xs text-gray-500">{this.describeType(f.typ)}</div>
-              </div>
-              {f.doc !== "" ? (
-                <div className="text-sm text-gray-700">{f.doc}</div>
-              ) : (
-                <div className="text-xs text-gray-400">No description.</div>
-              )}
-            </div>
-          )}
-      </div>
-    )
-  }
-
-  describeType(t: Type): string {
-    return (
-      t.struct ? "struct" :
-      t.map ? "map" :
-      t.list ? "list of " + this.describeType(t.list.elem) :
-      t.builtin ? this.describeBuiltin(t.builtin) :
-      t.named ? this.describeNamed(t.named) :
-      t.type_parameter ? this.describeTypeParameter(t.type_parameter) :
-      "<unknown>"
-    )
-  }
-
-  describeTypeParameter(t: TypeParameterRef): string {
-    const typeArgument = this.typeArgumentStack[this.typeArgumentStack.length - 1][t.param_idx]
-    return this.describeType(typeArgument)
-  }
-
-
-  describeBuiltin(t: Builtin): string {
-    switch (t) {
-    case Builtin.ANY: return "<any>"
-    case Builtin.BOOL: return "boolean"
-    case Builtin.INT: return "int"
-    case Builtin.INT8: return "int"
-    case Builtin.INT16: return "int"
-    case Builtin.INT32: return "int"
-    case Builtin.INT64: return "int"
-    case Builtin.UINT: return "uint"
-    case Builtin.UINT8: return "uint"
-    case Builtin.UINT16: return "uint"
-    case Builtin.UINT32: return "uint"
-    case Builtin.UINT64: return "uint"
-    case Builtin.FLOAT32: return "float"
-    case Builtin.FLOAT64: return "float"
-    case Builtin.STRING: return "string"
-    case Builtin.BYTES: return "bytes"
-    case Builtin.TIME: return "RFC 3339-formatted timestamp"
-    case Builtin.UUID: return "UUID"
-    case Builtin.JSON: return "arbitrary JSON"
-    case Builtin.USER_ID: return "User ID"
-    case Builtin.UNRECOGNIZED: return "<unknown>"
-    }
-
-    return unreachableUnknownType(t)
-  }
-
-  describeNamed(named: NamedType): string {
-    const decl = this.meta.decls[named.id]
-
-    let types = ""
-    if (named.type_arguments.length > 0) {
-      types = "["
-
-      for (let i = 0; i < named.type_arguments.length; i++) {
-        if (i > 0) {
-          types += ", "
+    render(d: Type, method: string, asResponse: boolean) {
+        if (!d?.named) {
+            throw new Error("TableDialect can only rendered named structs")
         }
 
-        types += this.describeType(named.type_arguments[i])
-      }
+        const st = this.meta.decls[d.named.id].type.struct
+        if (!st) {
+            throw new Error("TableDialect can only render named structs")
+        }
 
-      types += "]"
+        this.typeArgumentStack.push(d.named.type_arguments)
+        return this.renderStruct(st, 0, method, asResponse)
     }
 
-    return decl.loc.pkg_name + "." + decl.name + types
-  }
+    renderStruct(t: StructType, level: number, method: string, asResponse: boolean): JSX.Element {
+        return (
+            <div className={level !== 0 ? "rounded-sm border-gray-200" : ""}>
+                {t.fields.map((f, i) => {
+                    const [name, location] = fieldNameAndLocation(f, method, asResponse)
+
+                    return <div key={f.name} className={i > 0 ? "border-t border-gray-200 mt-1 pt-1" : ""}>
+                        <div className="flex leading-6 font-mono">
+                            <div className="font-bold text-gray-900 text-sm">
+                                {name}
+                            </div>
+                            <div className="ml-2 text-xs text-gray-500 flex-grow p-0.5">{this.describeType(f.typ)}</div>
+                            {location !== FieldLocation.Body &&
+                                <div className="text-xs text-blue-700 bg-blue-100 rounded text-center p-1 cursor-help"
+                                     title={locationDescription(name, location)}>{location}</div>}
+                        </div>
+                        {f.doc !== "" ? (
+                            <div className="text-sm text-gray-700">{f.doc}</div>
+                        ) : (
+                            <div className="text-xs text-gray-400">No description.</div>
+                        )}
+                    </div>
+                })}
+            </div>
+        )
+    }
+
+    describeType(t: Type): string {
+        return (
+            t.struct ? "struct" :
+                t.map ? "map" :
+                    t.list ? "list of " + this.describeType(t.list.elem) :
+                        t.builtin ? this.describeBuiltin(t.builtin) :
+                            t.named ? this.describeNamed(t.named) :
+                                t.type_parameter ? this.describeTypeParameter(t.type_parameter) :
+                                    "<unknown>"
+        )
+    }
+
+    describeTypeParameter(t: TypeParameterRef): string {
+        const typeArgument = this.typeArgumentStack[this.typeArgumentStack.length - 1][t.param_idx]
+        return this.describeType(typeArgument)
+    }
+
+
+    describeBuiltin(t: Builtin): string {
+        switch (t) {
+            case Builtin.ANY:
+                return "<any>"
+            case Builtin.BOOL:
+                return "boolean"
+            case Builtin.INT:
+                return "int"
+            case Builtin.INT8:
+                return "int"
+            case Builtin.INT16:
+                return "int"
+            case Builtin.INT32:
+                return "int"
+            case Builtin.INT64:
+                return "int"
+            case Builtin.UINT:
+                return "uint"
+            case Builtin.UINT8:
+                return "uint"
+            case Builtin.UINT16:
+                return "uint"
+            case Builtin.UINT32:
+                return "uint"
+            case Builtin.UINT64:
+                return "uint"
+            case Builtin.FLOAT32:
+                return "float"
+            case Builtin.FLOAT64:
+                return "float"
+            case Builtin.STRING:
+                return "string"
+            case Builtin.BYTES:
+                return "bytes"
+            case Builtin.TIME:
+                return "RFC 3339-formatted timestamp"
+            case Builtin.UUID:
+                return "UUID"
+            case Builtin.JSON:
+                return "arbitrary JSON"
+            case Builtin.USER_ID:
+                return "User ID"
+            case Builtin.UNRECOGNIZED:
+                return "<unknown>"
+        }
+
+        return unreachableUnknownType(t)
+    }
+
+    describeNamed(named: NamedType): string {
+        const decl = this.meta.decls[named.id]
+
+        let types = ""
+        if (named.type_arguments.length > 0) {
+            types = "["
+
+            for (let i = 0; i < named.type_arguments.length; i++) {
+                if (i > 0) {
+                    types += ", "
+                }
+
+                types += this.describeType(named.type_arguments[i])
+            }
+
+            types += "]"
+        }
+
+        return decl.loc.pkg_name + "." + decl.name + types
+    }
 }
 
-const dialects: { [key in Dialect]: (meta: APIMeta) => DialectIface} = {
-  "go": (meta) => new GoDialect(meta),
-  "typescript": (meta) => new TypescriptDialect(meta),
-  "json": (meta) => new JSONDialect(meta),
-  "table": (meta) => new TableDialect(meta),
+const dialects: { [key in Dialect]: (meta: APIMeta) => DialectIface } = {
+    "go":         (meta) => new GoDialect(meta),
+    "typescript": (meta) => new TypescriptDialect(meta),
+    "json":       (meta) => new JSONDialect(meta),
+    "table":      (meta) => new TableDialect(meta),
 }
 
 // This function serves two purposes
@@ -480,5 +627,5 @@ const dialects: { [key in Dialect]: (meta: APIMeta) => DialectIface} = {
 // 2. If we have a switch statement on an enum without a default, and return from each case then if we miss one of the
 //    enum options, we'll get a compile error if we try and pass that case as the parameter x to this function
 export function unreachableUnknownType(_: never): string {
-  return "<unknown>";
+    return "<unknown>";
 }

--- a/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/SchemaView.tsx
@@ -117,7 +117,11 @@ abstract class TextBasedDialect extends DialectIface {
 
     protected renderTypeParameter(t: TypeParameterRef) {
         const typeArguments = this.typeArgumentStack[this.typeArgumentStack.length - 1]
-        this.writeType(typeArguments[t.param_idx])
+        if (typeArguments === undefined || typeArguments.length <= t.param_idx) {
+            this.write("?")
+        } else {
+            this.writeType(typeArguments[t.param_idx])
+        }
     }
 
     protected abstract writeSeenDecl(decl: Decl): void

--- a/cli/daemon/dash/dashapp/src/components/api/schema.ts
+++ b/cli/daemon/dash/dashapp/src/components/api/schema.ts
@@ -20,6 +20,10 @@ export enum FieldLocation {
     UnusedField = "hidden",
 }
 
+export interface DescribedField extends Field {
+    SrcName: string
+}
+
 export function methodSupportsPayloads(method: string): boolean {
     return method !== "GET" && method !== "HEAD" && method !== "DELETE"
 }
@@ -74,8 +78,8 @@ export function locationDescription(name: string, location: FieldLocation): stri
     }
 }
 
-export function splitFieldsByLocation(t: StructType, method: string, asResponse: boolean): Record<FieldLocation, Field[]> {
-    let rtn: Record<FieldLocation, Field[]> = {
+export function splitFieldsByLocation(t: StructType, method: string, asResponse: boolean): Record<FieldLocation, DescribedField[]> {
+    let rtn: Record<FieldLocation, DescribedField[]> = {
         [FieldLocation.Body]: [],
         [FieldLocation.Query]: [],
         [FieldLocation.Header]: [],
@@ -85,7 +89,7 @@ export function splitFieldsByLocation(t: StructType, method: string, asResponse:
     for (const field of t.fields) {
         const [name, location] = fieldNameAndLocation(field, method, asResponse)
 
-        const newField = {...field, name}
+        const newField = {...field, SrcName: field.name, name: name}
 
         rtn[location].push(newField)
     }

--- a/cli/daemon/dash/dashapp/src/components/api/schema.ts
+++ b/cli/daemon/dash/dashapp/src/components/api/schema.ts
@@ -70,13 +70,13 @@ export function fieldNameAndLocation(f: Field, method: string, asResponse: boole
                     return ["-", FieldLocation.UnusedField]
                 }
 
-                if (methodSupportsPayloads(method)) {
+                if (methodSupportsPayloads(method) || asResponse) {
                     return [tag.name, FieldLocation.Body]
                 }
         }
     }
 
-    if (methodSupportsPayloads(method)) {
+    if (methodSupportsPayloads(method) || asResponse) {
         return [f.name, FieldLocation.Body]
     } else {
         return [f.name, FieldLocation.Query]

--- a/cli/daemon/dash/dashapp/src/components/api/schema.ts
+++ b/cli/daemon/dash/dashapp/src/components/api/schema.ts
@@ -1,5 +1,6 @@
 import {Field} from "../../../../../../../proto/encore/parser/schema/v1/schema.pb"
 import * as pb from '../../../../../../../proto/encore/parser/schema/v1/schema.pb'
+import { APIMeta, RPC } from "./api"
 export * from '../../../../../../../proto/encore/parser/schema/v1/schema.pb'
 
 // Aliases to match old type names
@@ -26,6 +27,21 @@ export interface DescribedField extends Field {
 
 export function methodSupportsPayloads(method: string): boolean {
     return method !== "GET" && method !== "HEAD" && method !== "DELETE"
+}
+
+export function rpcHasBody(md: APIMeta, rpc: RPC, method: string) {
+    const named = rpc.request_schema?.named
+    if (!named) {
+        return false
+    }
+    const astFields = md.decls[named.id].type.struct!.fields
+    for (const f of astFields) {
+        let [_, location] = fieldNameAndLocation(f, method, false)
+        if (location === FieldLocation.Body) {
+            return true
+        }
+    }
+    return false
 }
 
 export function fieldNameAndLocation(f: Field, method: string, asResponse: boolean): [string, FieldLocation] {

--- a/cli/daemon/dash/dashapp/src/components/api/schema.ts
+++ b/cli/daemon/dash/dashapp/src/components/api/schema.ts
@@ -1,3 +1,4 @@
+import {Field} from "../../../../../../../proto/encore/parser/schema/v1/schema.pb"
 import * as pb from '../../../../../../../proto/encore/parser/schema/v1/schema.pb'
 export * from '../../../../../../../proto/encore/parser/schema/v1/schema.pb'
 
@@ -11,3 +12,57 @@ export type StructType = pb.Struct
 export {
     Builtin as BuiltinType,
 }  from '../../../../../../../proto/encore/parser/schema/v1/schema.pb'
+
+export enum FieldLocation {
+    Body = "JSON Payload",
+    Header = "HTTP Header",
+    Query = "Query String",
+}
+
+export function fieldNameAndLocation(f: Field, method: string, asResponse: boolean): [string, FieldLocation] {
+    for (const tag of f.tags) {
+        switch (tag.key) {
+            case "qs":
+            case "query":
+                if (!asResponse) {
+                    return [tag.name, FieldLocation.Query]
+                }
+                break
+            case "header":
+                return [tag.name, FieldLocation.Header]
+            case "json":
+                return [tag.name, FieldLocation.Body]
+        }
+    }
+
+    return [f.name, FieldLocation.Body]
+}
+
+export function locationDescription(name: string, location: FieldLocation): string {
+    switch (location) {
+        case FieldLocation.Header:
+            return `"${name}" is sent as a HTTP Header`
+        case FieldLocation.Query:
+            return `"${name}" is sent as a query string parameter`
+        default:
+            return ""
+    }
+}
+
+export function splitFieldsByLocation(t: StructType, method: string, asResponse: boolean): Record<FieldLocation, Field[]> {
+    let rtn: Record<FieldLocation, Field[]> = {
+        [FieldLocation.Body]: [],
+        [FieldLocation.Query]: [],
+        [FieldLocation.Header]: []
+    }
+
+    for (const field of t.fields) {
+        const [name, location] = fieldNameAndLocation(field, method, asResponse)
+
+        const newField = {...field, name}
+
+        rtn[location].push(newField)
+    }
+
+    return rtn
+}

--- a/cli/daemon/dash/dashapp/src/components/app/AppAPI.tsx
+++ b/cli/daemon/dash/dashapp/src/components/app/AppAPI.tsx
@@ -81,6 +81,19 @@ export default class AppAPI extends React.Component<Props, State> {
 
                 {svc.rpcs.map(rpc => {
                   const pathParams = rpc.path.segments.filter(p => p.type !== "LITERAL")
+
+                  let defaultMethod = rpc.http_methods[0]
+                  if (defaultMethod === "*") {
+                    defaultMethod = "POST"
+                  } else if (defaultMethod !== "POST") {
+                    for (const method of rpc.http_methods) {
+                      if (method === "POST") {
+                        defaultMethod = method
+                        break
+                      }
+                    }
+                  }
+
                   return (
                     <div key={rpc.name} className="border-t border-gray-300 py-10">
                       <h3 id={svc.name+"."+rpc.name} className="text-2xl leading-10 font-sans font-medium text-gray-700 flex items-center">
@@ -114,16 +127,13 @@ export default class AppAPI extends React.Component<Props, State> {
                                       </div>
                                     )}
                                   </div>
-                                  {rpc.request_schema ? <SchemaView meta={meta} type={rpc.request_schema} dialect="table" /> :
-                                    <div className="text-gray-400 text-sm">No parameters.</div>
-                                  }
                                 </div>
                               }
 
                               <div className="mt-4">
                                 <h4 className="font-medium font-sans text-gray-700">Request</h4>
                                 <hr className="my-4 border-gray-200" />
-                                {rpc.request_schema ? <SchemaView meta={meta} type={rpc.request_schema} dialect="table" /> :
+                                {rpc.request_schema ? <SchemaView meta={meta} method={defaultMethod} type={rpc.request_schema} dialect="table" /> :
                                   <div className="text-gray-400 text-sm">No parameters.</div>
                                 }
                               </div>
@@ -131,7 +141,7 @@ export default class AppAPI extends React.Component<Props, State> {
                               <div className="mt-12">
                                 <h4 className="font-medium font-sans text-gray-700">Response</h4>
                                 <hr className="my-4 border-gray-200" />
-                                {rpc.response_schema ? <SchemaView meta={meta} type={rpc.response_schema} dialect="table" /> :
+                                {rpc.response_schema ? <SchemaView meta={meta} method={defaultMethod} type={rpc.response_schema} dialect="table" asResponse /> :
                                   <div className="text-gray-400 text-sm">No response.</div>
                                 }
                               </div>
@@ -176,6 +186,18 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
     {title: "Call", type: "call"},
   ]
 
+  let defaultMethod = props.rpc.http_methods[0]
+  if (defaultMethod === "*") {
+    defaultMethod = "POST"
+  } else if (defaultMethod !== "POST") {
+    for (const method of props.rpc.http_methods) {
+      if (method === "POST") {
+        defaultMethod = method
+        break
+      }
+    }
+  }
+
     return <div>
       <nav className="flex justify-end space-x-4 mb-3">
         {tabs.map(t =>
@@ -196,12 +218,12 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
                   className="form-select h-full py-0 border-transparent bg-transparent text-gray-300 text-xs leading-none">
                 <option value="json">JSON</option>
                 <option value="go">Go</option>
-                <option value="typescript">TypeScript</option>
+                {/*<option value="typescript">TypeScript</option>*/}
               </select>
             </div>
           </div>
           <div className="rounded-b-md bg-gray-800 text-gray-100 p-2 font-mono overflow-auto">
-            <SchemaView meta={props.meta} type={props.rpc.request_schema} dialect={respDialect} />
+            <SchemaView meta={props.meta} type={props.rpc.request_schema} method={defaultMethod} dialect={respDialect} />
           </div>
         </div>
       }
@@ -214,12 +236,12 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
                   className="form-select h-full py-0 border-transparent bg-transparent text-gray-500 text-xs leading-none">
                 <option value="json">JSON</option>
                 <option value="go">Go</option>
-                <option value="typescript">TypeScript</option>
+                {/*<option value="typescript">TypeScript</option>*/}
               </select>
             </div>
           </div>
           <div className="rounded-b-md bg-gray-100 p-2 font-mono overflow-auto">
-            <SchemaView meta={props.meta} type={props.rpc.response_schema} dialect={respDialect} />
+            <SchemaView meta={props.meta} type={props.rpc.response_schema} method={defaultMethod} dialect={respDialect} asResponse />
           </div>
         </div>
       }

--- a/cli/daemon/dash/dashapp/src/components/app/AppAPI.tsx
+++ b/cli/daemon/dash/dashapp/src/components/app/AppAPI.tsx
@@ -133,7 +133,7 @@ export default class AppAPI extends React.Component<Props, State> {
                               <div className="mt-4">
                                 <h4 className="font-medium font-sans text-gray-700">Request</h4>
                                 <hr className="my-4 border-gray-200" />
-                                {rpc.request_schema ? <SchemaView meta={meta} method={defaultMethod} type={rpc.request_schema} dialect="table" /> :
+                                {rpc.request_schema ? <SchemaView meta={meta} service={svc} rpc={rpc} method={defaultMethod} type={rpc.request_schema} dialect="table" /> :
                                   <div className="text-gray-400 text-sm">No parameters.</div>
                                 }
                               </div>
@@ -141,7 +141,7 @@ export default class AppAPI extends React.Component<Props, State> {
                               <div className="mt-12">
                                 <h4 className="font-medium font-sans text-gray-700">Response</h4>
                                 <hr className="my-4 border-gray-200" />
-                                {rpc.response_schema ? <SchemaView meta={meta} method={defaultMethod} type={rpc.response_schema} dialect="table" asResponse /> :
+                                {rpc.response_schema ? <SchemaView meta={meta} service={svc} rpc={rpc} method={defaultMethod} type={rpc.response_schema} dialect="table" asResponse /> :
                                   <div className="text-gray-400 text-sm">No response.</div>
                                 }
                               </div>
@@ -224,7 +224,7 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
             </div>
           </div>
           <div className="rounded-b-md bg-gray-800 text-gray-100 p-2 font-mono overflow-auto">
-            <SchemaView meta={props.meta} type={props.rpc.request_schema} method={defaultMethod} dialect={respDialect} />
+            <SchemaView meta={props.meta} service={props.svc} rpc={props.rpc} type={props.rpc.request_schema} method={defaultMethod} dialect={respDialect} />
           </div>
         </div>
       }
@@ -243,7 +243,7 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
             </div>
           </div>
           <div className="rounded-b-md bg-gray-100 p-2 font-mono overflow-auto">
-            <SchemaView meta={props.meta} type={props.rpc.response_schema} method={defaultMethod} dialect={respDialect} asResponse />
+            <SchemaView meta={props.meta} service={props.svc} rpc={props.rpc} type={props.rpc.response_schema} method={defaultMethod} dialect={respDialect} asResponse />
           </div>
         </div>
       }

--- a/cli/daemon/dash/dashapp/src/components/app/AppAPI.tsx
+++ b/cli/daemon/dash/dashapp/src/components/app/AppAPI.tsx
@@ -218,6 +218,7 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
                   className="form-select h-full py-0 border-transparent bg-transparent text-gray-300 text-xs leading-none">
                 <option value="json">JSON</option>
                 <option value="go">Go</option>
+                <option value="curl">curl</option>
                 {/*<option value="typescript">TypeScript</option>*/}
               </select>
             </div>
@@ -236,6 +237,7 @@ const RPCDemo: FunctionComponent<RPCDemoProps> = (props) => {
                   className="form-select h-full py-0 border-transparent bg-transparent text-gray-500 text-xs leading-none">
                 <option value="json">JSON</option>
                 <option value="go">Go</option>
+                <option value="curl">curl</option>
                 {/*<option value="typescript">TypeScript</option>*/}
               </select>
             </div>

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -471,7 +471,7 @@ func (r *Run) generateConfig(p *Proc, params *startProcParams) *config.Runtime {
 	return &config.Runtime{
 		AppID:         r.ID,
 		AppSlug:       r.AppSlug,
-		APIBaseURL:    fmt.Sprintf("http://localhost:%d", params.RuntimePort),
+		APIBaseURL:    "http://" + r.ListenAddr,
 		DeployID:      fmt.Sprintf("run_%s", xid.New()),
 		DeployedAt:    time.Now().UTC(), // Force UTC to not cause confusion
 		EnvID:         p.ID,

--- a/cli/daemon/run/run_test.go
+++ b/cli/daemon/run/run_test.go
@@ -107,6 +107,10 @@ func TestEndToEndWithApp(t *testing.T) {
 	// Use golden to test that the generated clients are as expected for the echo test app
 	for lang, path := range map[codegen.Lang]string{codegen.LangGo: "client/client.go", codegen.LangTypeScript: "client.ts"} {
 		client, err := codegen.Client(lang, "slug", build.Parse.Meta)
+		if err != nil {
+			fmt.Println(err.Error())
+			c.FailNow()
+		}
 		c.Assert(err, qt.IsNil, qt.Commentf("Got an error generating the client for: %s", lang))
 
 		golden.TestAgainst(c, filepath.Join("echo_client", path), string(client))

--- a/cli/daemon/run/testdata/echo/echo/echo.go
+++ b/cli/daemon/run/testdata/echo/echo/echo.go
@@ -43,7 +43,7 @@ type NonBasicData struct {
 
 	// Auth Parameters
 	AuthHeader string
-	AuthQuery  []int 
+	AuthQuery  []int
 
 	// Unexported fields
 	unexported string

--- a/cli/daemon/run/testdata/echo/echo/echo.go
+++ b/cli/daemon/run/testdata/echo/echo/echo.go
@@ -37,13 +37,13 @@ type NonBasicData struct {
 	QueryNumber int    `query:"no"`
 
 	// Path Parameters
-	PathString string `query:"-"`
-	PathInt    int    `query:"-"`
-	PathWild   string `query:"-"`
+	PathString string
+	PathInt    int
+	PathWild   string
 
 	// Auth Parameters
-	AuthHeader string `query:"-"`
-	AuthQuery  []int  `query:"-"`
+	AuthHeader string
+	AuthQuery  []int 
 
 	// Unexported fields
 	unexported string

--- a/cli/daemon/run/testdata/echo_client/client.ts
+++ b/cli/daemon/run/testdata/echo_client/client.ts
@@ -265,6 +265,11 @@ export namespace echo {
             // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
             const body: Record<string, any> = {
                 AnonStruct:       params.AnonStruct,
+                AuthHeader:       params.AuthHeader,
+                AuthQuery:        params.AuthQuery,
+                PathInt:          params.PathInt,
+                PathString:       params.PathString,
+                PathWild:         params.PathWild,
                 RawStruct:        params.RawStruct,
                 Struct:           params.Struct,
                 StructMap:        params.StructMap,

--- a/cli/daemon/run/testdata/echo_client/client/client.go
+++ b/cli/daemon/run/testdata/echo_client/client/client.go
@@ -151,11 +151,11 @@ type EchoNonBasicData struct {
 	RawStruct   json.RawMessage
 	QueryString string `query:"string"` // Query
 	QueryNumber int    `query:"no"`
-	PathString  string `query:"-"` // Path Parameters
-	PathInt     int    `query:"-"`
-	PathWild    string `query:"-"`
-	AuthHeader  string `query:"-"` // Auth Parameters
-	AuthQuery   []int  `query:"-"`
+	PathString  string // Path Parameters
+	PathInt     int
+	PathWild    string
+	AuthHeader  string // Auth Parameters
+	AuthQuery   []int
 }
 
 // EchoClient Provides you access to call public and authenticated APIs on echo. The concrete implementation is echoClient.
@@ -333,9 +333,19 @@ func (c *echoClient) NonBasicEcho(ctx context.Context, pathString string, pathIn
 		} `json:"AnonStruct"`
 		NamedStruct EchoData[string, float64] `json:"formatted_nest"`
 		RawStruct   json.RawMessage           `json:"RawStruct"`
+		PathString  string                    `json:"PathString"`
+		PathInt     int                       `json:"PathInt"`
+		PathWild    string                    `json:"PathWild"`
+		AuthHeader  string                    `json:"AuthHeader"`
+		AuthQuery   []int                     `json:"AuthQuery"`
 	}{
 		AnonStruct:   params.AnonStruct,
+		AuthHeader:   params.AuthHeader,
+		AuthQuery:    params.AuthQuery,
 		NamedStruct:  params.NamedStruct,
+		PathInt:      params.PathInt,
+		PathString:   params.PathString,
+		PathWild:     params.PathWild,
 		RawStruct:    params.RawStruct,
 		Struct:       params.Struct,
 		StructMap:    params.StructMap,

--- a/cli/internal/appfile/appfile.go
+++ b/cli/internal/appfile/appfile.go
@@ -2,6 +2,7 @@
 package appfile
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -26,7 +27,11 @@ type File struct {
 // Parse parses the app file data into a File.
 func Parse(data []byte) (*File, error) {
 	var f File
-	if err := hujson.Unmarshal(data, &f); err != nil {
+	data, err := hujson.Standardize(data)
+	if err == nil {
+		err = json.Unmarshal(data, &f)
+	}
+	if err != nil {
 		return nil, fmt.Errorf("appfile.Parse: %v", err)
 	}
 	return &f, nil

--- a/cli/internal/codegen/golang.go
+++ b/cli/internal/codegen/golang.go
@@ -780,7 +780,7 @@ func (g *golang) getType(typ *schema.Type) Code {
 
 		for _, field := range typ.Struct.Fields {
 			// Skip over hidden fields
-			if field.JsonName == "-" || field.QueryStringName == "-" {
+			if encoding.IgnoreField(field) {
 				continue
 			}
 

--- a/cli/internal/codegen/golang.go
+++ b/cli/internal/codegen/golang.go
@@ -603,7 +603,7 @@ func (g *golang) rpcCallSite(rpc *meta.RPC) (code []Code, err error) {
 		return Id("callAPI").Call(
 			Id("ctx"),
 			Id("c").Dot("base"),
-			Lit(rpcEncoding.DefaultRequestEncoding.HTTPMethods[0]),
+			Lit(rpcEncoding.DefaultMethod),
 			g.createApiPath(rpc, withQueryString),
 			headers,
 			body,

--- a/cli/internal/codegen/testdata/expected_typescript.ts
+++ b/cli/internal/codegen/testdata/expected_typescript.ts
@@ -169,7 +169,6 @@ export namespace svc {
     export type Foo = number
 
     export interface GetRequest {
-        Bar: string
         Baz: number
     }
 

--- a/cli/internal/codegen/testdata/input.go
+++ b/cli/internal/codegen/testdata/input.go
@@ -56,6 +56,14 @@ type AllInputTypes[A any] struct {
     B []int     `query:"Bob"`                    // Specify this comes from a query string
     C bool      `json:"Charlies-Bool,omitempty"` // This can come from anywhere, but if it comes from the payload in JSON it must be called Charile
     Dave A                                       // This generic type complicates the whole thing 🙈
+
+    // Tags named "-" are ignored in schemas
+    Ignore1 string `header:"-"`
+    Ignore2 string `query:"-"`
+    Ignore3 string `json:"-"`
+
+    // Unexported tags are ignored
+    ignore4 string
 }
 
 // HeaderOnlyStruct contains all types we support in headers

--- a/cli/internal/codegen/typescript.go
+++ b/cli/internal/codegen/typescript.go
@@ -359,7 +359,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 	// Build the call to callAPI
 	callAPI := fmt.Sprintf(
 		"this.baseClient.callAPI(\"%s\", `%s`",
-		rpcEncoding.DefaultRequestEncoding.HTTPMethods[0],
+		rpcEncoding.DefaultMethod,
 		rpcPath,
 	)
 	if body != "" || headers != "" || query != "" {

--- a/cli/internal/codegen/typescript.go
+++ b/cli/internal/codegen/typescript.go
@@ -881,7 +881,7 @@ func (ts *typescript) writeTyp(ns string, typ *schema.Type, numIndents int) {
 		// Filter the fields to print based on struct tags.
 		fields := make([]*schema.Field, 0, len(typ.Struct.Fields))
 		for _, f := range typ.Struct.Fields {
-			if f.JsonName == "-" {
+			if encoding.IgnoreField(f) {
 				continue
 			}
 			fields = append(fields, f)

--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -64,6 +64,7 @@ func (b *Builder) Main() (f *File, err error) {
 	}
 
 	f.Var().Id("json").Op("=").Qual(JsonPkg, "Config").Values(Dict{
+		Id("IndentionStep"):          Qual("encore.dev/runtime/config", "JsonIndentStepForResponses").Call(),
 		Id("EscapeHTML"):             False(),
 		Id("SortMapKeys"):            True(),
 		Id("ValidateJsonRawMessage"): True(),

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
@@ -11,6 +11,7 @@ import (
 
 var json = jsoniter.Config{
 	EscapeHTML:             false,
+	IndentionStep:          config.JsonIndentStepForResponses(),
 	SortMapKeys:            true,
 	ValidateJsonRawMessage: true,
 }.Froze()

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -26,6 +26,7 @@ import (
 
 var json = jsoniter.Config{
 	EscapeHTML:             false,
+	IndentionStep:          config.JsonIndentStepForResponses(),
 	SortMapKeys:            true,
 	ValidateJsonRawMessage: true,
 }.Froze()

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -29,6 +29,7 @@ import (
 
 var json = jsoniter.Config{
 	EscapeHTML:             false,
+	IndentionStep:          config.JsonIndentStepForResponses(),
 	SortMapKeys:            true,
 	ValidateJsonRawMessage: true,
 }.Froze()

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.7
+	github.com/google/go-cmp v0.5.8
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87
@@ -30,7 +30,7 @@ require (
 	github.com/rs/xid v1.3.0
 	github.com/rs/zerolog v1.26.1
 	github.com/spf13/cobra v1.4.0
-	github.com/tailscale/hujson v0.0.0-20220421170326-6583d0610064
+	github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5
 	go.uber.org/goleak v1.1.10
 	go4.org v0.0.0-20201209231011-d4a079459e60
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,9 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v35 v35.2.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1114,8 +1115,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tailscale/hujson v0.0.0-20220421170326-6583d0610064 h1:QYGQDMEHpjU2wphrSGYmosrknQ4Oa63PvySl//4GCV0=
-github.com/tailscale/hujson v0.0.0-20220421170326-6583d0610064/go.mod h1:iTDXJsA6A2wNNjurgic2rk+is6uzU4U2NLm4T+edr6M=
+github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 h1:erxeiTyq+nw4Cz5+hLDkOwNF5/9IQWCQPv0gpb3+QHU=
+github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/runtime/runtime/config/runtime.go
+++ b/runtime/runtime/config/runtime.go
@@ -61,3 +61,17 @@ func ParseSecrets(s string) map[string]string {
 	}
 	return m
 }
+
+// JsonIndentStepForResponses is the number of spaces to indent JSON responses sent from the application.
+//
+// - 0 means no pretty printing will occur for JSON responses.
+// - any other value means pretty printing with that number of spaces for each level of indentation.
+//
+// In production environments this function will return 0, for all others it will return 2.
+func JsonIndentStepForResponses() int {
+	if Cfg.Runtime.EnvType == "production" {
+		return 0
+	}
+
+	return 2
+}

--- a/runtime/runtime/request.go
+++ b/runtime/runtime/request.go
@@ -32,9 +32,9 @@ var (
 )
 
 var json = jsoniter.Config{
-	IndentionStep:          2,
+	IndentionStep:          config.JsonIndentStepForResponses(),
 	EscapeHTML:             false,
-	SortMapKeys:            false,
+	SortMapKeys:            true,
 	ValidateJsonRawMessage: true,
 }.Froze()
 


### PR DESCRIPTION
This PR adds support in the local dashboard to support header fields and query fields, as well as the new authentication handler type which supports a parameters object rather than just a bearer token string.

### Screenshots
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/236641/170743724-d83ff165-8eb5-4d59-8173-f8297830ae54.png">
<img width="1344" alt="image" src="https://user-images.githubusercontent.com/236641/170743763-d8da31b9-33e6-4cc7-b035-e3859a006296.png">


Fixes #245