### PR TITLE
Import all services into the main file

### DIFF
--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -39,6 +39,7 @@ func (b *Builder) Main(compilerVersion string) (f *File, err error) {
 
 	f = NewFile("main")
 	b.registerImports(f)
+	b.importServices(f)
 
 	mwNames, mwCode := b.RenderMiddlewares("")
 
@@ -139,6 +140,15 @@ func (b *Builder) computeHandlerRegistrationConfig(mwNames map[*est.Middleware]*
 			}
 		}
 	})
+}
+
+func (b *Builder) importServices(f *File) {
+	// All services should be imported by the main package so they get initialized on system startup
+	// Services may not have API handlers as they could be purely operating on PubSub subscriptions
+	// so without this anonymous package import, that service might not be initialised.
+	for _, svc := range b.res.App.Services {
+		f.Anon(svc.Root.ImportPath)
+	}
 }
 
 func (b *Builder) typeName(param *est.Param, skipPtr bool) *Statement {

--- a/compiler/internal/codegen/codegen_testmain.go
+++ b/compiler/internal/codegen/codegen_testmain.go
@@ -16,6 +16,7 @@ func (b *Builder) TestMain(pkg *est.Package, svcs []*est.Service) *File {
 	importPath := pkg.ImportPath + "!test"
 	f := NewFilePathName(importPath, pkg.Name+"_test")
 	b.registerImports(f)
+	b.importServices(f)
 	f.Anon("unsafe") // for go:linkname
 
 	testSvc := ""

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -2,6 +2,7 @@
 package main
 
 import (
+	_ "encore.app/otherservice"
 	"encore.app/svc"
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
@@ -21,9 +22,12 @@ func loadApp() *appinit.LoadData {
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
 		EncoreCompiler: "test",
-		PubsubTopics:   map[string]*config.StaticPubsubTopic{},
-		TestService:    "",
-		Testing:        false,
+		PubsubTopics: map[string]*config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*config.StaticPubsubSubscription{"subscription-name": {
+			Service:  "otherservice",
+			TraceIdx: 1,
+		}}}},
+		TestService: "",
+		Testing:     false,
 	}
 	handlers := []api.HandlerRegistration{
 		{
@@ -94,7 +98,7 @@ var EncoreInternal_svcMyMiddleware = &api.Middleware{
 	PkgName: "svc",
 	Name:    "MyMiddleware",
 	Global:  false,
-	DefLoc:  33,
+	DefLoc:  34,
 	Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
 		svc, err := svc.EncoreInternal_ServiceService.Get()
 		if err != nil {
@@ -103,6 +107,12 @@ var EncoreInternal_svcMyMiddleware = &api.Middleware{
 		return svc.MyMiddleware(req, next)
 	},
 }
+
+
+// generated types for service otherservice
+package otherservice
+
+import _ "encore.dev/appruntime/app/appinit"
 
 
 // generated types for service svc
@@ -129,7 +139,7 @@ var EncoreInternal_ServiceService = &service.Decl[Service]{
 	Service:     "svc",
 	Name:        "Service",
 	Setup:       initService,
-	SetupDefLoc: 31,
+	SetupDefLoc: 32,
 }
 
 type EncoreInternal_CronOneReq struct{}
@@ -142,7 +152,7 @@ var EncoreInternal_CronOneHandler = &api.Desc[*EncoreInternal_CronOneReq, Encore
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/cron",
-	DefLoc:   18,
+	DefLoc:   19,
 	Access:   api.Private,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_CronOneReq, err error) {
 		reqData = &EncoreInternal_CronOneReq{}
@@ -199,7 +209,7 @@ var EncoreInternal_DIHandler = &api.Desc[*EncoreInternal_DIReq, EncoreInternal_D
 	Methods:  []string{"GET"},
 	Raw:      false,
 	Path:     "/di",
-	DefLoc:   19,
+	DefLoc:   20,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_DIReq, err error) {
 		reqData = &EncoreInternal_DIReq{}
@@ -263,7 +273,7 @@ var EncoreInternal_EightHandler = &api.Desc[*EncoreInternal_EightReq, *EncoreInt
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/eight/:bar/:baz",
-	DefLoc:   20,
+	DefLoc:   21,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_EightReq, err error) {
 		reqData = &EncoreInternal_EightReq{}
@@ -393,7 +403,7 @@ var EncoreInternal_FiveHandler = &api.Desc[*EncoreInternal_FiveReq, EncoreIntern
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/five/:id/:key",
-	DefLoc:   21,
+	DefLoc:   22,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_FiveReq, err error) {
 		reqData = &EncoreInternal_FiveReq{}
@@ -517,7 +527,7 @@ var EncoreInternal_FourHandler = &api.Desc[*EncoreInternal_FourReq, EncoreIntern
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/four/*baz",
-	DefLoc:   22,
+	DefLoc:   23,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_FourReq, err error) {
 		reqData = &EncoreInternal_FourReq{}
@@ -611,7 +621,7 @@ var EncoreInternal_NineHandler = &api.Desc[*EncoreInternal_NineReq, *EncoreInter
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/nine/:bar/:baz",
-	DefLoc:   23,
+	DefLoc:   24,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_NineReq, err error) {
 		reqData = &EncoreInternal_NineReq{}
@@ -751,7 +761,7 @@ var EncoreInternal_OneHandler = &api.Desc[*EncoreInternal_OneReq, EncoreInternal
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/svc.One",
-	DefLoc:   24,
+	DefLoc:   25,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_OneReq, err error) {
 		reqData = &EncoreInternal_OneReq{}
@@ -810,7 +820,7 @@ var EncoreInternal_QueryHandler = &api.Desc[*EncoreInternal_QueryReq, *EncoreInt
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/query",
-	DefLoc:   25,
+	DefLoc:   26,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_QueryReq, err error) {
 		reqData = &EncoreInternal_QueryReq{}
@@ -965,7 +975,7 @@ var EncoreInternal_SevenHandler = &api.Desc[*EncoreInternal_SevenReq, EncoreInte
 	Methods:  []string{"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"},
 	Raw:      true,
 	Path:     "/foo/:bar/:baz",
-	DefLoc:   26,
+	DefLoc:   27,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_SevenReq, err error) {
 		reqData = &EncoreInternal_SevenReq{}
@@ -1028,7 +1038,7 @@ var EncoreInternal_SixHandler = &api.Desc[*EncoreInternal_SixReq, EncoreInternal
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/six/:id/*key",
-	DefLoc:   27,
+	DefLoc:   28,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_SixReq, err error) {
 		reqData = &EncoreInternal_SixReq{}
@@ -1158,7 +1168,7 @@ var EncoreInternal_TenHandler = &api.Desc[*EncoreInternal_TenReq, *EncoreInterna
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/ten",
-	DefLoc:   28,
+	DefLoc:   29,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_TenReq, err error) {
 		reqData = &EncoreInternal_TenReq{}
@@ -1253,7 +1263,7 @@ var EncoreInternal_ThreeHandler = &api.Desc[*EncoreInternal_ThreeReq, EncoreInte
 	Methods:  []string{"GET", "POST"},
 	Raw:      false,
 	Path:     "/three/:id",
-	DefLoc:   29,
+	DefLoc:   30,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_ThreeReq, err error) {
 		reqData = &EncoreInternal_ThreeReq{}
@@ -1342,7 +1352,7 @@ var EncoreInternal_TwoHandler = &api.Desc[*EncoreInternal_TwoReq, EncoreInternal
 	Methods:  []string{"POST"},
 	Raw:      false,
 	Path:     "/svc.Two",
-	DefLoc:   30,
+	DefLoc:   31,
 	Access:   api.Public,
 	DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (reqData *EncoreInternal_TwoReq, err error) {
 		reqData = &EncoreInternal_TwoReq{}
@@ -1433,7 +1443,7 @@ type EncoreInternal_AuthHandlerAuthParams = AuthParams
 var EncoreInternal_AuthHandlerAuthHandler = &api.AuthHandlerDesc[*EncoreInternal_AuthHandlerAuthParams]{
 	Service:     "svc",
 	Endpoint:    "AuthHandler",
-	DefLoc:      32,
+	DefLoc:      33,
 	HasAuthData: true,
 	DecodeAuth: func(req *http.Request) (params *EncoreInternal_AuthHandlerAuthParams, err error) {
 		params = &EncoreInternal_AuthHandlerAuthParams{}

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
@@ -1,7 +1,8 @@
-// pkg svc
-package svc_test
+// pkg otherservice
+package otherservice_test
 
 import (
+	_ "encore.app/otherservice"
 	"encore.app/svc"
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
@@ -14,10 +15,13 @@ import (
 //go:linkname loadApp encore.dev/appruntime/app/appinit.load
 func loadApp() *appinit.LoadData {
 	static := &config.Static{
-		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
-		PubsubTopics: map[string]*config.StaticPubsubTopic{},
-		TestService:  "svc",
-		Testing:      true,
+		AuthData: reflect.TypeOf((*svc.AuthData)(nil)),
+		PubsubTopics: map[string]*config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*config.StaticPubsubSubscription{"subscription-name": {
+			Service:  "otherservice",
+			TraceIdx: 1,
+		}}}},
+		TestService: "otherservice",
+		Testing:     true,
 	}
 	handlers := []api.HandlerRegistration{
 		{
@@ -83,7 +87,106 @@ var EncoreInternal_svcMyMiddleware = &api.Middleware{
 	PkgName: "svc",
 	Name:    "MyMiddleware",
 	Global:  false,
-	DefLoc:  33,
+	DefLoc:  34,
+	Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
+		svc, err := svc.EncoreInternal_ServiceService.Get()
+		if err != nil {
+			return middleware.Response{Err: err}
+		}
+		return svc.MyMiddleware(req, next)
+	},
+}
+
+// pkg svc
+package svc_test
+
+import (
+	_ "encore.app/otherservice"
+	"encore.app/svc"
+	"encore.dev/appruntime/api"
+	"encore.dev/appruntime/app/appinit"
+	"encore.dev/appruntime/config"
+	middleware "encore.dev/middleware"
+	"reflect"
+	_ "unsafe"
+)
+
+//go:linkname loadApp encore.dev/appruntime/app/appinit.load
+func loadApp() *appinit.LoadData {
+	static := &config.Static{
+		AuthData: reflect.TypeOf((*svc.AuthData)(nil)),
+		PubsubTopics: map[string]*config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*config.StaticPubsubSubscription{"subscription-name": {
+			Service:  "otherservice",
+			TraceIdx: 1,
+		}}}},
+		TestService: "svc",
+		Testing:     true,
+	}
+	handlers := []api.HandlerRegistration{
+		{
+			Handler:    svc.EncoreInternal_CronOneHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_DIHandler,
+			Middleware: []*api.Middleware{EncoreInternal_svcMyMiddleware},
+		},
+		{
+			Handler:    svc.EncoreInternal_EightHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_FiveHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_FourHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_NineHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_OneHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_QueryHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_SevenHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_SixHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_TenHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_ThreeHandler,
+			Middleware: nil,
+		},
+		{
+			Handler:    svc.EncoreInternal_TwoHandler,
+			Middleware: nil,
+		},
+	}
+	return &appinit.LoadData{
+		APIHandlers: handlers,
+		StaticCfg:   static,
+	}
+}
+
+var EncoreInternal_svcMyMiddleware = &api.Middleware{
+	PkgName: "svc",
+	Name:    "MyMiddleware",
+	Global:  false,
+	DefLoc:  34,
 	Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
 		svc, err := svc.EncoreInternal_ServiceService.Get()
 		if err != nil {

--- a/compiler/internal/codegen/testdata/variants.txt
+++ b/compiler/internal/codegen/testdata/variants.txt
@@ -10,6 +10,7 @@ import (
 	"encore.dev/beta/auth"
 	"encore.dev/cron"
 	"encore.dev/middleware"
+	"encore.dev/pubsub"
 	"encore.dev/rlog"
 	"encore.dev/types/uuid"
 )
@@ -19,6 +20,13 @@ var _ = cron.NewJob("cron-one", cron.JobConfig{
 	Schedule: "* * * * 5",
 	Endpoint: CronOne,
 })
+
+var Topic = pubsub.NewTopic[*FooParams](
+	"test-topic",
+	pubsub.TopicConfig{
+		DeliveryGuarantee: pubsub.AtLeastOnce,
+	},
+)
 
 type FooParams struct {
 	Name string
@@ -147,4 +155,26 @@ func (s *Service) DI(ctx context.Context) error {
 //encore:middleware target=tag:di
 func (s *Service) MyMiddleware(req middleware.Request, next middleware.Next) middleware.Response {
     return next(req)
+}
+
+-- otherservice/svc.go --
+package otherservice
+
+import (
+	"context"
+
+	"encore.dev/pubsub"
+
+	"encore.app/svc"
+)
+
+var _ = pubsub.NewSubscription(
+	svc.Topic, "subscription-name",
+	pubsub.SubscriptionConfig[*svc.Topic]{
+		Handler: Consumer,
+	},
+)
+
+func Consumer(ctx context.Context, msg *svc.Topic) error {
+    return nil
 }


### PR DESCRIPTION
This commit ensures that all services get imported into
the generated `main.go` file for a built app.

This was to fix a bug where a service could be created using
a PubSub subscriber, but if a service only had subscribers and
had no API handlers, it was never imported by the main package,
thus never started up.