### PR TITLE
parser: fix Service Struct parsing

### DIFF
--- a/cli/daemon/run/testdata/echo/di/di.go
+++ b/cli/daemon/run/testdata/echo/di/di.go
@@ -1,7 +1,10 @@
 package di
 
 import (
+	"archive/zip"
 	"context"
+	"database/sql"
+	"sync"
 )
 
 type Response struct {
@@ -11,6 +14,12 @@ type Response struct {
 //encore:service
 type Service struct {
 	Msg string
+
+	// Include various types to make sure the parser doesn't complain.
+	mu   sync.Mutex
+	once *sync.Once
+	db   *sql.DB
+	fn   func() *zip.Writer
 }
 
 //encore:api public path=/di/one

--- a/docs/develop/middleware.md
+++ b/docs/develop/middleware.md
@@ -94,7 +94,7 @@ func (s *Service) MyMiddleware(req middleware.Request, next middleware.Next) mid
 }
 ```
 
-See the [Dependency Injection](/docs/how-to/dependency-injection.md) docs for more information.
+See the [Dependency Injection](/docs/how-to/dependency-injection) docs for more information.
 
 </Callout>
 


### PR DESCRIPTION
We were using `resolveParameter` to find the receiver name.
This had the inadvertent effect of preventing use of
non-basic types inside the struct. Fix this by resolving
the receiver name by hand instead.