### PR TITLE
Refactor resource service startup

### DIFF
--- a/cli/cmd/encore/daemon/daemon.go
+++ b/cli/cmd/encore/daemon/daemon.go
@@ -114,6 +114,7 @@ func (d *Daemon) init() {
 		DBProxyPort: tcpPort(d.DBProxy),
 		DashPort:    tcpPort(d.Dash),
 		Secret:      d.Secret,
+		ClusterMgr:  d.ClusterMgr,
 	}
 	d.DashSrv = dash.NewServer(d.RunMgr, d.Trace)
 

--- a/cli/cmd/encore/main.go
+++ b/cli/cmd/encore/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/rs/zerolog"
@@ -156,7 +157,7 @@ func streamCommandOutput(stream commandOutputStream, convertJSON bool) int {
 			case st.Code() == codes.FailedPrecondition:
 				fmt.Fprintln(os.Stderr, st.Message())
 				return 1
-			case err == io.EOF || st.Code() == codes.Canceled:
+			case err == io.EOF || st.Code() == codes.Canceled || strings.HasSuffix(err.Error(), "error reading from server: EOF"):
 				return 0
 			default:
 				log.Fatal().Err(err).Msg("connection failure")

--- a/cli/daemon/pubsub/nsq.go
+++ b/cli/daemon/pubsub/nsq.go
@@ -2,10 +2,12 @@ package pubsub
 
 import (
 	"os"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/nsqio/go-nsq"
 	"github.com/nsqio/nsq/nsqd"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go4.org/syncutil"
 )
@@ -26,7 +28,8 @@ func (n *NSQDaemon) Stats() (*nsqd.Stats, error) {
 }
 
 func (n *NSQDaemon) isReady() error {
-	p, err := nsq.NewProducer(n.Opts.TCPAddress, nsq.NewConfig())
+	p, err := nsq.NewProducer(n.Addr(), nsq.NewConfig())
+	p.SetLogger(&logAdapter{"nsq producer"}, nsq.LogLevelWarning)
 	if err != nil {
 		return err
 	}
@@ -34,6 +37,10 @@ func (n *NSQDaemon) isReady() error {
 	p.Stop()
 	n.nsqd.GetError()
 	return err
+}
+
+func (n *NSQDaemon) Addr() string {
+	return n.nsqd.RealTCPAddr().String()
 }
 
 func (n *NSQDaemon) Start() error {
@@ -45,6 +52,15 @@ func (n *NSQDaemon) Start() error {
 				return errors.Wrap(err, "failed to create tmp nsqd datapath")
 			}
 			n.Opts.DataPath = tmpDir
+
+			n.Opts.LogLevel = nsqd.LOG_WARN
+			n.Opts.Logger = &logAdapter{"nsqd"}
+
+			// Take the default address options and scope down to localhost (to prevent firewall warnings / permission requests)
+			// then set the port to 0 to allow any port to be used which is free
+			n.Opts.TCPAddress = "127.0.0.1:0"
+			n.Opts.HTTPAddress = "127.0.0.1:0"
+			n.Opts.HTTPSAddress = "127.0.0.1:0"
 		}
 		nsq, err := nsqd.New(n.Opts)
 		if err != nil {
@@ -65,5 +81,52 @@ func (n *NSQDaemon) Start() error {
 func (n *NSQDaemon) Stop() {
 	if n.nsqd != nil {
 		n.nsqd.Exit()
+	}
+}
+
+type logAdapter struct{ serviceName string }
+
+var _ nsqd.Logger = (*logAdapter)(nil)
+
+func (l *logAdapter) Output(maxdepth int, s string) error {
+	// Attempt to extract the level, start with cutting on ":"
+	lvl, logMsg, found := strings.Cut(s, ":")
+	if !found || strings.Contains(lvl, " ") {
+		// then if that fails or we have a space in that cut, try cutting on the first space
+		newLvl, suffix, _ := strings.Cut(lvl, " ")
+		lvl = newLvl
+
+		if found {
+			logMsg = suffix + ":" + logMsg
+		}
+	}
+
+	// Attempt to convert the level string to a zerolog level
+	logLevel := l.OutputLevel(lvl)
+	if logLevel == zerolog.NoLevel {
+		// and if that fails, then just log the message
+		logMsg = s
+	}
+
+	log.WithLevel(logLevel).Str("service", l.serviceName).Msg(strings.TrimSpace(logMsg))
+
+	return nil
+}
+
+func (l *logAdapter) OutputLevel(lvl string) zerolog.Level {
+	switch strings.ToLower(lvl) {
+	case "debug", "dbg":
+		return zerolog.DebugLevel
+	case "info", "inf":
+		return zerolog.InfoLevel
+	case "warn", "wrn":
+		return zerolog.WarnLevel
+	case "error", "err":
+		return zerolog.ErrorLevel
+	case "fatal":
+		return zerolog.FatalLevel
+	default:
+		log.Warn().Msg("unknown level: " + lvl)
+		return zerolog.NoLevel
 	}
 }

--- a/cli/daemon/run/async.go
+++ b/cli/daemon/run/async.go
@@ -1,0 +1,73 @@
+package run
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"encr.dev/internal/optracker"
+)
+
+type asyncBuildJobs struct {
+	ctx        context.Context
+	cancelCtx  context.CancelFunc
+	m          sync.Mutex
+	wait       sync.WaitGroup
+	firstError error
+	tracker    *optracker.OpTracker
+	start      time.Time
+	appID      string
+}
+
+func newAsyncBuildJobs(ctx context.Context, appID string, tracker *optracker.OpTracker) *asyncBuildJobs {
+	ctx, cancelCtx := context.WithCancel(ctx)
+
+	return &asyncBuildJobs{
+		ctx:       ctx,
+		cancelCtx: cancelCtx,
+		appID:     appID,
+		tracker:   tracker,
+		start:     time.Now(),
+	}
+}
+
+func (a *asyncBuildJobs) Go(description string, track bool, minDuration time.Duration, f func(ctx context.Context) error) {
+	a.wait.Add(1)
+
+	trackerID := optracker.NoOperationID
+	if track {
+		trackerID = a.tracker.Add(description, a.start)
+	}
+
+	go func() {
+		defer a.wait.Done()
+
+		log.Info().Str("app_id", a.appID).Str("job", description).Msg("starting build job")
+		if err := f(a.ctx); err != nil {
+			log.Err(err).Str("app_id", a.appID).Str("job", description).Msg("build job failed")
+			a.tracker.Fail(trackerID, err)
+			a.recordError(err)
+		} else {
+			a.tracker.Done(trackerID, minDuration)
+			log.Info().Str("app_id", a.appID).Str("job", description).Msg("build job finished")
+		}
+	}()
+}
+
+func (a *asyncBuildJobs) Wait() error {
+	a.wait.Wait()
+	return a.firstError
+}
+
+func (a *asyncBuildJobs) recordError(err error) {
+	a.m.Lock()
+	defer a.m.Unlock()
+
+	a.cancelCtx()
+
+	if a.firstError == nil {
+		a.firstError = err
+	}
+}

--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"encr.dev/cli/daemon/secret"
+	"encr.dev/cli/daemon/sqldb"
 )
 
 // Manager manages the set of running applications.
@@ -13,11 +14,11 @@ type Manager struct {
 	DBProxyPort int // port for sqldb proxy
 	DashPort    int // port for dev dashboard
 	Secret      *secret.Manager
+	ClusterMgr  *sqldb.ClusterManager
 
 	listeners []EventListener
-
-	mu   sync.Mutex
-	runs map[string]*Run // id -> run
+	mu        sync.Mutex
+	runs      map[string]*Run // id -> run
 }
 
 // EventListener is the interface for listening to events

--- a/cli/daemon/run/resources.go
+++ b/cli/daemon/run/resources.go
@@ -1,0 +1,153 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"encr.dev/cli/daemon/apps"
+	"encr.dev/cli/daemon/pubsub"
+	"encr.dev/cli/daemon/sqldb"
+	"encr.dev/cli/daemon/sqldb/docker"
+	"encr.dev/parser"
+	"encr.dev/parser/est"
+)
+
+// ResourceServices represent the set of servers/services we have started up
+// to support the running Encore application.
+type ResourceServices struct {
+	mutex   sync.Mutex
+	servers map[est.ResourceType]ResourceServer
+
+	app    *apps.Instance
+	sqlMgr *sqldb.ClusterManager
+	log    zerolog.Logger
+}
+
+func newResourceServices(app *apps.Instance, sqlMgr *sqldb.ClusterManager) *ResourceServices {
+	return &ResourceServices{
+		app:    app,
+		sqlMgr: sqlMgr,
+
+		servers: make(map[est.ResourceType]ResourceServer),
+		log:     log.With().Str("app_id", app.PlatformOrLocalID()).Logger(),
+	}
+}
+
+func (rs *ResourceServices) StopAll() {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+
+	rs.log.Info().Int("num", len(rs.servers)).Msg("Stopping all resource services")
+
+	for _, daemon := range rs.servers {
+		daemon.Stop()
+	}
+}
+
+type ResourceServer interface {
+	Stop() // Shutdown the resource
+}
+
+// StartRequiredServices will start the required services for the current application
+// if they are not already running based on the given parse result
+func (rs *ResourceServices) StartRequiredServices(a *asyncBuildJobs, parse *parser.Result) error {
+	if sqldb.IsUsed(parse.Meta) && rs.GetSQLCluster() == nil {
+		a.Go("Creating PostgreSQL database cluster", true, 300*time.Millisecond, rs.StartSQLCluster(a, parse))
+	}
+
+	if pubsub.IsUsed(parse.Meta) && rs.GetPubSub() == nil {
+		a.Go("Starting PubSub daemon", true, 250*time.Millisecond, rs.StartPubSub)
+	}
+
+	return nil
+}
+
+// StartPubSub starts a PubSub daemon if it is not already running
+func (rs *ResourceServices) StartPubSub(ctx context.Context) error {
+	nsqd := &pubsub.NSQDaemon{}
+	err := nsqd.Start()
+	if err != nil {
+		return err
+	}
+
+	rs.mutex.Lock()
+	rs.servers[est.PubSubTopicResource] = nsqd
+	rs.mutex.Unlock()
+	return nil
+}
+
+// GetPubSub returns the PubSub daemon if it is running otherwise it returns nil
+func (rs *ResourceServices) GetPubSub() *pubsub.NSQDaemon {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+
+	if daemon, found := rs.servers[est.PubSubTopicResource]; found {
+		return daemon.(*pubsub.NSQDaemon)
+	}
+	return nil
+}
+
+func (rs *ResourceServices) StartSQLCluster(a *asyncBuildJobs, parse *parser.Result) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+
+		cluster := rs.sqlMgr.Create(ctx, &sqldb.CreateParams{
+			ClusterID: sqldb.GetClusterID(rs.app, sqldb.Run),
+			Memfs:     false,
+		})
+		if _, err := exec.LookPath("docker"); err != nil {
+			return errors.New("This application requires docker to run since it uses an SQL database. Install docker first.")
+		}
+
+		log.Debug().Msg("checking if sqldb image exists")
+		if ok, err := docker.ImageExists(ctx); err == nil && !ok {
+			rs.log.Debug().Msg("pulling sqldb image")
+			pullOp := a.tracker.Add("Pulling PostgreSQL docker image", time.Now())
+			if err := docker.PullImage(ctx); err != nil {
+				rs.log.Error().Err(err).Msg("unable to pull sqldb image")
+				a.tracker.Fail(pullOp, err)
+			} else {
+				a.tracker.Done(pullOp, 0)
+				rs.log.Info().Msg("successfully pulled sqldb image")
+			}
+		} else if err != nil {
+			return fmt.Errorf("unable to check if sqldb image exists: %w", err)
+		}
+
+		if _, err := cluster.Start(ctx); err != nil {
+			return fmt.Errorf("unable to start sqldb cluster: %w", err)
+		}
+		rs.mutex.Lock()
+		rs.servers[est.SQLDBResource] = cluster
+		rs.mutex.Unlock()
+
+		// Set up the database asynchronously since it can take a while.
+		a.Go("Running database migrations", true, 250*time.Millisecond, func(ctx context.Context) error {
+			err := cluster.SetupAndMigrate(ctx, rs.app.Root(), parse.Meta)
+			if err != nil {
+				rs.log.Error().Err(err).Msg("failed to setup db")
+				return err
+			}
+			return nil
+		})
+
+		return nil
+	}
+}
+
+// GetSQLCluster returns the SQL cluster
+func (rs *ResourceServices) GetSQLCluster() *sqldb.Cluster {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+
+	if cluster, found := rs.servers[est.SQLDBResource]; found {
+		return cluster.(*sqldb.Cluster)
+	}
+	return nil
+}

