### PR TITLE
compiler/internal/codegen: clone nil as nil

### DIFF
--- a/compiler/internal/codegen/api_handlers.go
+++ b/compiler/internal/codegen/api_handlers.go
@@ -695,6 +695,13 @@ func (b *rpcBuilder) renderResponseStructDesc() structCodegen {
 		b.RespType(),
 		Error(),
 	).BlockFunc(func(g *Group) {
+		if b.RespIsPtr() {
+			// If the response is nil, we should return nil as well.
+			g.If(Id("resp").Op("==").Nil()).Block(
+				Return(Nil(), Nil()),
+			)
+		}
+
 		// We could optimize the clone operation if there are no reference types (pointers, maps, slices)
 		// in the struct. For now, simply serialize it as JSON and back.
 		g.Var().Id("clone").Id(b.RespTypeName())

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -195,6 +195,9 @@ var EncoreInternal_EightHandler = &api.Desc[*EncoreInternal_EightReq, *EncoreInt
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_EightResp) (*EncoreInternal_EightResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_EightResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -195,6 +195,9 @@ var EncoreInternal_EightHandler = &api.Desc[*EncoreInternal_EightReq, *EncoreInt
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_EightResp) (*EncoreInternal_EightResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_EightResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -195,6 +195,9 @@ var EncoreInternal_EightHandler = &api.Desc[*EncoreInternal_EightReq, *EncoreInt
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_EightResp) (*EncoreInternal_EightResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_EightResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -359,6 +359,9 @@ var EncoreInternal_EightHandler = &api.Desc[*EncoreInternal_EightReq, *EncoreInt
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_EightResp) (*EncoreInternal_EightResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_EightResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {
@@ -718,6 +721,9 @@ var EncoreInternal_NineHandler = &api.Desc[*EncoreInternal_NineReq, *EncoreInter
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_NineResp) (*EncoreInternal_NineResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_NineResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {
@@ -929,6 +935,9 @@ var EncoreInternal_QueryHandler = &api.Desc[*EncoreInternal_QueryReq, *EncoreInt
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_QueryResp) (*EncoreInternal_QueryResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_QueryResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {
@@ -1212,6 +1221,9 @@ var EncoreInternal_TenHandler = &api.Desc[*EncoreInternal_TenReq, *EncoreInterna
 		return [][]byte{v}, nil
 	},
 	CloneResp: func(resp *EncoreInternal_TenResp) (*EncoreInternal_TenResp, error) {
+		if resp == nil {
+			return nil, nil
+		}
 		var clone EncoreInternal_TenResp
 		bytes, err := jsoniter.ConfigDefault.Marshal(resp)
 		if err == nil {


### PR DESCRIPTION
If an API returns `(nil, nil)` we erroneously cloned this
response as `(&T{}, nil)`. Fix this.