### PR TITLE
Create config dir before opening db

### DIFF
--- a/cli/cmd/encore/daemon/daemon.go
+++ b/cli/cmd/encore/daemon/daemon.go
@@ -201,6 +201,8 @@ func (d *Daemon) openDB() *sql.DB {
 	dir, err := conf.Dir()
 	if err != nil {
 		fatal(err)
+	} else if err := os.MkdirAll(dir, 0755); err != nil {
+		fatal(err)
 	}
 	dbPath := filepath.Join(dir, "encore.db")
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?cache=shared", dbPath))


### PR DESCRIPTION
Opening the database fails if the parent directory does not exist.
This can happen if trying to run `encore run` prior to logging in.