### PR TITLE
runtime/storage/cache: rename Decr->Decrement

### DIFF
--- a/docs/develop/caching.md
+++ b/docs/develop/caching.md
@@ -119,10 +119,14 @@ type MyKey struct {
 
 // ResourceRequestsPerUser tracks the number of requests per user and resource.
 // The cache items expire after 10 seconds without activity.
-var ResourceRequestsPerUser = cache.NewIntKeyspace[auth.UID](cluster, cache.KeyspaceConfig{
+var ResourceRequestsPerUser = cache.NewIntKeyspace[MyKey](cluster, cache.KeyspaceConfig{
 	KeyPattern:    "requests/:UserID/:ResourcePath",
 	DefaultExpiry: cache.ExpireIn(10 * time.Second),
 })
+
+// ... then:
+key := MyKey{UserID: "some-user-id", ResourcePath: "/foo"}
+ResourceRequestsPerUser.Increment(ctx, key, 1)
 ```
 
 <Callout type="important">
@@ -147,7 +151,7 @@ Basic keyspace types include
 [strings](https://pkg.go.dev/encore.dev/storage/cache#NewStringKeyspace),
 [integers](https://pkg.go.dev/encore.dev/storage/cache#NewIntKeyspace),
 [floats](https://pkg.go.dev/encore.dev/storage/cache#NewFloatKeyspace),
-and [struct types](https://pkg.go.dev/encore.dev/storage/cache#NewStringKeyspace).
+and [struct types](https://pkg.go.dev/encore.dev/storage/cache#NewStructKeyspace).
 These keyspaces all share the same set of methods (along with a few keyspace-specific ones).
 
 There are also more advanced keyspaces for storing [sets of basic types](https://pkg.go.dev/encore.dev/storage/cache#NewSetKeyspace)

--- a/runtime/storage/cache/basic.go
+++ b/runtime/storage/cache/basic.go
@@ -281,11 +281,11 @@ func (s *IntKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, er
 // before incrementing.
 //
 // Negative values can be used to decrease the value,
-// but typically you want to use the Decr method for that.
+// but typically you want to use the Decrement method for that.
 //
 // See https://redis.io/commands/incrby/ for more information.
 func (s *IntKeyspace[K]) Increment(ctx context.Context, key K, delta int64) (newVal int64, err error) {
-	const op = "incr"
+	const op = "increment"
 	k, err := s.key(key, op)
 	defer s.doTrace(op, true, k)(err)
 	if err != nil {
@@ -299,18 +299,18 @@ func (s *IntKeyspace[K]) Increment(ctx context.Context, key K, delta int64) (new
 	return res, err
 }
 
-// Decr decrements the number stored in key by delta,
+// Decrement decrements the number stored in key by delta,
 // and returns the new value.
 //
 // If the key does not exist it is first created with a value of 0
 // before decrementing.
 //
 // Negative values can be used to increase the value,
-// but typically you want to use the Incr method for that.
+// but typically you want to use the Increment method for that.
 //
 // See https://redis.io/commands/decrby/ for more information.
-func (s *IntKeyspace[K]) Decr(ctx context.Context, key K, delta int64) (newVal int64, err error) {
-	const op = "decr"
+func (s *IntKeyspace[K]) Decrement(ctx context.Context, key K, delta int64) (newVal int64, err error) {
+	const op = "decrement"
 	k, err := s.key(key, op)
 	defer s.doTrace(op, true, k)(err)
 	if err != nil {
@@ -419,11 +419,11 @@ func (s *FloatKeyspace[K]) Delete(ctx context.Context, keys ...K) (deleted int, 
 // before incrementing.
 //
 // Negative values can be used to decrease the value,
-// but typically you want to use the Decr method for that.
+// but typically you want to use the Decrement method for that.
 //
 // See https://redis.io/commands/incrbyfloat/ for more information.
 func (s *FloatKeyspace[K]) Increment(ctx context.Context, key K, delta float64) (newVal float64, err error) {
-	const op = "incr"
+	const op = "increment"
 	k, err := s.key(key, op)
 	defer s.doTrace(op, true, k)(err)
 	if err != nil {
@@ -437,18 +437,18 @@ func (s *FloatKeyspace[K]) Increment(ctx context.Context, key K, delta float64) 
 	return res, err
 }
 
-// Decr decrements the number stored in key by delta,
+// Decrement decrements the number stored in key by delta,
 // and returns the new value.
 //
 // If the key does not exist it is first created with a value of 0
 // before decrementing.
 //
 // Negative values can be used to increase the value,
-// but typically you want to use the Incr method for that.
+// but typically you want to use the Increment method for that.
 //
 // See https://redis.io/commands/incrbyfloat/ for more information.
-func (s *FloatKeyspace[K]) Decr(ctx context.Context, key K, delta float64) (newVal float64, err error) {
-	const op = "decr"
+func (s *FloatKeyspace[K]) Decrement(ctx context.Context, key K, delta float64) (newVal float64, err error) {
+	const op = "decrement"
 	k, err := s.key(key, op)
 	defer s.doTrace(op, true, k)(err)
 	if err != nil {

--- a/runtime/storage/cache/basic_test.go
+++ b/runtime/storage/cache/basic_test.go
@@ -106,7 +106,7 @@ func TestIntKeyspace(t *testing.T) {
 		t.Errorf("incr: got %v, want %v", got, want)
 	}
 
-	if got, want := must(ks.Decr(ctx, "one", 1)), int64(3); got != want {
+	if got, want := must(ks.Decrement(ctx, "one", 1)), int64(3); got != want {
 		t.Errorf("decr: got %v, want %v", got, want)
 	}
 }
@@ -126,7 +126,7 @@ func TestFloatKeyspace(t *testing.T) {
 		t.Errorf("incr: got %v, want %v", got, want)
 	}
 
-	if got, want := must(ks.Decr(ctx, "one", 1)), float64(3); got != want {
+	if got, want := must(ks.Decrement(ctx, "one", 1)), float64(3); got != want {
 		t.Errorf("decr: got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
This was missed in the release earlier today. Fix it now
before people start depending on it and we become stuck
with inconsistent names.

Also fix a documentation error while we're at it.
Thanks @melkstam for the reports!

Fixes #378 #379 #381