### PR TITLE
Fix black box bug in firefox

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/svgElements.tsx
+++ b/cli/daemon/dash/dashapp/src/components/svgElements.tsx
@@ -51,7 +51,6 @@ export const ServiceSVG = ({
 
       <foreignObject
         className="transform duration-100 ease-in-out group-hover:-translate-x-1 group-hover:-translate-y-1"
-        style={{ background: OFF_WHITE_COLOR }}
         width={node.width}
         height={node.height}
       >


### PR DESCRIPTION
Firefox did not allow background color to be set on the foreignObject tag

**Before**
<img width="782" alt="image" src="https://user-images.githubusercontent.com/1826823/188967515-d7ac4506-1469-4118-a0cb-1c731fd9b4d6.png">

**Now**
<img width="833" alt="image" src="https://user-images.githubusercontent.com/1826823/188967594-b203349b-2c8b-4ef9-b804-e331035ba0d9.png">
