### PR TITLE
Force Runtime DI setup before use.

### DIFF
--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -42,8 +42,8 @@ func (b *Builder) Main() (f *File, err error) {
 
 	f.Anon("unsafe") // for go:linkname
 	f.Comment("loadApp loads the Encore app runtime.")
-	f.Comment("//go:linkname loadApp encore.dev/appruntime/app/appinit.load")
-	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app/appinit", "LoadData").BlockFunc(func(g *Group) {
+	f.Comment("//go:linkname loadApp encore.dev/appruntime/app.load")
+	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app", "LoadData").BlockFunc(func(g *Group) {
 		g.Id("static").Op(":=").Op("&").Qual("encore.dev/appruntime/config", "Static").Values(Dict{
 			Id("AuthData"):       b.authDataType(),
 			Id("EncoreCompiler"): Lit(b.compilerVersion),
@@ -73,7 +73,7 @@ func (b *Builder) Main() (f *File, err error) {
 			authHandlerExpr = Qual(ah.Svc.Root.ImportPath, b.authHandlerName(ah))
 		}
 
-		g.Return(Op("&").Qual("encore.dev/appruntime/app/appinit", "LoadData").Values(Dict{
+		g.Return(Op("&").Qual("encore.dev/appruntime/app", "LoadData").Values(Dict{
 			Id("StaticCfg"):   Id("static"),
 			Id("APIHandlers"): Id("handlers"),
 			Id("AuthHandler"): authHandlerExpr,

--- a/compiler/internal/codegen/codegen_testmain.go
+++ b/compiler/internal/codegen/codegen_testmain.go
@@ -24,15 +24,15 @@ func (b *Builder) TestMain(pkg *est.Package, svcs []*est.Service) *File {
 	if pkg.Service != nil {
 		testSvc = pkg.Service.Name
 	}
-	f.Comment("//go:linkname loadApp encore.dev/appruntime/app/appinit.load")
-	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app/appinit", "LoadData").Block(
+	f.Comment("//go:linkname loadApp encore.dev/appruntime/app.load")
+	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app", "LoadData").Block(
 		Id("static").Op(":=").Op("&").Qual("encore.dev/appruntime/config", "Static").Values(Dict{
 			Id("AuthData"):     b.authDataType(),
 			Id("Testing"):      True(),
 			Id("TestService"):  Lit(testSvc),
 			Id("PubsubTopics"): b.computeStaticPubsubConfig(),
 		}),
-		Return(Op("&").Qual("encore.dev/appruntime/app/appinit", "LoadData").Values(Dict{
+		Return(Op("&").Qual("encore.dev/appruntime/app", "LoadData").Values(Dict{
 			Id("StaticCfg"):   Id("static"),
 			Id("APIHandlers"): Nil(),
 		})),

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
@@ -3,14 +3,15 @@ package main
 
 import (
 	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	_ "unsafe"
 )
 
 // loadApp loads the Encore app runtime.
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AppCommit: config.CommitInfo{
 			Revision:    "",
@@ -23,7 +24,7 @@ func loadApp() *appinit.LoadData {
 		Testing:        false,
 	}
 	handlers := []api.Handler{}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: handlers,
 		AuthHandler: nil,
 		StaticCfg:   static,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -4,6 +4,7 @@ package main
 import (
 	"encore.app/svc"
 	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	"reflect"
@@ -11,8 +12,8 @@ import (
 )
 
 // loadApp loads the Encore app runtime.
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AppCommit: config.CommitInfo{
 			Revision:    "",
@@ -27,7 +28,7 @@ func loadApp() *appinit.LoadData {
 	handlers := []api.Handler{
 		svc.EncoreInternal_EightHandler,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: handlers,
 		AuthHandler: svc.EncoreInternal_AuthHandlerAuthHandler,
 		StaticCfg:   static,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -4,6 +4,7 @@ package main
 import (
 	"encore.app/svc"
 	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	"reflect"
@@ -11,8 +12,8 @@ import (
 )
 
 // loadApp loads the Encore app runtime.
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AppCommit: config.CommitInfo{
 			Revision:    "",
@@ -27,7 +28,7 @@ func loadApp() *appinit.LoadData {
 	handlers := []api.Handler{
 		svc.EncoreInternal_EightHandler,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: handlers,
 		AuthHandler: svc.EncoreInternal_AuthHandlerAuthHandler,
 		StaticCfg:   static,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -4,6 +4,7 @@ package main
 import (
 	"encore.app/svc"
 	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	"reflect"
@@ -11,8 +12,8 @@ import (
 )
 
 // loadApp loads the Encore app runtime.
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AppCommit: config.CommitInfo{
 			Revision:    "",
@@ -27,7 +28,7 @@ func loadApp() *appinit.LoadData {
 	handlers := []api.Handler{
 		svc.EncoreInternal_EightHandler,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: handlers,
 		AuthHandler: svc.EncoreInternal_AuthHandlerAuthHandler,
 		StaticCfg:   static,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -4,6 +4,7 @@ package main
 import (
 	"encore.app/svc"
 	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	"reflect"
@@ -11,8 +12,8 @@ import (
 )
 
 // loadApp loads the Encore app runtime.
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AppCommit: config.CommitInfo{
 			Revision:    "",
@@ -38,7 +39,7 @@ func loadApp() *appinit.LoadData {
 		svc.EncoreInternal_ThreeHandler,
 		svc.EncoreInternal_TwoHandler,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: handlers,
 		AuthHandler: svc.EncoreInternal_AuthHandlerAuthHandler,
 		StaticCfg:   static,

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_header_auth.golden
@@ -3,21 +3,21 @@ package svc_test
 
 import (
 	"encore.app/svc"
-	"encore.dev/appruntime/app/appinit"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/config"
 	"reflect"
 	_ "unsafe"
 )
 
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
 		PubsubTopics: map[string]*config.StaticPubsubTopic{},
 		TestService:  "svc",
 		Testing:      true,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: nil,
 		StaticCfg:   static,
 	}

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_query_auth.golden
@@ -3,21 +3,21 @@ package svc_test
 
 import (
 	"encore.app/svc"
-	"encore.dev/appruntime/app/appinit"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/config"
 	"reflect"
 	_ "unsafe"
 )
 
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
 		PubsubTopics: map[string]*config.StaticPubsubTopic{},
 		TestService:  "svc",
 		Testing:      true,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: nil,
 		StaticCfg:   static,
 	}

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__token_auth.golden
@@ -3,21 +3,21 @@ package svc_test
 
 import (
 	"encore.app/svc"
-	"encore.dev/appruntime/app/appinit"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/config"
 	"reflect"
 	_ "unsafe"
 )
 
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
 		PubsubTopics: map[string]*config.StaticPubsubTopic{},
 		TestService:  "svc",
 		Testing:      true,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: nil,
 		StaticCfg:   static,
 	}

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
@@ -3,21 +3,21 @@ package svc_test
 
 import (
 	"encore.app/svc"
-	"encore.dev/appruntime/app/appinit"
+	"encore.dev/appruntime/app"
 	"encore.dev/appruntime/config"
 	"reflect"
 	_ "unsafe"
 )
 
-//go:linkname loadApp encore.dev/appruntime/app/appinit.load
-func loadApp() *appinit.LoadData {
+//go:linkname loadApp encore.dev/appruntime/app.load
+func loadApp() *app.LoadData {
 	static := &config.Static{
 		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
 		PubsubTopics: map[string]*config.StaticPubsubTopic{},
 		TestService:  "svc",
 		Testing:      true,
 	}
-	return &appinit.LoadData{
+	return &app.LoadData{
 		APIHandlers: nil,
 		StaticCfg:   static,
 	}

--- a/runtime/appruntime/app/appinit/appinit.go
+++ b/runtime/appruntime/app/appinit/appinit.go
@@ -6,9 +6,20 @@ import (
 	"fmt"
 	"os"
 
-	"encore.dev/appruntime/api"
-	"encore.dev/appruntime/app"
-	"encore.dev/appruntime/config"
+	"github.com/rs/zerolog"
+
+	// Note: We should not have any dependencies on any of
+	// the "encore.dev" packages, since we want to use this
+	// package to force initialisation of the Encore runtime to always
+	// occur before any user code can execute. Thus almost all packages inside
+	// encore.dev will import this package - and that would cause a circular dependency.
+
+	// This needs to be imported to allow JSON Iterator and it's dependancies to have
+	// there package level structs loaded, otherwise we get a nil pointer panic.
+	// This is due to the fact that the loadAppInstance() call will initialise
+	// the JSON iterator for the app, but it's package level variables
+	// wouldn't otherwise be setup yet.
+	_ "github.com/json-iterator/go"
 )
 
 // AppMain is the entrypoint to the Encore Application.
@@ -18,33 +29,23 @@ func AppMain() {
 	}
 }
 
-// singleton is the instance of the Encore app.
-var singleton *app.App
-
-// load is provided by the code-generated main package
-// and linked here using go:linkname.
-func load() *LoadData
-
-type LoadData struct {
-	StaticCfg   *config.Static
-	APIHandlers []api.Handler
-	AuthHandler api.AuthHandler
+type AppInstance interface {
+	Run() error
+	RootLogger() *zerolog.Logger
+	GetSecret(key string) (string, bool)
 }
 
-// We load everything during init so that the whole runtime is available to the Encore app
-// even from within the app's init functions. The AppMain function runs later.
+// singleton is the instance of the Encore app.
+var singleton AppInstance
+
+// loadAppInstance is provided by the "appruntime/app"
+// and linked here using go:linkname. This indirection is
+// done to avoid a dependency on the "appruntime/app" package which
+// would create an circular dependency on the whole runtime.
+func loadAppInstance() AppInstance
+
 func init() {
-	data := load()
-	cfg := &config.Config{
-		Runtime: config.ParseRuntime(config.GetAndClearEnv("ENCORE_RUNTIME_CONFIG")),
-		Secrets: config.ParseSecrets(config.GetAndClearEnv("ENCORE_APP_SECRETS")),
-		Static:  data.StaticCfg,
-	}
-	singleton = app.New(&app.NewParams{
-		Cfg:         cfg,
-		APIHandlers: data.APIHandlers,
-		AuthHandler: data.AuthHandler,
-	})
+	singleton = loadAppInstance()
 }
 
 // LoadSecret loads the secret with the given key.

--- a/runtime/appruntime/app/init.go
+++ b/runtime/appruntime/app/init.go
@@ -1,0 +1,39 @@
+//go:build encore_app
+
+package app
+
+import (
+	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app/appinit"
+	"encore.dev/appruntime/config"
+
+	_ "unsafe"
+)
+
+// load is provided by the code-generated main package
+// and linked here using go:linkname.
+func load() *LoadData
+
+type LoadData struct {
+	StaticCfg   *config.Static
+	APIHandlers []api.Handler
+	AuthHandler api.AuthHandler
+}
+
+// We load everything during init so that the whole runtime is available to the Encore app
+// even from within the app's init functions. The AppMain function runs later.
+//go:linkname loadAppInstance encore.dev/appruntime/app/appinit.loadAppInstance
+func loadAppInstance() appinit.AppInstance {
+	data := load()
+
+	cfg := &config.Config{
+		Runtime: config.ParseRuntime(config.GetAndClearEnv("ENCORE_RUNTIME_CONFIG")),
+		Secrets: config.ParseSecrets(config.GetAndClearEnv("ENCORE_APP_SECRETS")),
+		Static:  data.StaticCfg,
+	}
+	return New(&NewParams{
+		Cfg:         cfg,
+		APIHandlers: data.APIHandlers,
+		AuthHandler: data.AuthHandler,
+	})
+}

--- a/runtime/appruntime/testsupport/runtimehooks_app.go
+++ b/runtime/appruntime/testsupport/runtimehooks_app.go
@@ -5,6 +5,8 @@ package testsupport
 import (
 	"testing"
 	_ "unsafe" // for go:linkname
+
+	_ "encore.dev/appruntime/app/appinit" // Force the app to initialise all singletons before these functions can be used
 )
 
 var Singleton *Manager

--- a/runtime/beta/auth/pkgfn.go
+++ b/runtime/beta/auth/pkgfn.go
@@ -2,6 +2,8 @@
 
 package auth
 
+import _ "encore.dev/appruntime/app/appinit" // Force the app to initialise all singletons before these functions can be used
+
 //publicapigen:drop
 var Singleton *Manager // injected on app init
 

--- a/runtime/pkgfn.go
+++ b/runtime/pkgfn.go
@@ -2,6 +2,8 @@
 
 package encore
 
+import _ "encore.dev/appruntime/app/appinit" // Force the app to initialise all singletons before these functions can be used
+
 //publicapigen:drop
 var Singleton *Manager
 

--- a/runtime/pubsub/pkgfn.go
+++ b/runtime/pubsub/pkgfn.go
@@ -2,6 +2,8 @@
 
 package pubsub
 
+import _ "encore.dev/appruntime/app/appinit" // Force the app to initialise all singletons before these functions can be used
+
 //publicapigen:drop
 var Singleton *Manager
 

--- a/runtime/rlog/pkgfn.go
+++ b/runtime/rlog/pkgfn.go
@@ -2,6 +2,8 @@
 
 package rlog
 
+import _ "encore.dev/appruntime/app/appinit" // Force the app to initialise all singletons before these functions can be used
+
 //publicapigen:drop
 var Singleton *Manager
 

--- a/runtime/storage/sqldb/pkgfn.go
+++ b/runtime/storage/sqldb/pkgfn.go
@@ -4,6 +4,8 @@ package sqldb
 
 import (
 	"context"
+
+	_ "encore.dev/appruntime/app/appinit" // Force the app to initialise all singletons before these functions can be used
 )
 
 // Exec executes a query without returning any rows.


### PR DESCRIPTION
We recently refactored the runtime to use a DI setup with
singletons routing the package level function calls into the
runtime instance.

There's a bug where if a package uses one of these package level
functions in an `init()` function, but the package doesn't import
any other part of the Encore runtime or expose an API, it would result
in a nil pointer deference, as the singletons had not be initialised
yet.

This commit adds an import to the `appinit` package, which initialises
the singletons.

To prevent a cicrular depdency I've had to move parts of `appinit` back
into the `app` package and link into it with `linkname`.