### PR TITLE
.devcontainer: upgrade to go 1.19

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.19
 
 RUN apt-get update && apt-get install -y sudo
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \

--- a/.devcontainer/scripts/install.sh
+++ b/.devcontainer/scripts/install.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-encore_uri=$(curl -sSf -N "https://encore.dev/api/releases?target=linux_amd64&show=url")
+target="$(go env GOOS)_$(go env GOARCH)"
+
+encore_uri=$(curl -sSf -N "https://encore.dev/api/releases?target=${target}&show=url")
 if [ ! "$encore_uri" ]; then
     echo "Error: Unable to determine latest Encore release." 1>&2
     exit 1


### PR DESCRIPTION
Also add support for arm64 while we're at it.

Fixes #367