### PR TITLE
compiler/internal/codegen: Skip auth validation for empty auth params

### DIFF
--- a/cli/daemon/run/run_test.go
+++ b/cli/daemon/run/run_test.go
@@ -281,6 +281,20 @@ func TestEndToEndWithApp(t *testing.T) {
 			c.Assert(w.Code, qt.Equals, 200)
 		}
 
+		// Call an endpoint with an invalid auth parameter
+		{
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/echo.NilResponse", nil)
+			req.Header.Add("x-auth-int", "invalid")
+			run.ServeHTTP(w, req)
+			c.Assert(w.Code, qt.Equals, 400)
+			c.Assert(w.Body.Bytes(), qt.JSONEquals, map[string]any{
+				"code":    "invalid_argument",
+				"details": nil,
+				"message": "invalid auth param: x-auth-int: invalid parameter: strconv.ParseInt: parsing \"invalid\": invalid syntax",
+			})
+		}
+
 		// Call an endpoint without request parameters and response value
 		{
 			w := httptest.NewRecorder()

--- a/cli/daemon/run/testdata/echo/echo/echo.go
+++ b/cli/daemon/run/testdata/echo/echo/echo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -166,6 +167,7 @@ func AppMeta(ctx context.Context) (*AppMetadata, error) {
 
 type AuthParams struct {
 	Header        string `header:"X-Header"`
+	AuthInt       int    `header:"X-Auth-Int"`
 	Authorization string `header:"Authorization"`
 	Query         []int  `query:"query"`
 	NewAuth       bool   `query:"new-auth"`
@@ -173,6 +175,9 @@ type AuthParams struct {
 
 //encore:authhandler
 func AuthHandler(ctx context.Context, params *AuthParams) (auth.UID, *AuthParams, error) {
+	if reflect.ValueOf(params).Elem().IsZero() {
+		panic("zero value auth params should skip authhandler")
+	}
 	if params.Authorization == "Bearer tokendata" && params.NewAuth == false {
 		return "user", params, nil
 	}

--- a/cli/daemon/run/testdata/echo_client/client.ts
+++ b/cli/daemon/run/testdata/echo_client/client.ts
@@ -69,6 +69,7 @@ export namespace echo {
 
     export interface AuthParams {
         Header: string
+        AuthInt: number
         Authorization: string
         Query: number[]
         NewAuth: boolean
@@ -643,6 +644,7 @@ class BaseClient {
             query["query"] = authData.Query.map((v) => String(v))
             query["new-auth"] = String(authData.NewAuth)
             init.headers["x-header"] = authData.Header
+            init.headers["x-auth-int"] = String(authData.AuthInt)
             init.headers["authorization"] = authData.Authorization
         }
 

--- a/cli/daemon/run/testdata/echo_client/main.go
+++ b/cli/daemon/run/testdata/echo_client/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	// Test auth handlers
 	_, err = api.Test.TestAuthHandler(ctx)
-	assertStructuredError(err, client.ErrUnauthenticated, "invalid token")
+	assertStructuredError(err, client.ErrUnauthenticated, "missing auth param")
 
 	// Test with static auth data
 	{

--- a/cli/daemon/run/testdata/echo_client/main.ts
+++ b/cli/daemon/run/testdata/echo_client/main.ts
@@ -93,7 +93,7 @@ const mResp = await api.test.MarshallerTestHandler(params)
 deepEqual(mResp, params, "Expected the same response from the marshaller test")
 
 // Test auth handlers
-await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated, "invalid token")
+await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated, "missing auth param")
 
 // Test with static auth data
 {
@@ -101,6 +101,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
     "http://" + process.argv[2] as BaseURL,
     {
       auth: {
+        AuthInt:        34,
         Authorization: "Bearer tokendata",
         NewAuth:        false,
         Header:        "",
@@ -122,6 +123,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
       auth: (): echo.AuthParams => {
         return {
           Authorization: "Bearer " + tokenToReturn,
+          AuthInt:        34,
           NewAuth:        false,
           Header:        "",
           Query:         [],
@@ -146,6 +148,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
     {
       auth: {
         Authorization: "",
+        AuthInt:        34,
         NewAuth:        true,
         Header:        "102",
         Query:         [42, 100, -50, 10],
@@ -163,6 +166,7 @@ await assertStructuredError(api.test.TestAuthHandler(), ErrCode.Unauthenticated,
     "http://" + process.argv[2] as BaseURL,
     {
       auth: {
+        AuthInt:        34,
         Authorization: "Bearer tokendata",
         NewAuth:        false,
         Header:        "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -205,16 +205,10 @@ func (validationDetails) ErrDetails() {}
 // If requireAuth is false, it reports ("", nil, true) on authentication failure.
 func __encore_authenticate(w http.ResponseWriter, req *http.Request, requireAuth bool, svcName, rpcName string) (uid auth.UID, authData interface{}, proceed bool) {
 	param, err := __encore_resolveAuthParam(req)
-	if err != nil {
-		if requireAuth {
-			runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth")
-			errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err())
-			return "", nil, false
-		}
-		return "", nil, true
-	}
 
-	uid, authData, err = __encore_validateToken(req.Context(), param)
+	if err == nil {
+		uid, authData, err = __encore_validateToken(req.Context(), param)
+	}
 	if errs.Code(err) == errs.Unauthenticated && !requireAuth {
 		return "", nil, true
 	} else if err != nil {
@@ -231,11 +225,14 @@ func __encore_resolveAuthParam(req *http.Request) (param *svc.AuthHeaders, err e
 	dec := &marshaller{}
 	// Decode Headers
 	h := req.Header
-	params.Header1 = h.Get("header1")
+	params.Header1 = dec.ToString("header1", h.Get("header1"), false)
 	params.Header2 = dec.ToInt("header2", h.Get("header2"), false)
 
 	if dec.LastError != nil {
-		return nil, dec.LastError
+		return nil, errs.B().Code(errs.InvalidArgument).Msgf("invalid auth param: %v", dec.LastError).Err()
+	}
+	if dec.NonEmptyValues == 0 {
+		return nil, errs.B().Code(errs.Unauthenticated).Msg("missing auth param").Err()
 	}
 	return params, nil
 }
@@ -285,13 +282,15 @@ func __encore_validateToken(ctx context.Context, param *svc.AuthHeaders) (uid au
 
 // marshaller is used to serialize request data into strings and deserialize response data from strings
 type marshaller struct {
-	LastError error // The last error that occurred
+	LastError      error // The last error that occurred
+	NonEmptyValues int   // The number of values this decoder has decoded
 }
 
 func (e *marshaller) ToString(field string, s string, required bool) (v string) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	return s
 }
 
@@ -299,6 +298,7 @@ func (e *marshaller) ToInt(field string, s string, required bool) (v int) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	x, err := strconv.ParseInt(s, 10, 64)
 	e.setErr("invalid parameter", field, err)
 	return int(x)

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -205,16 +205,10 @@ func (validationDetails) ErrDetails() {}
 // If requireAuth is false, it reports ("", nil, true) on authentication failure.
 func __encore_authenticate(w http.ResponseWriter, req *http.Request, requireAuth bool, svcName, rpcName string) (uid auth.UID, authData interface{}, proceed bool) {
 	param, err := __encore_resolveAuthParam(req)
-	if err != nil {
-		if requireAuth {
-			runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth")
-			errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err())
-			return "", nil, false
-		}
-		return "", nil, true
-	}
 
-	uid, authData, err = __encore_validateToken(req.Context(), param)
+	if err == nil {
+		uid, authData, err = __encore_validateToken(req.Context(), param)
+	}
 	if errs.Code(err) == errs.Unauthenticated && !requireAuth {
 		return "", nil, true
 	} else if err != nil {
@@ -231,11 +225,14 @@ func __encore_resolveAuthParam(req *http.Request) (param *svc.AuthQuery, err err
 	dec := &marshaller{}
 	// Decode Query String
 	qs := req.URL.Query()
-	params.Query1 = qs.Get("query1")
+	params.Query1 = dec.ToString("query1", qs.Get("query1"), false)
 	params.Query2 = dec.ToInt("query2", qs.Get("query2"), false)
 
 	if dec.LastError != nil {
-		return nil, dec.LastError
+		return nil, errs.B().Code(errs.InvalidArgument).Msgf("invalid auth param: %v", dec.LastError).Err()
+	}
+	if dec.NonEmptyValues == 0 {
+		return nil, errs.B().Code(errs.Unauthenticated).Msg("missing auth param").Err()
 	}
 	return params, nil
 }
@@ -285,13 +282,15 @@ func __encore_validateToken(ctx context.Context, param *svc.AuthQuery) (uid auth
 
 // marshaller is used to serialize request data into strings and deserialize response data from strings
 type marshaller struct {
-	LastError error // The last error that occurred
+	LastError      error // The last error that occurred
+	NonEmptyValues int   // The number of values this decoder has decoded
 }
 
 func (e *marshaller) ToString(field string, s string, required bool) (v string) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	return s
 }
 
@@ -299,6 +298,7 @@ func (e *marshaller) ToInt(field string, s string, required bool) (v int) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	x, err := strconv.ParseInt(s, 10, 64)
 	e.setErr("invalid parameter", field, err)
 	return int(x)

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -9,7 +9,6 @@ import (
 	"encore.dev/runtime"
 	"encore.dev/runtime/config"
 	serde "encore.dev/runtime/serde"
-	"errors"
 	"fmt"
 	"github.com/json-iterator/go"
 	"github.com/julienschmidt/httprouter"
@@ -206,16 +205,10 @@ func (validationDetails) ErrDetails() {}
 // If requireAuth is false, it reports ("", nil, true) on authentication failure.
 func __encore_authenticate(w http.ResponseWriter, req *http.Request, requireAuth bool, svcName, rpcName string) (uid auth.UID, authData interface{}, proceed bool) {
 	param, err := __encore_resolveAuthParam(req)
-	if err != nil {
-		if requireAuth {
-			runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth")
-			errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err())
-			return "", nil, false
-		}
-		return "", nil, true
-	}
 
-	uid, authData, err = __encore_validateToken(req.Context(), param)
+	if err == nil {
+		uid, authData, err = __encore_validateToken(req.Context(), param)
+	}
 	if errs.Code(err) == errs.Unauthenticated && !requireAuth {
 		return "", nil, true
 	} else if err != nil {
@@ -237,7 +230,7 @@ func __encore_resolveAuthParam(req *http.Request) (param string, err error) {
 			}
 		}
 	}
-	return "", errors.New("missing auth token")
+	return "", errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err()
 }
 
 // __encore_validateToken validates an auth token.
@@ -281,13 +274,15 @@ func __encore_validateToken(ctx context.Context, param string) (uid auth.UID, au
 
 // marshaller is used to serialize request data into strings and deserialize response data from strings
 type marshaller struct {
-	LastError error // The last error that occurred
+	LastError      error // The last error that occurred
+	NonEmptyValues int   // The number of values this decoder has decoded
 }
 
 func (e *marshaller) ToString(field string, s string, required bool) (v string) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	return s
 }
 

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -190,7 +190,7 @@ func __encore_svc_Five(w http.ResponseWriter, req *http.Request, ps httprouter.P
 	case "GET":
 		// Decode Query String
 		qs := req.URL.Query()
-		params.Name = qs.Get("name")
+		params.Name = dec.ToString("name", qs.Get("name"), false)
 
 	case "POST":
 		// Decode JSON Body
@@ -415,7 +415,15 @@ func __encore_svc_Nine(w http.ResponseWriter, req *http.Request, ps httprouter.P
 		respData = append(respData, '\n')
 
 		// Encode headers
-		headers = map[string][]string{"x-header": {resp.Header}}
+		headerEncoder := &marshaller{}
+		headers = map[string][]string{"x-header": {headerEncoder.FromString(resp.Header)}}
+		if headerEncoder.LastError != nil {
+			headerErr := errs.WrapCode(headerEncoder.LastError, errs.Internal, "failed to marshal headers")
+			runtime.FinishRequest(nil, headerErr)
+			errs.HTTPError(w, headerErr)
+			return
+		}
+
 	}
 
 	// Record tracing data
@@ -501,7 +509,7 @@ func __encore_svc_Query(w http.ResponseWriter, req *http.Request, ps httprouter.
 		params.JSON = dec.ToJSON("json", qs.Get("json"), false)
 		params.Float32 = dec.ToFloat32("float32", qs.Get("float32"), false)
 		params.Float64 = dec.ToFloat64("float64", qs.Get("float64"), false)
-		params.Strings = qs["strings"]
+		params.Strings = dec.ToStringList("strings", qs["strings"], false)
 		params.Times = dec.ToTimeList("times", qs["times"], false)
 
 	default:
@@ -643,7 +651,7 @@ func __encore_svc_Six(w http.ResponseWriter, req *http.Request, ps httprouter.Pa
 	case "GET":
 		// Decode Query String
 		qs := req.URL.Query()
-		params.Name = qs.Get("name")
+		params.Name = dec.ToString("name", qs.Get("name"), false)
 
 	case "POST":
 		// Decode JSON Body
@@ -770,7 +778,15 @@ func __encore_svc_Ten(w http.ResponseWriter, req *http.Request, ps httprouter.Pa
 	if resp != nil {
 
 		// Encode headers
-		headers = map[string][]string{"x-header": {resp.Header}}
+		headerEncoder := &marshaller{}
+		headers = map[string][]string{"x-header": {headerEncoder.FromString(resp.Header)}}
+		if headerEncoder.LastError != nil {
+			headerErr := errs.WrapCode(headerEncoder.LastError, errs.Internal, "failed to marshal headers")
+			runtime.FinishRequest(nil, headerErr)
+			errs.HTTPError(w, headerErr)
+			return
+		}
+
 	}
 
 	// Record tracing data
@@ -1074,16 +1090,10 @@ func (validationDetails) ErrDetails() {}
 // If requireAuth is false, it reports ("", nil, true) on authentication failure.
 func __encore_authenticate(w http.ResponseWriter, req *http.Request, requireAuth bool, svcName, rpcName string) (uid auth.UID, authData interface{}, proceed bool) {
 	param, err := __encore_resolveAuthParam(req)
-	if err != nil {
-		if requireAuth {
-			runtime.Logger().Info().Str("service", svcName).Str("endpoint", rpcName).Msg("rejecting request due to missing auth")
-			errs.HTTPError(w, errs.B().Code(errs.Unauthenticated).Msg("invalid auth param").Err())
-			return "", nil, false
-		}
-		return "", nil, true
-	}
 
-	uid, authData, err = __encore_validateToken(req.Context(), param)
+	if err == nil {
+		uid, authData, err = __encore_validateToken(req.Context(), param)
+	}
 	if errs.Code(err) == errs.Unauthenticated && !requireAuth {
 		return "", nil, true
 	} else if err != nil {
@@ -1100,18 +1110,21 @@ func __encore_resolveAuthParam(req *http.Request) (param *svc.AuthParams, err er
 	dec := &marshaller{}
 	// Decode Headers
 	h := req.Header
-	params.Header1 = h.Get("one")
+	params.Header1 = dec.ToString("one", h.Get("one"), false)
 	params.Header2 = dec.ToInt("two", h.Get("two"), false)
 	params.Header3 = dec.ToUint("three", h.Get("three"), false)
 
 	// Decode Query String
 	qs := req.URL.Query()
-	params.Query1 = qs.Get("one")
-	params.Query2 = qs["two"]
+	params.Query1 = dec.ToString("one", qs.Get("one"), false)
+	params.Query2 = dec.ToStringList("two", qs["two"], false)
 	params.Query3 = dec.ToTime("three", qs.Get("three"), false)
 
 	if dec.LastError != nil {
-		return nil, dec.LastError
+		return nil, errs.B().Code(errs.InvalidArgument).Msgf("invalid auth param: %v", dec.LastError).Err()
+	}
+	if dec.NonEmptyValues == 0 {
+		return nil, errs.B().Code(errs.Unauthenticated).Msg("missing auth param").Err()
 	}
 	return params, nil
 }
@@ -1161,13 +1174,15 @@ func __encore_validateToken(ctx context.Context, param *svc.AuthParams) (uid aut
 
 // marshaller is used to serialize request data into strings and deserialize response data from strings
 type marshaller struct {
-	LastError error // The last error that occurred
+	LastError      error // The last error that occurred
+	NonEmptyValues int   // The number of values this decoder has decoded
 }
 
 func (e *marshaller) ToString(field string, s string, required bool) (v string) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	return s
 }
 
@@ -1175,6 +1190,7 @@ func (e *marshaller) ToUUID(field string, s string, required bool) (v uuid.UUID)
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	v, err := uuid.FromString(s)
 	e.setErr("invalid parameter", field, err)
 	return v
@@ -1184,15 +1200,22 @@ func (e *marshaller) ToUint(field string, s string, required bool) (v uint) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	x, err := strconv.ParseUint(s, 10, 64)
 	e.setErr("invalid parameter", field, err)
 	return uint(x)
+}
+
+func (e *marshaller) FromString(s string) (v string) {
+	e.NonEmptyValues++
+	return s
 }
 
 func (e *marshaller) ToTime(field string, s string, required bool) (v time.Time) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	v, err := time.Parse(time.RFC3339, s)
 	e.setErr("invalid parameter", field, err)
 	return v
@@ -1202,6 +1225,7 @@ func (e *marshaller) ToUserID(field string, s string, required bool) (v auth.UID
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	return auth.UID(s)
 }
 
@@ -1209,6 +1233,7 @@ func (e *marshaller) ToJSON(field string, s string, required bool) (v stdjson.Ra
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	return stdjson.RawMessage(s)
 }
 
@@ -1216,6 +1241,7 @@ func (e *marshaller) ToFloat32(field string, s string, required bool) (v float32
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	x, err := strconv.ParseFloat(s, 32)
 	e.setErr("invalid parameter", field, err)
 	return float32(x)
@@ -1225,15 +1251,28 @@ func (e *marshaller) ToFloat64(field string, s string, required bool) (v float64
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	x, err := strconv.ParseFloat(s, 64)
 	e.setErr("invalid parameter", field, err)
 	return x
+}
+
+func (e *marshaller) ToStringList(field string, s []string, required bool) (v []string) {
+	if !required && len(s) == 0 {
+		return
+	}
+	e.NonEmptyValues++
+	for _, x := range s {
+		v = append(v, e.ToString(field, x, required))
+	}
+	return v
 }
 
 func (e *marshaller) ToTimeList(field string, s []string, required bool) (v []time.Time) {
 	if !required && len(s) == 0 {
 		return
 	}
+	e.NonEmptyValues++
 	for _, x := range s {
 		v = append(v, e.ToTime(field, x, required))
 	}
@@ -1244,6 +1283,7 @@ func (e *marshaller) ToInt(field string, s string, required bool) (v int) {
 	if !required && s == "" {
 		return
 	}
+	e.NonEmptyValues++
 	x, err := strconv.ParseInt(s, 10, 64)
 	e.setErr("invalid parameter", field, err)
 	return int(x)


### PR DESCRIPTION
This PR implements changes to only call the encore authhandler if at least one auth field is set. If an auth field is set, the authhandler will be called for *all* endpoints (including public ones). Unauthenticated errors will be ignored for all but 'auth' endpoints, whereas other errors (such as parsing error, other authhandler errors) will be returned to the caller.