### PR TITLE
Fix Local Dashboard Logging

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/trace/SpanDetail.tsx
+++ b/cli/daemon/dash/dashapp/src/components/trace/SpanDetail.tsx
@@ -633,7 +633,7 @@ const renderLog = (tr: Trace, log: LogMessage, key: any, onStackTrace: (s: Stack
   dt = dt.plus(Duration.fromMillis(ms))
 
   const render = (v: any) => {
-    if (typeof v === "object" && v !== null) {
+    if (v !== null) {
       return JSON.stringify(v)
     }
     return v

--- a/cli/daemon/dash/dashapp/src/pages/AppHome.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/AppHome.tsx
@@ -19,13 +19,13 @@ const AppHome: FunctionComponent = (props) => {
             <div className="flex-1 min-w-0 md:mr-8">
               <h2 className="px-2 text-lg font-medium">API Explorer</h2>
               <div className="mt-2 rounded-lg overflow-hidden">
-                <AppCaller appID={appID} conn={conn} />
+                <AppCaller key={appID} appID={appID} conn={conn} />
               </div>
             </div>
             <div className="mt-4 md:mt-0 flex-1 min-w-0">
               <h2 className="px-2 text-lg font-medium">Traces</h2>
               <div className="mt-2 rounded-lg overflow-hidden">
-                <AppTraces appID={appID} conn={conn} />
+                <AppTraces key={appID} appID={appID} conn={conn} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
This commit fixes encoredev/encore.dev#4 - which reported that the dashboard
log viewer does not render booleans correctly. This was due to the UI returning
a `true` or `false` value directly as a React.Node - which React does not render.

The fix was to render everything as JSON strings, which prevents thus bug, and
other falsy values from not rendering.

This commit also fixes an issue where if you're running multiple apps at the same time,
the home screen of the dash would not swap between the two apps when you use the app
switcher. The fix was to introduce a key for both the API caller and Trace List, such that
when the `AppID` changes, both those components get unmoutned and remoutned.