### PR TITLE
Reserve attribute names starting `encore`.

### DIFF
--- a/parser/schema.go
+++ b/parser/schema.go
@@ -25,6 +25,14 @@ var disallowedHeaders = []string{
 	"Upgrade",
 }
 
+type structTagParser func(p *parser, rawTag *ast.BasicLit, parsedTag *structtag.Tag, structType *schema.Struct, fieldName string, fieldType *schema.Type)
+
+var structTagParsers = map[string]structTagParser{}
+
+func registerStructTagParser(tag string, f structTagParser) {
+	structTagParsers[tag] = f
+}
+
 // resolveType parses the schema from a type expression.
 func (p *parser) resolveType(pkg *est.Package, file *est.File, expr ast.Expr, typeParameters typeParameterLookup) *schema.Type {
 	expr = deref(expr)
@@ -85,7 +93,7 @@ func (p *parser) resolveType(pkg *est.Package, file *est.File, expr ast.Expr, ty
 			if len(field.Names) == 0 {
 				p.err(field.Pos(), "cannot use anonymous fields in Encore struct types")
 			}
-			opts := p.parseStructTag(field.Tag, typ)
+			opts := p.parseStructTag(field.Tag, st, field.Names[0].Name, typ)
 
 			// Validate the names to make sure we don't have any name collisions
 			if js := opts.JSONName; js != "" {
@@ -211,7 +219,7 @@ func schemaTags(tags []*structtag.Tag) []*schema.Tag {
 
 // parseStructTag parses the struct tag to determine any encore-specific options
 // and the JSON name, if any.
-func (p *parser) parseStructTag(tag *ast.BasicLit, resolvedType *schema.Type) structFieldOptions {
+func (p *parser) parseStructTag(tag *ast.BasicLit, structType *schema.Struct, fieldName string, fieldType *schema.Type) structFieldOptions {
 	var opts structFieldOptions
 	if tag == nil {
 		return opts
@@ -263,13 +271,13 @@ func (p *parser) parseStructTag(tag *ast.BasicLit, resolvedType *schema.Type) st
 		//
 		// We've decided against doing any encoding of strings, as that would be unexpected and hidden
 		// behaviour from handwritten clients using the APIs.
-		if resolvedType.GetList() != nil {
+		if fieldType.GetList() != nil {
 			p.errf(tag.Pos(), "header tags are not allowed on slices")
 		}
 
 		// We're not allowing generic fields in headers, as at parse time we cannot know if the generic
 		// is being used as a slice.
-		if resolvedType.GetTypeParameter() != nil {
+		if fieldType.GetTypeParameter() != nil {
 			p.errf(tag.Pos(), "header tags are not allowed on generic fields")
 		}
 
@@ -281,11 +289,19 @@ func (p *parser) parseStructTag(tag *ast.BasicLit, resolvedType *schema.Type) st
 		}
 
 		// Because we need to do type casting in the clients, we're limiting the types to built in Encore types
-		switch resolvedType.Typ.(type) {
+		switch fieldType.Typ.(type) {
 		case *schema.Type_Builtin:
 			// no-op
 		default:
 			p.errf(tag.Pos(), "header tags can only be used on built in types or types provided by Encore")
+		}
+	}
+
+	// Resolve any
+	for _, resolvedTag := range tags.Tags() {
+		tagParser, found := structTagParsers[resolvedTag.Key]
+		if found {
+			tagParser(p, tag, resolvedTag, structType, fieldName, fieldType)
 		}
 	}
 

--- a/parser/schema_test.go
+++ b/parser/schema_test.go
@@ -65,7 +65,7 @@ func TestParseStructTag(t *testing.T) {
 		x, err := goparser.ParseExpr("`" + test.Tag + "`")
 		c.Assert(err, qt.IsNil)
 		lit := x.(*ast.BasicLit)
-		got := p.parseStructTag(lit, nil)
+		got := p.parseStructTag(lit, nil, "", nil)
 		c.Assert(p.errors.Err(), qt.IsNil)
 		c.Assert(got, qt.DeepEquals, test.Want)
 	}

--- a/parser/testdata/pubsub.txt
+++ b/parser/testdata/pubsub.txt
@@ -47,6 +47,12 @@ func Subscriber1(ctx context.Context, msg *shared.MessageType) error {
 -- svc/domain/code.go --
 package domain
 
+import (
+    "context"
+
+    "test/shared"
+)
+
 func SubscriptionCode(ctx context.Context, msg *shared.MessageType) error {
     return nil
 }

--- a/parser/testdata/pubsub_err_attributes_not_start_encore.txt
+++ b/parser/testdata/pubsub_err_attributes_not_start_encore.txt
@@ -1,0 +1,31 @@
+# Verify that pub sub is parsed
+! parse
+stderr 'Pubsub attribute tags must not start with "encore". The field Name currently has an attribute tag of "encorename".'
+
+-- shared/topics.go --
+package shared
+
+import (
+    "encore.dev/pubsub"
+)
+
+type MessageType struct {
+    Name string `pubsub-attr:"encorename"`
+}
+
+var BasicTopic = pubsub.NewTopic[*MessageType]("same-name")
+
+-- svc/svc.go --
+package svc
+
+import (
+    "context"
+
+    "encore.dev/pubsub"
+)
+
+type MessageType struct {
+    Name string
+}
+
+var AnotherTopic = pubsub.NewTopic[*MessageType]("same-Name")


### PR DESCRIPTION
This commit adds a compiler error for any attribute
names which start `encore` as we need to reserve them
so we can pass Encore specific meta data for PubSub
messages