### PR TITLE
runtime/runtime/cors: support extra headers

### DIFF
--- a/runtime/runtime/config/config.go
+++ b/runtime/runtime/config/config.go
@@ -94,6 +94,11 @@ type CORS struct {
 	// that don't include credentials. If nil it defaults to allowing all domains
 	// (equivalent to []string{"*"}).
 	AllowOriginsWithoutCredentials []string `json:"allow_origins_without_credentials"`
+
+	// ExtraAllowedHeaders specifies extra headers to allow, beyond
+	// the default set of {"Origin", "Authorization", "Content-Type"}.
+	// As a special case, if the list contains "*" all headers are allowed.
+	ExtraAllowedHeaders []string `json:"raw_allowed_headers"`
 }
 
 type CommitInfo struct {

--- a/runtime/runtime/cors/cors.go
+++ b/runtime/runtime/cors/cors.go
@@ -23,10 +23,12 @@ func Options(cfg *config.CORS) cors.Options {
 	hasWildcardOriginWithoutCreds := cfg.AllowOriginsWithoutCredentials == nil || sortedSliceContains(originsWithoutCreds, "*")
 	hasUnsafeWildcardOriginWithCreds := sortedSliceContains(originsCreds, config.UnsafeAllOriginWithCredentials)
 
+	allowedHeaders := append([]string{"Authorization", "Content-Type"}, cfg.ExtraAllowedHeaders...)
+
 	return cors.Options{
 		AllowCredentials: !cfg.DisableCredentials,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "HEAD", "DELETE", "OPTIONS", "TRACE", "CONNECT"},
-		AllowedHeaders:   []string{"Authorization", "Content-Type"},
+		AllowedHeaders:   allowedHeaders,
 		AllowOriginRequestFunc: func(r *http.Request, origin string) bool {
 			// If the request has credentials, look up origins in AllowOriginsWithCredentials.
 			// Credentials are cookies, authorization headers, or TLS client certificates.


### PR DESCRIPTION
Add a way to specify extra headers that should be allowed through CORS.