### PR TITLE
Support Unit Tests in GoLand

### DIFF
--- a/compiler/internal/codegen/codegen_test.go
+++ b/compiler/internal/codegen/codegen_test.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	goparser "go/parser"
 	"go/token"
@@ -183,7 +184,7 @@ func TestCodeGen_TestMain(t *testing.T) {
 
 			for _, pkg := range res.App.Packages {
 				fmt.Fprintf(&buf, "// pkg %s\n", pkg.RelPath)
-				err = bld.TestMain(pkg, res.App.Services).Render(&buf)
+				err = bld.TestMain(pkg, res.App.Services, []string{"ENCORE_DUMMY_ENV_VAR=" + base64.RawURLEncoding.EncodeToString([]byte("{ \"test\": true }"))}).Render(&buf)
 				if err != nil {
 					c.Fatalf("got render error: \n%s", err.Error())
 				}

--- a/compiler/internal/codegen/codegen_testmain.go
+++ b/compiler/internal/codegen/codegen_testmain.go
@@ -1,12 +1,14 @@
 package codegen
 
 import (
+	"strings"
+
 	. "github.com/dave/jennifer/jen"
 
 	"encr.dev/parser/est"
 )
 
-func (b *Builder) TestMain(pkg *est.Package, svcs []*est.Service) *File {
+func (b *Builder) TestMain(pkg *est.Package, svcs []*est.Service, envToEmbed []string) *File {
 	// Define this package as an external foo_test package so that we can
 	// work around potential import cycles between the foo package and
 	// imports of the auth data type (necessary for calling reflect.TypeOf).
@@ -27,19 +29,32 @@ func (b *Builder) TestMain(pkg *est.Package, svcs []*est.Service) *File {
 	mwNames, mwCode := b.RenderMiddlewares(importPath)
 
 	f.Comment("//go:linkname loadApp encore.dev/appruntime/app/appinit.load")
-	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app/appinit", "LoadData").Block(
-		Id("static").Op(":=").Op("&").Qual("encore.dev/appruntime/config", "Static").Values(Dict{
+	f.Func().Id("loadApp").Params().Op("*").Qual("encore.dev/appruntime/app/appinit", "LoadData").BlockFunc(func(g *Group) {
+		staticDict := Dict{
 			Id("AuthData"):     b.authDataType(),
 			Id("Testing"):      True(),
 			Id("TestService"):  Lit(testSvc),
 			Id("PubsubTopics"): b.computeStaticPubsubConfig(),
-		}),
-		Id("handlers").Op(":=").Add(b.computeHandlerRegistrationConfig(mwNames)),
-		Return(Op("&").Qual("encore.dev/appruntime/app/appinit", "LoadData").Values(Dict{
+		}
+
+		// When building tests with the arg "-c", we need to embed the encore runtime environmental arguments into the test binary.
+		// we also want to format the logs
+		if len(envToEmbed) > 0 {
+			for _, env := range envToEmbed {
+				key, value, _ := strings.Cut(env, "=")
+				g.Qual("os", "Setenv").Call(Lit(key), Lit(value))
+			}
+
+			staticDict[Id("TestAsExternalBinary")] = True()
+		}
+
+		g.Id("static").Op(":=").Op("&").Qual("encore.dev/appruntime/config", "Static").Values(staticDict)
+		g.Id("handlers").Op(":=").Add(b.computeHandlerRegistrationConfig(mwNames))
+		g.Return(Op("&").Qual("encore.dev/appruntime/app/appinit", "LoadData").Values(Dict{
 			Id("StaticCfg"):   Id("static"),
 			Id("APIHandlers"): Id("handlers"),
-		})),
-	)
+		}))
+	})
 
 	for _, c := range mwCode {
 		f.Line()

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_header_auth.golden
@@ -6,17 +6,20 @@ import (
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
+	"os"
 	"reflect"
 	_ "unsafe"
 )
 
 //go:linkname loadApp encore.dev/appruntime/app/appinit.load
 func loadApp() *appinit.LoadData {
+	os.Setenv("ENCORE_DUMMY_ENV_VAR", "eyAidGVzdCI6IHRydWUgfQ")
 	static := &config.Static{
-		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
-		PubsubTopics: map[string]*config.StaticPubsubTopic{},
-		TestService:  "svc",
-		Testing:      true,
+		AuthData:             reflect.TypeOf((*svc.AuthData)(nil)),
+		PubsubTopics:         map[string]*config.StaticPubsubTopic{},
+		TestAsExternalBinary: true,
+		TestService:          "svc",
+		Testing:              true,
 	}
 	handlers := []api.HandlerRegistration{
 		{

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__only_query_auth.golden
@@ -6,17 +6,20 @@ import (
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
+	"os"
 	"reflect"
 	_ "unsafe"
 )
 
 //go:linkname loadApp encore.dev/appruntime/app/appinit.load
 func loadApp() *appinit.LoadData {
+	os.Setenv("ENCORE_DUMMY_ENV_VAR", "eyAidGVzdCI6IHRydWUgfQ")
 	static := &config.Static{
-		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
-		PubsubTopics: map[string]*config.StaticPubsubTopic{},
-		TestService:  "svc",
-		Testing:      true,
+		AuthData:             reflect.TypeOf((*svc.AuthData)(nil)),
+		PubsubTopics:         map[string]*config.StaticPubsubTopic{},
+		TestAsExternalBinary: true,
+		TestService:          "svc",
+		Testing:              true,
 	}
 	handlers := []api.HandlerRegistration{
 		{

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__token_auth.golden
@@ -6,17 +6,20 @@ import (
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
+	"os"
 	"reflect"
 	_ "unsafe"
 )
 
 //go:linkname loadApp encore.dev/appruntime/app/appinit.load
 func loadApp() *appinit.LoadData {
+	os.Setenv("ENCORE_DUMMY_ENV_VAR", "eyAidGVzdCI6IHRydWUgfQ")
 	static := &config.Static{
-		AuthData:     reflect.TypeOf((*svc.AuthData)(nil)),
-		PubsubTopics: map[string]*config.StaticPubsubTopic{},
-		TestService:  "svc",
-		Testing:      true,
+		AuthData:             reflect.TypeOf((*svc.AuthData)(nil)),
+		PubsubTopics:         map[string]*config.StaticPubsubTopic{},
+		TestAsExternalBinary: true,
+		TestService:          "svc",
+		Testing:              true,
 	}
 	handlers := []api.HandlerRegistration{
 		{

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
@@ -8,20 +8,23 @@ import (
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	middleware "encore.dev/middleware"
+	"os"
 	"reflect"
 	_ "unsafe"
 )
 
 //go:linkname loadApp encore.dev/appruntime/app/appinit.load
 func loadApp() *appinit.LoadData {
+	os.Setenv("ENCORE_DUMMY_ENV_VAR", "eyAidGVzdCI6IHRydWUgfQ")
 	static := &config.Static{
 		AuthData: reflect.TypeOf((*svc.AuthData)(nil)),
 		PubsubTopics: map[string]*config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*config.StaticPubsubSubscription{"subscription-name": {
 			Service:  "otherservice",
 			TraceIdx: 1,
 		}}}},
-		TestService: "otherservice",
-		Testing:     true,
+		TestAsExternalBinary: true,
+		TestService:          "otherservice",
+		Testing:              true,
 	}
 	handlers := []api.HandlerRegistration{
 		{
@@ -107,20 +110,23 @@ import (
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
 	middleware "encore.dev/middleware"
+	"os"
 	"reflect"
 	_ "unsafe"
 )
 
 //go:linkname loadApp encore.dev/appruntime/app/appinit.load
 func loadApp() *appinit.LoadData {
+	os.Setenv("ENCORE_DUMMY_ENV_VAR", "eyAidGVzdCI6IHRydWUgfQ")
 	static := &config.Static{
 		AuthData: reflect.TypeOf((*svc.AuthData)(nil)),
 		PubsubTopics: map[string]*config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*config.StaticPubsubSubscription{"subscription-name": {
 			Service:  "otherservice",
 			TraceIdx: 1,
 		}}}},
-		TestService: "svc",
-		Testing:     true,
+		TestAsExternalBinary: true,
+		TestService:          "svc",
+		Testing:              true,
 	}
 	handlers := []api.HandlerRegistration{
 		{

--- a/compiler/test.go
+++ b/compiler/test.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
 type TestConfig struct {
@@ -72,6 +74,29 @@ func (b *builder) Test(ctx context.Context) (err error) {
 		}
 	}
 	return b.runTests(ctx)
+}
+
+// EncoreEnvironmentalVariablesToEmbed tells us if we need to embed the environmental variables into the built
+// binary for testing.
+//
+// This is needed because GoLand first builds the test binary as one phase, and then secondary executes that built binary
+func (b *builder) EncoreEnvironmentalVariablesToEmbed() []string {
+	if b.forTesting == false || b.cfg.Test == nil {
+		return nil
+	}
+
+	// If -c is passed to the go test, it means compile the test binary to pkg.test but do not run it
+	if !slices.Contains(b.cfg.Test.Args, "-c") {
+		return nil
+	}
+
+	rtn := make([]string, 0)
+	for _, env := range b.cfg.Test.Env {
+		if strings.HasPrefix(env, "ENCORE_") {
+			rtn = append(rtn, env)
+		}
+	}
+	return rtn
 }
 
 func (b *builder) writeTestMains() error {

--- a/compiler/wrappers.go
+++ b/compiler/wrappers.go
@@ -176,7 +176,7 @@ func (b *builder) generateTestMain(pkg *est.Package) (err error) {
 		}
 	}()
 
-	f := b.codegen.TestMain(pkg, b.res.App.Services)
+	f := b.codegen.TestMain(pkg, b.res.App.Services, b.EncoreEnvironmentalVariablesToEmbed())
 	b.addOverlay(filepath.Join(pkg.Dir, "encore_testmain_test.go"), testMainPath)
 	return f.Render(file)
 }

--- a/runtime/appruntime/app/app.go
+++ b/runtime/appruntime/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"io"
 	"os"
 
 	jsoniter "github.com/json-iterator/go"
@@ -49,7 +50,15 @@ type NewParams struct {
 
 func New(p *NewParams) *App {
 	cfg := p.Cfg
-	rootLogger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	var logOutput io.Writer = os.Stderr
+	if cfg.Static.TestAsExternalBinary {
+		// If we're running as a test and as a binary outside of the Encore Daemon, then we want to
+		// log the output via a console logger, rather than the underlying JSON logs.
+		logOutput = zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {
+			w.Out = logOutput
+		})
+	}
+	rootLogger := zerolog.New(logOutput).With().Timestamp().Logger()
 
 	pc := platform.NewClient(cfg)
 	doTrace := trace.Enabled(cfg)

--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -23,8 +23,9 @@ type Static struct {
 
 	PubsubTopics map[string]*StaticPubsubTopic
 
-	Testing     bool
-	TestService string // service being tested, if any
+	Testing              bool
+	TestService          string // service being tested, if any
+	TestAsExternalBinary bool   // should logs be pretty printed in tests (used when building a test binary to be used outside of the Encore daemon)
 }
 
 type Runtime struct {


### PR DESCRIPTION
This commit adds basic support for running tests from within
GoLand using the Encore GoLand Plugin (yet to be released).

GoLand runs tests in two phases; first it compiles the test, and
then it runs the compiled test file. It does this using the `-c`
argument to `go test`.

This causes problems for Encore as the current assumption is test
binaries will always execute through the Encore daemon, which isn't
the case here.

If we detect that `-c` has been passed to `encore test` then we need
to embed into the binary any enviromental varaibles that would normally
be passed from the daemon to the test (such as the secrets or runtime config).
This allows the Encore runtime to startup correctly for the tests when the execute.

A small change was also made to logging, such that when running in this way
we get human readable logs outputted, rather than the raw JSON payloads. Again
this was due to the fact the daemon is normally the entity receiving the logs
and it internally pretty prints them for the end users.