### PR TITLE
parser: support multiple fields with JSON ignore

### DIFF
--- a/parser/schema.go
+++ b/parser/schema.go
@@ -96,13 +96,20 @@ func (p *parser) resolveType(pkg *est.Package, file *est.File, expr ast.Expr, ty
 			opts := p.parseStructTag(field.Tag, st, field.Names[0].Name, typ)
 
 			// Validate the names to make sure we don't have any name collisions
-			if js := opts.JSONName; js != "" {
+			switch js := opts.JSONName; true {
+			case js == "-":
+				// Ignore
+
+			case js != "":
+				// Check JSON names
 				if len(field.Names) > 1 {
 					pp := p.fset.Position(field.Names[0].Pos())
 					p.errf(field.Names[1].Pos(), "json field name %s conflicts with previous field (defined at %s)", js, pp)
 				}
 				checkName(field.Tag.Pos(), js, "json")
-			} else {
+
+			case js == "":
+				// Check field names
 				for _, name := range field.Names {
 					checkName(name.Pos(), name.Name, "field")
 				}

--- a/parser/testdata/struct_duplicate_json_ignore.txt
+++ b/parser/testdata/struct_duplicate_json_ignore.txt
@@ -1,0 +1,25 @@
+parse
+
+-- svc/svc.go --
+package svc
+
+import (
+    "context"
+    
+    "encore.dev/beta/auth"
+)
+
+type SomeStruct struct {
+    A string `json:"-"`
+    B string `json:"-"`
+}
+
+//encore:api public
+func Foo(ctx context.Context, p *SomeStruct) error {
+    return nil
+}
+
+//encore:api public
+func Bar(ctx context.Context) (*SomeStruct, error) {
+    return nil, nil
+}


### PR DESCRIPTION
Our parser tries to detect name collisions, but did not
consider the case where the field is ignored with `json:"-"`.

Handle this case. Thanks to @melkstam for the report.

Fixes #319