### PR TITLE
runtime/appruntime/api: fix panic on request decode error

### DIFF
--- a/runtime/appruntime/api/handler_test.go
+++ b/runtime/appruntime/api/handler_test.go
@@ -2,7 +2,6 @@ package api_test
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/zerolog"
 
+	encore "encore.dev"
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/config"
 	"encore.dev/appruntime/model"
@@ -20,37 +20,64 @@ import (
 )
 
 type mockReq struct {
-	Body   string
-	Params api.PathParams
-}
-
-func (m mockReq) Serialize(json jsoniter.API) ([][]byte, error) {
-	data, err := json.Marshal(m)
-	return [][]byte{data}, err
-}
-
-func (m mockReq) Clone() (mockReq, error) {
-	m2 := m
-	m2.Params = make(api.PathParams, len(m.Params))
-	copy(m2.Params, m.Params)
-	return m2, nil
-}
-
-func (m mockReq) Path() (path string, params api.PathParams, err error) {
-	return "/foo", nil, nil
+	Body string
 }
 
 type mockResp struct {
 	Message string
 }
 
-func (m mockResp) Serialize(json jsoniter.API) ([][]byte, error) {
-	data, err := json.Marshal(m)
-	return [][]byte{data}, err
-}
+func newMockAPIDesc(access api.Access) *api.Desc[*mockReq, *mockResp] {
+	return &api.Desc[*mockReq, *mockResp]{
+		Service:  "service",
+		Endpoint: "endpoint",
+		Path:     "/foo",
+		Access:   access,
 
-func (m mockResp) Clone() (mockResp, error) {
-	return m, nil
+		DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (*mockReq, error) {
+			var reqData mockReq
+			if err := json.NewDecoder(req.Body).Decode(&reqData); err != nil {
+				return nil, err
+			}
+			return &reqData, nil
+		},
+		CloneReq: func(req *mockReq) (*mockReq, error) {
+			if req == nil {
+				return nil, nil
+			}
+			clone := *req
+			return &clone, nil
+		},
+		SerializeReq: func(json jsoniter.API, req *mockReq) ([][]byte, error) {
+			data, _ := json.Marshal(req)
+			return [][]byte{data}, nil
+		},
+		ReqPath: func(req *mockReq) (string, api.PathParams, error) {
+			return "/foo", nil, nil
+		},
+		ReqUserPayload: func(req *mockReq) any {
+			return req
+		},
+		AppHandler: func(ctx context.Context, req *mockReq) (*mockResp, error) {
+			return &mockResp{Message: req.Body}, nil
+		},
+		EncodeResp: func(w http.ResponseWriter, json jsoniter.API, resp *mockResp) error {
+			data, err := json.Marshal(resp)
+			w.Write(data)
+			return err
+		},
+		SerializeResp: func(json jsoniter.API, resp *mockResp) ([][]byte, error) {
+			data, _ := json.Marshal(resp)
+			return [][]byte{data}, nil
+		},
+		CloneResp: func(resp *mockResp) (*mockResp, error) {
+			if resp == nil {
+				return nil, nil
+			}
+			clone := *resp
+			return &clone, nil
+		},
+	}
 }
 
 func TestDesc_EndToEnd(t *testing.T) {
@@ -61,80 +88,55 @@ func TestDesc_EndToEnd(t *testing.T) {
 	logger := zerolog.New(os.Stdout)
 	rt := reqtrack.New(logger, nil, false)
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	server := api.NewServer(cfg, rt, nil, logger, json)
+	encoreMgr := encore.NewManager(cfg, rt)
+	server := api.NewServer(cfg, rt, nil, encoreMgr, logger, json)
 
-	desc := &api.Desc[mockReq, mockResp]{
-		Service:  "service",
-		Endpoint: "endpoint",
-		Path:     "/foo",
-		Access:   api.Public,
-
-		DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (mockReq, error) {
-			body, _ := io.ReadAll(req.Body)
-			return mockReq{
-				Body:   string(body),
-				Params: ps,
-			}, nil
+	tests := []struct {
+		name     string
+		access   api.Access
+		reqBody  string
+		respBody string
+		status   int
+	}{
+		{
+			name:     "echo",
+			access:   api.Public,
+			reqBody:  `{"Body": "foo"}`,
+			respBody: `{"Message":"foo"}`,
+			status:   200,
 		},
-		AppHandler: func(ctx context.Context, req mockReq) (mockResp, error) {
-			return mockResp{Message: req.Body}, nil
+		{
+			name:     "invalid",
+			access:   api.Public,
+			reqBody:  `invalid json`,
+			respBody: ``,
+			status:   400,
 		},
-		EncodeResp: func(w http.ResponseWriter, json jsoniter.API, resp mockResp) error {
-			w.Write([]byte(resp.Message))
-			return nil
-		},
-	}
-
-	wantBody := "Test Body"
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/", strings.NewReader(wantBody))
-	ps := httprouter.Params{{Key: "key", Value: "value"}}
-	desc.Handle(server.NewIncomingContext(w, req, ps, model.AuthInfo{}))
-	if w.Code != 200 {
-		t.Errorf("got code %d, want 200", w.Code)
-	}
-	if got := w.Body.String(); got != wantBody {
-		t.Errorf("got body %q, want %q", got, wantBody)
-	}
-}
-
-func TestDesc_Unauthenticated(t *testing.T) {
-	cfg := &config.Config{
-		Static:  &config.Static{},
-		Runtime: &config.Runtime{},
-	}
-	logger := zerolog.New(os.Stdout)
-	rt := reqtrack.New(logger, nil, false)
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	server := api.NewServer(cfg, rt, nil, logger, json)
-
-	desc := &api.Desc[mockReq, mockResp]{
-		Service:  "service",
-		Endpoint: "endpoint",
-		Path:     "/foo",
-		Access:   api.RequiresAuth,
-
-		DecodeReq: func(req *http.Request, ps httprouter.Params, json jsoniter.API) (mockReq, error) {
-			body, _ := io.ReadAll(req.Body)
-			return mockReq{
-				Body:   string(body),
-				Params: ps,
-			}, nil
-		},
-		AppHandler: func(ctx context.Context, req mockReq) (mockResp, error) {
-			return mockResp{Message: req.Body}, nil
-		},
-		EncodeResp: func(w http.ResponseWriter, json jsoniter.API, resp mockResp) error {
-			w.Write([]byte(resp.Message))
-			return nil
+		{
+			name:     "unauthenticated",
+			access:   api.RequiresAuth,
+			reqBody:  `{}`,
+			respBody: ``,
+			status:   401,
 		},
 	}
 
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/", nil)
-	ps := httprouter.Params{{Key: "key", Value: "value"}}
-	desc.Handle(server.NewIncomingContext(w, req, ps, model.AuthInfo{}))
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("got code %d, want %d", w.Code, http.StatusUnauthorized)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/", strings.NewReader(test.reqBody))
+			ps := httprouter.Params{{Key: "key", Value: "value"}}
+			desc := newMockAPIDesc(test.access)
+			desc.Handle(server.NewIncomingContext(w, req, ps, model.AuthInfo{}))
+			if w.Code != test.status {
+				t.Errorf("got code %d, want %d", w.Code, test.status)
+				return
+			}
+			if test.respBody != "" {
+				if got := w.Body.String(); got != test.respBody {
+					t.Errorf("got body %q, want %q", got, test.respBody)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
If the API receives a request that cannot be decoded it
would sometimes cause a runtime panic. Fix this, and
improve test coverage of this area while we're at it.

Thanks @melkstam and Max D for the bug report