### PR TITLE
all: keep track of known apps persistently 

### DIFF
--- a/cli/cmd/encore/daemon/schema.sql
+++ b/cli/cmd/encore/daemon/schema.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    dummy BOOLEAN PRIMARY KEY,
+    version INT NOT NULL
+);
+
+INSERT OR REPLACE INTO schema_migrations(dummy, version) VALUES (true, 1);
+
+CREATE TABLE IF NOT EXISTS app (
+    root TEXT PRIMARY KEY,
+    local_id TEXT NOT NULL,
+    platform_id TEXT NULL, -- NULL if not linked
+    updated_at TEXT NOT NULL
+);

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -1,0 +1,140 @@
+package apps
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
+
+	"encr.dev/cli/daemon/internal/manifest"
+	"encr.dev/cli/internal/appfile"
+)
+
+var ErrNotFound = errors.New("app not found")
+
+// Instance describes an app instance known by the Encore daemon.
+type Instance struct {
+	root       string
+	localID    string
+	platformID string
+}
+
+func NewInstance(root, localID, platformID string) *Instance {
+	return &Instance{root, localID, platformID}
+}
+
+// Root returns the filesystem path for the app root.
+// It always returns a non-empty string.
+func (i *Instance) Root() string { return i.root }
+
+// LocalID reports a local, random id unique for this app,
+// as persisted in the .encore/manifest.json file.
+// It always returns a non-empty string.
+func (i *Instance) LocalID() string { return i.localID }
+
+// PlatformID reports the Encore Platform's ID for this app.
+// If the app is not linked it reports the empty string.
+func (i *Instance) PlatformID() string { return i.platformID }
+
+// PlatformOrLocalID reports PlatformID() if set and otherwise LocalID().
+func (i *Instance) PlatformOrLocalID() string {
+	if i.platformID != "" {
+		return i.platformID
+	}
+	return i.localID
+}
+
+func NewManager(db *sql.DB) *Manager {
+	return &Manager{db: db, instances: make(map[string]*Instance)}
+}
+
+// Manager keeps track of known apps and watches them for changes.
+type Manager struct {
+	db *sql.DB
+
+	mu        sync.Mutex
+	instances map[string]*Instance // root -> instance
+}
+
+// Track begins tracking an app, and marks it as updated
+// if the app is already tracked.
+func (mgr *Manager) Track(appRoot string) (*Instance, error) {
+	app, err := mgr.resolve(appRoot)
+	if err != nil {
+		return nil, err
+	}
+	_, err = mgr.db.Exec(`
+		INSERT OR REPLACE INTO app (root, local_id, platform_id, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, app.root, app.localID, app.platformID, time.Now())
+	if err != nil {
+		return nil, errors.Wrap(err, "update app store")
+	}
+	log.Info().Str("app_id", app.PlatformOrLocalID()).Msg("tracking app")
+	return app, nil
+}
+
+// FindLatestByPlatformID finds the most recently updated app instance with the given platformID.
+// If no such app is found it reports an error matching ErrNotFound.
+func (mgr *Manager) FindLatestByPlatformID(platformID string) (*Instance, error) {
+	var root string
+	err := mgr.db.QueryRow(`
+		SELECT root
+		FROM app
+		WHERE platform_id = ?
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`, platformID).Scan(&root)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, errors.WithStack(ErrNotFound)
+	} else if err != nil {
+		return nil, errors.Wrap(err, "query app store")
+	}
+
+	return mgr.resolve(root)
+}
+
+// resolve resolves the current information about the app located at appRoot.
+// If the app does not exist (either because appRoot does not exist,
+// or because encore.app does not exist within it), it reports an error
+// matching fs.ErrNotExist.
+func (mgr *Manager) resolve(appRoot string) (*Instance, error) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	if existing, ok := mgr.instances[appRoot]; ok {
+		return existing, nil
+	}
+
+	// Parse the encore.app file
+	var encore *appfile.File
+	{
+		path := filepath.Join(appRoot, appfile.Name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		encore, err = appfile.Parse(data)
+		if err != nil {
+			return nil, errors.Wrap(err, "parse encore.app")
+		}
+	}
+
+	// Parse the manifest file
+	man, err := manifest.ReadOrCreate(appRoot)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse manifest")
+	}
+
+	i := &Instance{
+		root:       appRoot,
+		localID:    man.LocalID,
+		platformID: encore.ID,
+	}
+	mgr.instances[appRoot] = i
+	return i, nil
+}

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -49,10 +49,10 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		apps := []app{} // prevent marshalling as null
 		seen := make(map[string]bool)
 		for _, r := range runs {
-			id := r.AppID
-			name := r.AppSlug
+			id := r.App.PlatformOrLocalID()
+			name := r.App.PlatformID()
 			if name == "" {
-				name = filepath.Base(r.Root)
+				name = filepath.Base(r.App.Root())
 			}
 			if !seen[id] {
 				seen[id] = true
@@ -105,7 +105,7 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 
 		return reply(ctx, map[string]interface{}{
 			"running": true,
-			"appID":   run.AppID,
+			"appID":   run.App.PlatformOrLocalID(),
 			"pid":     run.ID,
 			"meta":    json.RawMessage(str),
 			"addr":    run.ListenAddr,
@@ -250,7 +250,7 @@ func (s *Server) OnStart(r *run.Run) {
 	s.notify(&notification{
 		Method: "process/start",
 		Params: map[string]interface{}{
-			"appID": r.AppID,
+			"appID": r.App.PlatformOrLocalID(),
 			"pid":   r.ID,
 			"addr":  r.ListenAddr,
 			"meta":  json.RawMessage(str),
@@ -270,7 +270,7 @@ func (s *Server) OnReload(r *run.Run) {
 	s.notify(&notification{
 		Method: "process/reload",
 		Params: map[string]interface{}{
-			"appID": r.AppID,
+			"appID": r.App.PlatformOrLocalID(),
 			"pid":   r.ID,
 			"meta":  json.RawMessage(str),
 		},
@@ -282,7 +282,7 @@ func (s *Server) OnStop(r *run.Run) {
 	s.notify(&notification{
 		Method: "process/stop",
 		Params: map[string]interface{}{
-			"appID": r.AppID,
+			"appID": r.App.PlatformOrLocalID(),
 			"pid":   r.ID,
 		},
 	})
@@ -305,7 +305,7 @@ func (s *Server) onOutput(r *run.Run, out []byte) {
 	s.notify(&notification{
 		Method: "process/output",
 		Params: map[string]interface{}{
-			"appID":  r.AppID,
+			"appID":  r.App.PlatformOrLocalID(),
 			"pid":    r.ID,
 			"output": out2,
 		},

--- a/cli/daemon/dash/trace.go
+++ b/cli/daemon/dash/trace.go
@@ -570,7 +570,7 @@ func (tp *traceParser) stack(s *tracepb.StackTrace) Stack {
 		}
 		st.Frames = append(st.Frames, StackFrame{
 			FullFile:  f.Filename,
-			ShortFile: shortenFilename(tp.meta.AppRoot, f.Filename, f.Func),
+			ShortFile: shortenFilename(tp.meta.App.Root(), f.Filename, f.Func),
 			Func:      shortenFunc(f.Func),
 			Line:      int(f.Line),
 		})

--- a/cli/daemon/engine/runtime.go
+++ b/cli/daemon/engine/runtime.go
@@ -71,12 +71,11 @@ func (s *server) RecordTrace(w http.ResponseWriter, req *http.Request) {
 	}
 
 	tm := &trace.TraceMeta{
-		ID:      traceID,
-		Reqs:    reqs,
-		AppID:   proc.Run.AppID,
-		AppRoot: proc.Run.Root,
-		Date:    time.Now(),
-		Meta:    proc.Meta,
+		ID:   traceID,
+		Reqs: reqs,
+		App:  proc.Run.App,
+		Date: time.Now(),
+		Meta: proc.Meta,
 	}
 
 	err = s.ts.Store(req.Context(), tm)

--- a/cli/daemon/engine/trace/trace.go
+++ b/cli/daemon/engine/trace/trace.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"encr.dev/cli/daemon/apps"
 	"encr.dev/cli/daemon/run"
 	tracepb "encr.dev/proto/encore/engine/trace"
 	metapb "encr.dev/proto/encore/parser/meta/v1"
@@ -21,13 +22,12 @@ import (
 type ID [16]byte
 
 type TraceMeta struct {
-	ID      ID
-	Reqs    []*tracepb.Request
-	AppID   string
-	AppRoot string
-	EnvID   string
-	Date    time.Time
-	Meta    *metapb.Data
+	ID    ID
+	Reqs  []*tracepb.Request
+	App   *apps.Instance
+	EnvID string
+	Date  time.Time
+	Meta  *metapb.Data
 }
 
 // A Store stores traces received from running applications.
@@ -53,8 +53,9 @@ func (st *Store) Listen(ch chan<- *TraceMeta) {
 }
 
 func (st *Store) Store(ctx context.Context, tr *TraceMeta) error {
+	appID := tr.App.PlatformOrLocalID()
 	st.trmu.Lock()
-	st.traces[tr.AppID] = append(st.traces[tr.AppID], tr)
+	st.traces[appID] = append(st.traces[appID], tr)
 	st.trmu.Unlock()
 
 	st.lnmu.Lock()

--- a/cli/daemon/run/http.go
+++ b/cli/daemon/run/http.go
@@ -22,7 +22,7 @@ func (r *Run) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if endpoint == "" {
 		// If this appears to be a browser, serve a redirect to the dashboard.
 		// Otherwise, give a helpful error message for terminals and such.
-		dashURL := fmt.Sprintf("http://localhost:%d/%s", r.mgr.DashPort, r.AppID)
+		dashURL := fmt.Sprintf("http://localhost:%d/%s", r.mgr.DashPort, r.App.PlatformOrLocalID())
 		if ua := req.Header.Get("User-Agent"); strings.Contains(ua, "Gecko") {
 			http.Redirect(w, req, dashURL, http.StatusFound)
 			return

--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -54,7 +54,7 @@ func (mgr *Manager) FindRunByAppID(appID string) *Run {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 	for _, run := range mgr.runs {
-		if run.AppID == appID {
+		if appID == run.App.PlatformID() || appID == run.App.LocalID() {
 			select {
 			case <-run.Done():
 				// exited
@@ -75,7 +75,7 @@ func (mgr *Manager) ListRuns() []*Run {
 	}
 	mgr.mu.Unlock()
 
-	sort.Slice(runs, func(i, j int) bool { return runs[i].AppID < runs[j].AppID })
+	sort.Slice(runs, func(i, j int) bool { return runs[i].App.PlatformOrLocalID() < runs[j].App.PlatformOrLocalID() })
 	return runs
 }
 

--- a/cli/daemon/run/testdata/echo/go.mod
+++ b/cli/daemon/run/testdata/echo/go.mod
@@ -2,4 +2,4 @@ module encore.app
 
 go 1.18
 
-require "encore.dev" v0.0.0
+require "encore.dev" v1.1.0

--- a/cli/daemon/run/watch.go
+++ b/cli/daemon/run/watch.go
@@ -11,7 +11,7 @@ import (
 // them on c.
 func (mgr *Manager) watch(run *Run) error {
 	evs := make(chan notify.EventInfo)
-	if err := notify.Watch(filepath.Join(run.Root, "..."), evs, notify.All); err != nil {
+	if err := notify.Watch(filepath.Join(run.App.Root(), "..."), evs, notify.All); err != nil {
 		return err
 	}
 
@@ -26,7 +26,7 @@ func (mgr *Manager) watch(run *Run) error {
 			case <-run.Done():
 				return
 			case ev := <-evs:
-				if ignoreEvent(run.Root, ev) {
+				if ignoreEvent(ev) {
 					continue
 				}
 				// We've seen that some editors like vim rename the .go files to another extension,
@@ -46,7 +46,7 @@ func (mgr *Manager) watch(run *Run) error {
 	return nil
 }
 
-func ignoreEvent(appRoot string, ev notify.EventInfo) bool {
+func ignoreEvent(ev notify.EventInfo) bool {
 	path := ev.Path()
 
 	// Ignore non-Go files

--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -21,8 +21,9 @@ import (
 
 // Cluster represents a running database Cluster.
 type Cluster struct {
-	ID    string // cluster ID
-	Memfs bool   // use an in-memory filesystem?
+	ID       ClusterID // cluster ID
+	Memfs    bool      // use an in-memory filesystem?
+	Password string    // randomly generated password for this cluster
 
 	driver Driver
 	log    zerolog.Logger

--- a/cli/daemon/sqldb/driver.go
+++ b/cli/daemon/sqldb/driver.go
@@ -18,10 +18,10 @@ type Driver interface {
 
 	// DestroyCluster destroys a cluster with the given id.
 	// If a Driver doesn't support destroying the cluster it reports ErrUnsupported.
-	DestroyCluster(ctx context.Context, clusterID string) error
+	DestroyCluster(ctx context.Context, id ClusterID) error
 
 	// ClusterStatus reports the current status of a cluster.
-	ClusterStatus(ctx context.Context, clusterID string) (*ClusterStatus, error)
+	ClusterStatus(ctx context.Context, id ClusterID) (*ClusterStatus, error)
 }
 
 type ConnConfig struct {
@@ -35,10 +35,16 @@ type ConnConfig struct {
 	RootDatabase string // root database to connect to
 }
 
+type ClusterType string
+
+const (
+	Run  ClusterType = "run"
+	Test ClusterType = "test"
+)
+
 // CreateParams are the params to (*ClusterManager).Create.
 type CreateParams struct {
-	// ClusterID is the unique id of the cluster.
-	ClusterID string
+	ClusterID ClusterID
 
 	// Memfs, if true, configures the database container to use an
 	// in-memory filesystem as opposed to persisting the database to disk.

--- a/cli/daemon/sqldb/external/external.go
+++ b/cli/daemon/sqldb/external/external.go
@@ -23,7 +23,7 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 	return d.ClusterStatus(ctx, p.ClusterID)
 }
 
-func (d *Driver) ClusterStatus(ctx context.Context, clusterID string) (*sqldb.ClusterStatus, error) {
+func (d *Driver) ClusterStatus(ctx context.Context, id sqldb.ClusterID) (*sqldb.ClusterStatus, error) {
 	st := &sqldb.ClusterStatus{
 		Status: sqldb.Running,
 		Config: &sqldb.ConnConfig{
@@ -39,7 +39,7 @@ func (d *Driver) ClusterStatus(ctx context.Context, clusterID string) (*sqldb.Cl
 	return st, nil
 }
 
-func (d *Driver) DestroyCluster(ctx context.Context, clusterID string) error {
+func (d *Driver) DestroyCluster(ctx context.Context, id sqldb.ClusterID) error {
 	return sqldb.ErrUnsupported
 }
 

--- a/cli/daemon/sqldb/manager.go
+++ b/cli/daemon/sqldb/manager.go
@@ -2,11 +2,15 @@ package sqldb
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"sync"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
+
+	"encr.dev/cli/daemon/apps"
 )
 
 // NewClusterManager creates a new ClusterManager.
@@ -15,7 +19,7 @@ func NewClusterManager(driver Driver) *ClusterManager {
 	return &ClusterManager{
 		log:            log,
 		driver:         driver,
-		clusters:       make(map[string]*Cluster),
+		clusters:       make(map[clusterKey]*Cluster),
 		backendKeyData: make(map[uint32]*Cluster),
 	}
 }
@@ -27,21 +31,31 @@ type ClusterManager struct {
 	startGroup singleflight.Group
 
 	mu       sync.Mutex
-	clusters map[string]*Cluster // cluster id -> cluster
+	clusters map[clusterKey]*Cluster
 	// backendKeyData maps the secret data to a cluster,
 	// for forwarding cancel requests to the right cluster.
 	// Access is guarded by mu.
 	backendKeyData map[uint32]*Cluster
 }
 
+// ClusterID uniquely identifies a cluster.
+type ClusterID struct {
+	App  *apps.Instance
+	Type ClusterType
+}
+
+func GetClusterID(app *apps.Instance, typ ClusterType) ClusterID {
+	return ClusterID{app, typ}
+}
+
 // Create creates a database cluster but does not start it.
 // If the cluster already exists it is returned.
 // It does not perform any database migrations.
 func (cm *ClusterManager) Create(ctx context.Context, params *CreateParams) *Cluster {
-	cid := params.ClusterID
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
-	c, ok := cm.clusters[cid]
+
+	c, ok := cm.get(params.ClusterID)
 	if ok {
 		if status, err := c.Status(ctx); err != nil || status.Status != Running {
 			// The cluster is no longer running; recreate it to clear our cached state.
@@ -49,27 +63,77 @@ func (cm *ClusterManager) Create(ctx context.Context, params *CreateParams) *Clu
 			ok = false
 		}
 	}
+
 	if !ok {
 		ctx, cancel := context.WithCancel(context.Background())
+		key := clusterKeys(params.ClusterID)[0] // guaranteed to be non-empty
+		passwd := genPassword()
 		c = &Cluster{
-			ID:      params.ClusterID,
-			Memfs:   params.Memfs,
-			Ctx:     ctx,
-			driver:  cm.driver,
-			cancel:  cancel,
-			started: make(chan struct{}),
-			log:     cm.log.With().Str("cluster", params.ClusterID).Logger(),
-			dbs:     make(map[string]*DB),
+			ID:       params.ClusterID,
+			Memfs:    params.Memfs,
+			Password: passwd,
+			Ctx:      ctx,
+			driver:   cm.driver,
+			cancel:   cancel,
+			started:  make(chan struct{}),
+			log:      cm.log.With().Interface("cluster", params.ClusterID).Logger(),
+			dbs:      make(map[string]*DB),
 		}
-		cm.clusters[cid] = c
+
+		cm.clusters[key] = c
 	}
+
 	return c
 }
 
-// Get retrieves the cluster keyed by id.
-func (cm *ClusterManager) Get(clusterID string) (*Cluster, bool) {
+// LookupPassword looks up a cluster based on its password.
+func (cm *ClusterManager) LookupPassword(password string) (*Cluster, bool) {
 	cm.mu.Lock()
-	c, ok := cm.clusters[clusterID]
-	cm.mu.Unlock()
-	return c, ok
+	defer cm.mu.Unlock()
+
+	for _, c := range cm.clusters {
+		if c.Password == password {
+			return c, true
+		}
+	}
+	return nil, false
+}
+
+// Get retrieves the cluster keyed by id.
+func (cm *ClusterManager) Get(id ClusterID) (*Cluster, bool) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	return cm.get(id)
+}
+
+// get retrieves the cluster keyed by id.
+// cm.mu must be held.
+func (cm *ClusterManager) get(id ClusterID) (*Cluster, bool) {
+	for _, key := range clusterKeys(id) {
+		if c, ok := cm.clusters[key]; ok {
+			return c, true
+		}
+	}
+	return nil, false
+}
+
+type clusterKey string
+
+// clusterKeys computes clusterKey candidates for a given id.
+func clusterKeys(id ClusterID) []clusterKey {
+	suffix := "-" + string(id.Type)
+	var keys []clusterKey
+	if pid := id.App.PlatformID(); pid != "" {
+		keys = append(keys, clusterKey(pid+suffix))
+	}
+	keys = append(keys, clusterKey(id.App.LocalID()+suffix))
+	return keys
+}
+
+func genPassword() string {
+	var data [8]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		log.Fatal().Err(err).Msg("unable to generate random data")
+	}
+	return base64.RawURLEncoding.EncodeToString(data[:])
 }

--- a/cli/daemon/sqldb/utils.go
+++ b/cli/daemon/sqldb/utils.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4"
+
+	meta "encr.dev/proto/encore/parser/meta/v1"
 )
 
 // WaitForConn waits for a successful connection to uri to be established.
@@ -28,4 +30,14 @@ func WaitForConn(ctx context.Context, uri string) error {
 		time.Sleep(250 * time.Millisecond)
 	}
 	return fmt.Errorf("database did not come up: %v", err)
+}
+
+// IsUsed reports whether the application uses SQL databases at all.
+func IsUsed(md *meta.Data) bool {
+	for _, svc := range md.Svcs {
+		if len(svc.Migrations) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module encr.dev
 go 1.18
 
 require (
-	encore.dev v0.0.0
+	encore.dev v0.0.0-00010101000000-000000000000
 	github.com/AlecAivazis/survey/v2 v2.3.4
 	github.com/alecthomas/chroma v0.10.0
 	github.com/briandowns/spinner v1.18.1
@@ -64,7 +64,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/felixge/httpsnoop v1.0.2 // indirect
+	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -96,7 +96,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
+	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.34.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module encr.dev
 go 1.18
 
 require (
-	encore.dev v0.0.0-00010101000000-000000000000
+	encore.dev v1.1.0
 	github.com/AlecAivazis/survey/v2 v2.3.4
 	github.com/alecthomas/chroma v0.10.0
 	github.com/briandowns/spinner v1.18.1
@@ -84,6 +84,7 @@ require (
 	github.com/lib/pq v1.10.5 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-sqlite3 v1.14.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mdlayher/genetlink v1.2.0 // indirect
 	github.com/mdlayher/netlink v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1038,6 +1038,8 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.13 h1:1tj15ngiFfcZzii7yd82foL+ks+ouQcj8j/TPq3fk1I=
+github.com/mattn/go-sqlite3 v1.14.13/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
-github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -1238,8 +1238,9 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
+github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
To support dependency injection Encore needs to generate code that is
written into the app's file tree so that editors can pick it up.

It would be frustrating if the code generation was only enabled after
running 'encore run', but the daemon had no way of knowing the location
of Encore apps on the local filesystem.

Fix this by introducing a local sqlite db that tracks known Encore apps
on the local filesystem. We can then use this to watch the filesystem for
changes to the known Encore apps and trigger code generation even without
having to run 'encore run'.