### PR TITLE
runtime: ensure runtime is initialized

### DIFF
--- a/compiler/internal/codegen/api_handlers.go
+++ b/compiler/internal/codegen/api_handlers.go
@@ -37,8 +37,7 @@ func (b *Builder) ServiceHandlers(svc *est.Service) (f *File, err error) {
 	f = NewFilePathName(svc.Root.ImportPath, svc.Name)
 	b.registerImports(f)
 
-	// Import the runtime package with '_' as its name to start with to ensure it's imported.
-	// If other code uses it will be imported under its proper name.
+	// Import the appinit package to ensure the runtime is initialized.
 	f.Anon("encore.dev/appruntime/app/appinit")
 
 	for _, rpc := range svc.RPCs {
@@ -58,8 +57,7 @@ func (b *Builder) registerImports(f *File) {
 	f.ImportNames(importNames)
 	f.ImportAlias("encoding/json", "stdjson")
 
-	// Import the runtime package with '_' as its name to start with to ensure it's imported.
-	// If other code uses it will be imported under its proper name.
+	// Import the appinit package to ensure the runtime is initialized.
 	f.Anon("encore.dev/appruntime/app/appinit")
 
 	for _, pkg := range b.res.App.Packages {

--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -42,8 +42,8 @@ func (b *Builder) Main() (f *File, err error) {
 
 	f.Anon("unsafe") // for go:linkname
 	f.Comment("loadApp loads the Encore app runtime.")
-	f.Comment("//go:linkname loadApp encore.dev/appruntime/app/appinit.load")
-	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app/appinit", "LoadData").BlockFunc(func(g *Group) {
+	f.Comment("//go:linkname loadApp encore.dev/appruntime/app.load")
+	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app", "LoadData").BlockFunc(func(g *Group) {
 		g.Id("static").Op(":=").Op("&").Qual("encore.dev/appruntime/config", "Static").Values(Dict{
 			Id("AuthData"):       b.authDataType(),
 			Id("EncoreCompiler"): Lit(b.compilerVersion),
@@ -73,7 +73,7 @@ func (b *Builder) Main() (f *File, err error) {
 			authHandlerExpr = Qual(ah.Svc.Root.ImportPath, b.authHandlerName(ah))
 		}
 
-		g.Return(Op("&").Qual("encore.dev/appruntime/app/appinit", "LoadData").Values(Dict{
+		g.Return(Op("&").Qual("encore.dev/appruntime/app", "LoadData").Values(Dict{
 			Id("StaticCfg"):   Id("static"),
 			Id("APIHandlers"): Id("handlers"),
 			Id("AuthHandler"): authHandlerExpr,
@@ -82,7 +82,7 @@ func (b *Builder) Main() (f *File, err error) {
 	f.Line()
 
 	f.Func().Id("main").Params().Block(
-		Qual("encore.dev/appruntime/app/appinit", "AppMain").Call(),
+		Qual("encore.dev/appruntime/app", "Main").Call(),
 	)
 
 	return f, b.errors.Err()

--- a/compiler/internal/codegen/codegen_testmain.go
+++ b/compiler/internal/codegen/codegen_testmain.go
@@ -24,15 +24,15 @@ func (b *Builder) TestMain(pkg *est.Package, svcs []*est.Service) *File {
 	if pkg.Service != nil {
 		testSvc = pkg.Service.Name
 	}
-	f.Comment("//go:linkname loadApp encore.dev/appruntime/app/appinit.load")
-	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app/appinit", "LoadData").Block(
+	f.Comment("//go:linkname loadApp encore.dev/appruntime/app.load")
+	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app", "LoadData").Block(
 		Id("static").Op(":=").Op("&").Qual("encore.dev/appruntime/config", "Static").Values(Dict{
 			Id("AuthData"):     b.authDataType(),
 			Id("Testing"):      True(),
 			Id("TestService"):  Lit(testSvc),
 			Id("PubsubTopics"): b.computeStaticPubsubConfig(),
 		}),
-		Return(Op("&").Qual("encore.dev/appruntime/app/appinit", "LoadData").Values(Dict{
+		Return(Op("&").Qual("encore.dev/appruntime/app", "LoadData").Values(Dict{
 			Id("StaticCfg"):   Id("static"),
 			Id("APIHandlers"): Nil(),
 		})),

--- a/compiler/rewrite.go
+++ b/compiler/rewrite.go
@@ -76,7 +76,7 @@ func (b *builder) rewritePkg(pkg *est.Package, targetDir string) error {
 
 				decl := file.AST.Decls[0]
 				ln := fset.Position(decl.Pos())
-				rw.Insert(decl.Pos(), []byte(fmt.Sprintf("import __encore_app %s\n/*line :%d:%d*/", strconv.Quote("encore.dev/appruntime/app/appinit"), ln.Line, ln.Column)))
+				rw.Insert(decl.Pos(), []byte(fmt.Sprintf("import __encore_app %s\n/*line :%d:%d*/", strconv.Quote("encore.dev/appruntime/app"), ln.Line, ln.Column)))
 				return true
 
 			case est.CronJobNode:

--- a/runtime/appruntime/app/appinit.go
+++ b/runtime/appruntime/app/appinit.go
@@ -1,0 +1,73 @@
+//go:build encore_app
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/config"
+
+	// Import json-iterator to make sure its type registry is initialized.
+	_ "github.com/json-iterator/go"
+)
+
+// Main is the entrypoint to the Encore Application.
+func Main() {
+	if err := singleton.Run(); err != nil {
+		singleton.RootLogger().Fatal().Err(err).Msg("could not run")
+	}
+}
+
+// singleton is the instance of the Encore app.
+var singleton *App
+
+// load is provided by the code-generated main package
+// and linked here using go:linkname.
+func load() *LoadData
+
+type LoadData struct {
+	StaticCfg   *config.Static
+	APIHandlers []api.Handler
+	AuthHandler api.AuthHandler
+}
+
+// LoadSecret loads the secret with the given key.
+// If it is not defined it logs a fatal error and exits the process.
+func LoadSecret(key string) string {
+	if val, ok := singleton.GetSecret(key); ok {
+		return val
+	}
+
+	fmt.Fprintln(os.Stderr, "encore: could not find secret", key)
+	os.Exit(2)
+	panic("unreachable")
+}
+
+// initOnce ensures we only initialize things once.
+var initOnce sync.Once
+
+// We load everything during init so that the whole runtime is available to the Encore app
+// even from within the app's init functions. The Main function runs later.
+//
+// This is a not in an `init` so that we can call it from pkg `appinit` with go:linkname.
+func doInit() {
+	initOnce.Do(func() {
+		data := load()
+		cfg := &config.Config{
+			Runtime: config.ParseRuntime(config.GetAndClearEnv("ENCORE_RUNTIME_CONFIG")),
+			Secrets: config.ParseSecrets(config.GetAndClearEnv("ENCORE_APP_SECRETS")),
+			Static:  data.StaticCfg,
+		}
+		singleton = New(&NewParams{
+			Cfg:         cfg,
+			APIHandlers: data.APIHandlers,
+			AuthHandler: data.AuthHandler,
+		})
+	})
+}
+
+func init() {
+	doInit()
+}

--- a/runtime/appruntime/app/appinit/appinit.go
+++ b/runtime/appruntime/app/appinit/appinit.go
@@ -1,60 +1,13 @@
 //go:build encore_app
 
+// Package appinit exists to ensure the runtime is initialized before
+// user code runs. It can safely be depended on by any package as it
+// itself has no dependencies on any other package.
 package appinit
 
-import (
-	"fmt"
-	"os"
-
-	"encore.dev/appruntime/api"
-	"encore.dev/appruntime/app"
-	"encore.dev/appruntime/config"
-)
-
-// AppMain is the entrypoint to the Encore Application.
-func AppMain() {
-	if err := singleton.Run(); err != nil {
-		singleton.RootLogger().Fatal().Err(err).Msg("could not run")
-	}
-}
-
-// singleton is the instance of the Encore app.
-var singleton *app.App
-
-// load is provided by the code-generated main package
-// and linked here using go:linkname.
-func load() *LoadData
-
-type LoadData struct {
-	StaticCfg   *config.Static
-	APIHandlers []api.Handler
-	AuthHandler api.AuthHandler
-}
-
-// We load everything during init so that the whole runtime is available to the Encore app
-// even from within the app's init functions. The AppMain function runs later.
 func init() {
-	data := load()
-	cfg := &config.Config{
-		Runtime: config.ParseRuntime(config.GetAndClearEnv("ENCORE_RUNTIME_CONFIG")),
-		Secrets: config.ParseSecrets(config.GetAndClearEnv("ENCORE_APP_SECRETS")),
-		Static:  data.StaticCfg,
-	}
-	singleton = app.New(&app.NewParams{
-		Cfg:         cfg,
-		APIHandlers: data.APIHandlers,
-		AuthHandler: data.AuthHandler,
-	})
+	doInit()
 }
 
-// LoadSecret loads the secret with the given key.
-// If it is not defined it logs a fatal error and exits the process.
-func LoadSecret(key string) string {
-	if val, ok := singleton.GetSecret(key); ok {
-		return val
-	}
-
-	fmt.Fprintln(os.Stderr, "encore: could not find secret", key)
-	os.Exit(2)
-	panic("unreachable")
-}
+//go:linkname doInit encore.dev/appruntime/app.doInit
+func doInit()

--- a/runtime/beta/auth/pkgfn.go
+++ b/runtime/beta/auth/pkgfn.go
@@ -2,6 +2,11 @@
 
 package auth
 
+import (
+	// Ensure the runtime is initialized.
+	_ "encore.dev/appruntime/app/appinit"
+)
+
 //publicapigen:drop
 var Singleton *Manager // injected on app init
 

--- a/runtime/pubsub/pkgfn.go
+++ b/runtime/pubsub/pkgfn.go
@@ -2,6 +2,11 @@
 
 package pubsub
 
+import (
+	// Ensure the runtime is initialized.
+	_ "encore.dev/appruntime/app/appinit"
+)
+
 //publicapigen:drop
 var Singleton *Manager
 

--- a/runtime/rlog/pkgfn.go
+++ b/runtime/rlog/pkgfn.go
@@ -2,6 +2,11 @@
 
 package rlog
 
+import (
+	// Ensure the runtime is initialized.
+	_ "encore.dev/appruntime/app/appinit"
+)
+
 //publicapigen:drop
 var Singleton *Manager
 


### PR DESCRIPTION
Make the `appinit` have no dependencies and call
out to the `encore.dev/appruntime/app` package
with `go:linkname` to actually initialize the app.