### PR TITLE
dashapp: fix flow rendering in Firefox

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/svgElements.tsx
+++ b/cli/daemon/dash/dashapp/src/components/svgElements.tsx
@@ -57,7 +57,7 @@ export const ServiceSVG = ({
       >
         <div
           className="h-full w-full border-2"
-          style={{ borderColor: SOFT_BLACK_COLOR }}
+          style={{ background: OFF_WHITE_COLOR, borderColor: SOFT_BLACK_COLOR }}
         >
           <div className="p-1 px-2 font-mono font-semibold">
             <p>{node.label}</p>


### PR DESCRIPTION
For some reason the SVG did not render correctly
in Firefox. Adding an explicit background color
to the boxes fixes the issue.
