### PR TITLE
Fixed nil pointer on unbound resources.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -314,7 +314,9 @@ func (p *parser) parseReferences() {
 		resourceMap[pkg.ImportPath] = resources
 		for _, res := range pkg.Resources {
 			id := res.Ident()
-			resources[id.Name] = res
+			if id != nil {
+				resources[id.Name] = res
+			}
 		}
 	}
 

--- a/parser/parser_resources_usage.go
+++ b/parser/parser_resources_usage.go
@@ -17,7 +17,9 @@ func (p *parser) parseResourceUsage() {
 		resourceMap[pkg.ImportPath] = resources
 		for _, res := range pkg.Resources {
 			id := res.Ident()
-			resources[id.Name] = res
+			if id != nil {
+				resources[id.Name] = res
+			}
 		}
 	}
 


### PR DESCRIPTION
Most requires are bound to package level varaibles, like this:
```go
var db = sqldb.Named("svc")
```

We track the identifier `db` as being bound to the database `svc`.
However, it's possible to make calls like this:

```go
var db = sqldb.Named("svc").Stdlib()
```

In this case `db` is not longer bound against the database `svc`, as
the named resource isn't directly bound.

The refactored resource parser, correctly identified the named database,
and it wasn't bound to a varaible in the package. However, older code
was written expecting an identified resource to always have an ident.

This is what caused the nil pointer panic. I've added checks for `nil`
identifiers, and skip the resource usage tracking if we know that resource
isn't bound against anything.