### PR TITLE
Fix top offset for trace tooltip

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/trace/SpanDetail.tsx
+++ b/cli/daemon/dash/dashapp/src/components/trace/SpanDetail.tsx
@@ -271,7 +271,9 @@ const GoroutineDetail: FunctionComponent<{g: gdata, req: Request, trace: Trace, 
     setBarOver(true)
     setHoverObj(obj)
     const spanEl = (ev.target as HTMLElement)
-    el.style.marginTop = `calc(${spanEl.offsetTop}px - 40px)`;
+    const offset = spanEl.getBoundingClientRect();
+
+    el.style.top = `calc(${offset.top}px - 40px)`;
     el.style.transform = `translateX(calc(-100% + ${gel.offsetLeft}px + ${spanEl.offsetLeft}px))`
   }
 


### PR DESCRIPTION
## What
Fix bug were the trace tooltip does not follows along with the scrolling

## Screenshot
**Before** - Tooltip does not follow along with the scroll
![before](https://user-images.githubusercontent.com/1826823/183597216-da1c30a5-cc18-4fcc-9131-37b3607d588a.gif)

**After** - Tooltip is always inline with the trace beam
![after](https://user-images.githubusercontent.com/1826823/183597201-31044fee-6299-46b2-9223-ef3e93b59cc9.gif)


