### PR TITLE
runtime/appruntime: fix test tracking

### DIFF
--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -62,19 +62,23 @@ func (s *Server) beginRequest(ctx context.Context, p *beginRequestParams) error 
 		Traced:       s.tracingEnabled,
 	}
 
-	logCtx := s.rootLogger.With().Str("service", req.Service).Str("endpoint", req.Endpoint)
-	if req.UID != "" {
-		logCtx = logCtx.Str("uid", string(req.UID))
-	}
-	reqLogger := logCtx.Logger()
-	req.Logger = &reqLogger
-
 	if prev := s.rt.Current().Req; prev != nil {
 		req.UID = prev.UID
 		req.AuthData = prev.AuthData
 		req.ParentID = prev.SpanID
 		req.Traced = prev.Traced
+		req.Test = prev.Test
 	}
+
+	logCtx := s.rootLogger.With().Str("service", req.Service).Str("endpoint", req.Endpoint)
+	if req.UID != "" {
+		logCtx = logCtx.Str("uid", string(req.UID))
+	}
+	if req.Test != nil {
+		logCtx = logCtx.Str("test", req.Test.Current.Name())
+	}
+	reqLogger := logCtx.Logger()
+	req.Logger = &reqLogger
 
 	// Update request data based on call options, if any
 	if opts, _ := ctx.Value(callOptionsKey).(*CallOptions); opts != nil {

--- a/runtime/pubsub/subscription.go
+++ b/runtime/pubsub/subscription.go
@@ -140,6 +140,13 @@ func NewSubscription[T any](topic *Topic[T], name string, subscriptionCfg Subscr
 
 		mgr.rt.BeginRequest(req)
 		curr := mgr.rt.Current()
+
+		if prev := curr.Req; prev != nil {
+			req.ParentID = prev.SpanID
+			req.Traced = prev.Traced
+			req.Test = prev.Test
+		}
+
 		if curr.Trace != nil {
 			curr.Trace.BeginRequest(req, curr.Goctr)
 		}


### PR DESCRIPTION
In some circumstances the fact that we were running a test
was not being propagated to child requests.