--- a/cli/daemon/run/watch.go
+++ b/cli/daemon/run/watch.go
@@ -35,7 +35,7 @@ func (mgr *Manager) watch(run *Run) error {
 				// the user is busy working in their editor.
 				time.Sleep(100 * time.Millisecond)
 				mgr.runStdout(run, []byte("Changes detected, recompiling...\n"))
-				if _, err := run.Reload(); err != nil {
+				if err := run.Reload(); err != nil {
 					mgr.runStderr(run, []byte(err.Error()))
 				} else {
 					mgr.runStdout(run, []byte("Reloaded successfully.\n"))

--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -42,6 +42,10 @@ type Cluster struct {
 	dbs map[string]*DB // name -> db
 }
 
+func (c *Cluster) Stop() {
+	// no-op
+}
+
 // Ready returns a channel that is closed when the cluster is up and running.
 func (c *Cluster) Ready() <-chan struct{} {
 	return c.started

--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -142,7 +142,10 @@ func (b *Builder) Main() (f *File, err error) {
 	f.Line()
 
 	f.Func().Id("main").Params().Block(
-		If(Err().Op(":=").Qual("encore.dev/runtime", "ListenAndServe").Call(), Err().Op("!=").Nil()).Block(
+		If(
+			Err().Op(":=").Qual("encore.dev/runtime", "ListenAndServe").Call(),
+			Err().Op("!=").Nil().Op("&&").Err().Op("!=").Qual("io", "EOF"),
+		).Block(
 			Qual("encore.dev/runtime", "Logger").Call().Dot("Fatal").Call().
 				Dot("Err").Call(Err()).
 				Dot("Msg").Call(Lit("could not listen and serve")),

--- a/compiler/rewrite.go
+++ b/compiler/rewrite.go
@@ -88,7 +88,11 @@ func (b *builder) rewritePkg(pkg *est.Package, targetDir string) error {
 				ln := fset.Position(decl.Pos())
 				rw.Insert(decl.Pos(), []byte(fmt.Sprintf("import __encore_runtime %s\n/*line :%d:%d*/", strconv.Quote("encore.dev/runtime"), ln.Line, ln.Column)))
 				return true
-			case est.PubSubTopicDefNode:
+
+			case est.CronJobNode:
+				return true
+
+			case est.PubSubTopicDefNode, est.PubSubPublisherNode, est.PubSubSubscriberNode:
 				return true
 			default:
 				panic(fmt.Sprintf("unhandled rewrite type: %v", rewrite.Type))

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/mattn/go-sqlite3 v1.14.13
+	github.com/nsqio/go-nsq v1.1.0
 	github.com/nsqio/nsq v1.2.1
 	github.com/rjeczalik/notify v0.9.2
 	github.com/robfig/cron/v3 v3.0.1
@@ -98,7 +99,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nsqio/go-diskqueue v1.0.0 // indirect
-	github.com/nsqio/go-nsq v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect

--- a/internal/optracker/optracker.go
+++ b/internal/optracker/optracker.go
@@ -1,0 +1,195 @@
+package optracker
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/logrusorgru/aurora/v3"
+)
+
+func New(w io.Writer) *OpTracker {
+	return &OpTracker{
+		w: w,
+	}
+}
+
+type OpTracker struct {
+	mu      sync.Mutex
+	ops     []*slowOp
+	w       io.Writer
+	nl      int // number of lines written
+	started bool
+	quit    bool
+}
+
+type OperationID int
+
+const NoOperationID OperationID = -1
+
+// AllDone marks all ops as done.
+// This function is safe to call on a Nil OpTracker and will no-op in that case
+func (t *OpTracker) AllDone() {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := time.Now()
+	for _, o := range t.ops {
+		if o.done.IsZero() || o.done.After(now) {
+			o.done = now
+		}
+		if o.start.After(now) {
+			o.start = now
+		}
+	}
+	t.quit = true
+	t.refresh()
+}
+
+// Add creates a new item on the operations tracker returning the ID for that op.
+// minStart is the time at which the tracker will start to show the task as in progress.
+//
+// This function is safe to call on a Nil OpTracker and will no-op in that case
+func (t *OpTracker) Add(msg string, minStart time.Time) OperationID {
+	if t == nil {
+		return NoOperationID
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	id := OperationID(len(t.ops))
+
+	start := time.Now()
+	if start.Before(minStart) {
+		start = minStart
+	}
+	op := &slowOp{msg: msg, start: start}
+	t.ops = append(t.ops, op)
+	t.refresh()
+
+	if !t.started {
+		go t.spin()
+		t.started = true
+	}
+
+	return id
+}
+
+// Done marks the given operation as done
+//
+// This function is safe to call on a Nil OpTracker and will no-op in that case
+func (t *OpTracker) Done(id OperationID, minDuration time.Duration) {
+	if t == nil || id == NoOperationID {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	o := t.ops[id]
+
+	done := time.Now()
+	if a := o.start.Add(minDuration); a.After(done) {
+		done = a
+	}
+	o.done = done
+	t.refresh()
+}
+
+// Fail marks the operation as failed with the given error
+//
+// This function is safe to call on a Nil OpTracker and will no-op in that case
+func (t *OpTracker) Fail(id OperationID, err error) {
+	if t == nil || id == NoOperationID {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.ops[id].done.IsZero() {
+		return
+	}
+	t.ops[id].err = err
+	t.ops[id].done = time.Now()
+	t.refresh()
+}
+
+// refresh refreshes the display by writing to t.w.
+// The mutex must be held by the caller.
+func (t *OpTracker) refresh() {
+	fmt.Fprint(t.w, "\u001b[0;0H\u001b[0J\n")
+
+	nl := 0
+	now := time.Now()
+
+	// Sort ops by start time
+	ops := make([]*slowOp, len(t.ops))
+	copy(ops, t.ops)
+	sort.Slice(ops, func(i, j int) bool {
+		return ops[i].start.Before(ops[j].start)
+	})
+
+	for _, o := range ops {
+		started := o.start.Before(now)
+		done := !o.done.IsZero() && o.done.Before(now)
+		if !started && !done {
+			continue
+		}
+
+		var msg aurora.Value
+		format := "  %s %s... "
+		switch {
+		case done && o.err != nil:
+			msg = aurora.Red(fmt.Sprintf(format+"Failed: %v", fail, o.msg, o.err))
+		case done && o.err == nil:
+			msg = aurora.Green(fmt.Sprintf(format+"Done!", success, o.msg))
+		case !done:
+			msg = aurora.Cyan(fmt.Sprintf(format, spinner[o.spinIdx], o.msg))
+			o.spinIdx = (o.spinIdx + 1) % len(spinner)
+		}
+		str := msg.String()
+		fmt.Fprintf(t.w, "\u001b[2K%s\n", str)
+		nl += strings.Count(str, "\n") + 1
+	}
+	t.nl = nl
+}
+
+func (t *OpTracker) spin() {
+	refresh := 100 * time.Millisecond
+	if runtime.GOOS == "windows" {
+		// Window's terminal is quite slow at rendering.
+		// Reduce the refresh rate to avoid excessive flickering.
+		refresh = 250 * time.Millisecond
+	}
+	for {
+		time.Sleep(refresh)
+		(func() {
+			t.mu.Lock()
+			defer t.mu.Unlock()
+			if !t.quit {
+				t.refresh()
+			}
+		})()
+	}
+
+}
+
+type slowOp struct {
+	msg     string
+	err     error
+	spinIdx int
+	start   time.Time
+	done    time.Time
+}
+
+var (
+	success = "✔"
+	fail    = "❌"
+	spinner = []string{"⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋"}
+)

--- a/parser/meta.go
+++ b/parser/meta.go
@@ -103,13 +103,13 @@ func ParseMeta(appRevision string, appHasUncommittedChanges bool, appRoot string
 func parsePubsubTopic(topic *est.PubSubTopic) *meta.PubSubTopic {
 	parsePublisher := func(pubs ...*est.PubSubPublisher) (rtn []*meta.PubSubTopic_Publisher) {
 		for _, p := range pubs {
-			rtn = append(rtn, &meta.PubSubTopic_Publisher{ServiceName: p.File.Pkg.Service.Name})
+			rtn = append(rtn, &meta.PubSubTopic_Publisher{ServiceName: p.DeclFile.Pkg.Service.Name})
 		}
 		return rtn
 	}
 	parseSubscribers := func(subs ...*est.PubSubSubscriber) (rtn []*meta.PubSubTopic_Subscription) {
 		for _, s := range subs {
-			rtn = append(rtn, &meta.PubSubTopic_Subscription{ServiceName: s.File.Pkg.Service.Name})
+			rtn = append(rtn, &meta.PubSubTopic_Subscription{ServiceName: s.DeclFile.Pkg.Service.Name})
 		}
 		return rtn
 	}


### PR DESCRIPTION
This commit refactors the resource service startup, such
that if you add code for a SQL database or pubsub topic when
`encore run` is already running, the watch will pick up those
changes and start the required services on your system.

This involved:
- Moving the resource startup code into a new `ResourceServices` struct
- Moving the `OpTracker` into it's own package from `cli/daemon/run` so it could be passed around
- Making `OpTracker` reciever functions work will `nil` pointers (i.e. no-op) so the calling code doesn't need to check

While refactoring this code, I added a `asyncBuildJobs` which allows jobs which can be run in paralel to be run in paralel.

I also added an NSQ log adapter and limited the logs to warning's and above.

This means the outputs from the daemon and CLI run now look like this:
![image](https://user-images.githubusercontent.com/236641/174790578-2f2f936d-cc2a-4942-baf8-12bdfed5df49.png)
