### PR TITLE
cli/cmd/encore: fix app creation without Go install

### DIFF
--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -193,6 +193,7 @@ func checkAuthData(authDataType reflect.Type, uid model.UID, userData interface{
 
 	return nil
 }
+
 func (s *Server) beginCall(defLoc int32) (*model.APICall, error) {
 	spanID, err := model.GenSpanID()
 	if err != nil {


### PR DESCRIPTION
If the user does not have `go` installed, `encore app create`
would fail with an error since we're trying to fetch
the latest Encore dependency. Fix this by using the
`go` binary in the Encore-provided GOROOT.