### PR TITLE
Case Insensitive Language on Client Generation

### DIFF
--- a/cli/internal/codegen/client.go
+++ b/cli/internal/codegen/client.go
@@ -52,7 +52,7 @@ func Client(lang Lang, appSlug string, md *meta.Data) (code []byte, err error) {
 	}()
 
 	var gen generator
-	switch lang {
+	switch Lang(strings.ToLower(string(lang))) {
 	case LangTypeScript:
 		gen = &typescript{generatorVersion: typescriptGenLatestVersion}
 	case LangGo:


### PR DESCRIPTION
This commit modifies the client generation to allow case insensitive
comparisions for the language when generating a client.