### PR TITLE
Add ability to scroll to logs in trace view

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/app/AppTraces.tsx
+++ b/cli/daemon/dash/dashapp/src/components/app/AppTraces.tsx
@@ -174,7 +174,7 @@ const TraceView: FC<TraceViewProps> = (props) => {
 
   return (
     <section className="relative flex h-full flex-grow items-stretch bg-white">
-      <div className="absolute -top-2 -right-2">
+      <div className="absolute -top-2 -right-2 bg-white">
         <div
           className="hover:bg-gray-100 cursor-pointer rounded-full p-1"
           onClick={() => props.close()}
@@ -195,7 +195,7 @@ const TraceView: FC<TraceViewProps> = (props) => {
         </div>
       </div>
 
-      <div className="flex flex-grow flex-col overflow-scroll scrollbar-none">
+      <div className="flex flex-grow flex-col overflow-auto">
         <div className="border-gray-100 flex border-b p-4">
           <div className="mr-4 flex-shrink-0">
             <h1 className="text-gray-900 mb-1 text-2xl font-semibold leading-none">
@@ -235,7 +235,7 @@ const TraceView: FC<TraceViewProps> = (props) => {
               <h3 className="mb-2 flex items-center justify-between text-xl font-semibold">
                 Stack Trace
                 <button
-                  className="focus:outline-none hover:text-gray-600"
+                  className="hover:text-gray-600 focus:outline-none"
                   onClick={() => setStack(undefined)}
                 >
                   {icons.x("h-5 w-5")}
@@ -249,7 +249,7 @@ const TraceView: FC<TraceViewProps> = (props) => {
         </div>
       </div>
 
-      <div className="w-96 flex-shrink-0 overflow-scroll border-l border-black p-4 scrollbar-none md:w-1/2">
+      <div className="h-full w-96 flex-shrink-0 border-l border-black p-4 md:w-1/2">
         <SpanDetail req={selected} trace={tr} onStackTrace={setStack} />
       </div>
     </section>

--- a/cli/daemon/dash/dashapp/src/components/trace/SpanDetail.tsx
+++ b/cli/daemon/dash/dashapp/src/components/trace/SpanDetail.tsx
@@ -69,9 +69,16 @@ const SpanDetail: FunctionComponent<Props> = (props) => {
     type = "PubSub Message Received";
   }
 
+  const logsRef = useRef<HTMLDivElement>(null);
+  const scrollToRef = (ref: React.MutableRefObject<HTMLDivElement | null>) => {
+    if (ref.current && ref.current.scrollIntoView) {
+      ref.current.scrollIntoView();
+    }
+  };
+
   return (
     <>
-      <div>
+      <div className="flex h-full flex-col">
         <h2 className="text-2xl font-semibold">
           {icon("h-5 w-5 mr-2 inline-block", type)}
           {svcName}.{rpcName}
@@ -123,7 +130,12 @@ const SpanDetail: FunctionComponent<Props> = (props) => {
             Publish{publishedMessages.length !== 1 ? "es" : ""}
           </div>
 
-          <div className="body-sm flex items-center">
+          <div
+            className={`body-sm flex items-center ${
+              logs.length ? "cursor-pointer" : ""
+            }`}
+            onClick={() => scrollToRef(logsRef)}
+          >
             <div>{icons.menuAlt2("h-5 w-auto")}</div>
             <span className="text-gray-800 mx-1 font-semibold">
               {logs.length}
@@ -132,7 +144,7 @@ const SpanDetail: FunctionComponent<Props> = (props) => {
           </div>
         </div>
 
-        <div>
+        <div className="h-full overflow-auto">
           <div className="mt-6">
             <EventMap
               trace={props.trace}
@@ -271,7 +283,7 @@ const SpanDetail: FunctionComponent<Props> = (props) => {
           )}
 
           {logs.length > 0 && (
-            <div className="mt-6">
+            <div className="mt-6" ref={logsRef}>
               <h4 className="text-gray-300 mb-2 font-sans text-xs font-semibold uppercase leading-3 tracking-wider">
                 Logs
               </h4>
@@ -647,7 +659,7 @@ const PubsubPublishTooltip: FunctionComponent<{
         <h4 className="text-gray-300 mb-2 font-sans text-xs font-semibold uppercase leading-3 tracking-wider">
           Message
         </h4>
-        {renderData([publish.message])}
+        {renderData([publish.message], "max-h-96")}
       </div>
 
       <div className="mt-4">
@@ -689,7 +701,7 @@ const CacheOpTooltip: FunctionComponent<{
           {op.end_time ? latencyStr(op.end_time - op.start_time) : "Unknown"}
           {op.stack.frames.length > 0 && (
             <button
-              className="focus:outline-none -mr-1"
+              className="-mr-1 focus:outline-none"
               onClick={() => props.onStackTrace(op.stack)}
             >
               {icons.stackTrace("m-1 h-4 w-auto")}
@@ -703,9 +715,7 @@ const CacheOpTooltip: FunctionComponent<{
           <h4 className="text-gray-300 mb-2 font-sans text-xs font-semibold uppercase leading-3 tracking-wider">
             Keyspace
           </h4>
-          <div className="text-gray-700 text-sm">
-            {keyspaceName}
-          </div>
+          <div className="text-gray-700 text-sm">{keyspaceName}</div>
         </div>
       )}
 
@@ -713,9 +723,7 @@ const CacheOpTooltip: FunctionComponent<{
         <h4 className="text-gray-300 mb-2 font-sans text-xs font-semibold uppercase leading-3 tracking-wider">
           Operation
         </h4>
-        <div className="text-gray-700 text-sm">
-          {op.operation}
-        </div>
+        <div className="text-gray-700 text-sm">{op.operation}</div>
       </div>
 
       {op.keys.length > 0 && (
@@ -779,7 +787,7 @@ const DBQueryTooltip: FunctionComponent<{
         <h4 className="text-gray-300 mb-2 font-sans text-xs font-semibold uppercase leading-3 tracking-wider">
           Query
         </h4>
-        {renderData([q.query], "sql")}
+        {renderData([q.query], "max-h-96", "sql")}
       </div>
 
       <div className="mt-4">
@@ -854,7 +862,7 @@ const RPCCallTooltip: FunctionComponent<{
         </h4>
         {target !== undefined ? (
           target.outputs.length > 0 ? (
-            renderData(target.outputs)
+            renderData(target.outputs, "max-h-96")
           ) : (
             <div className="text-gray-700 text-sm">No response data.</div>
           )
@@ -993,6 +1001,7 @@ const HTTPCallTooltip: FunctionComponent<{
 
 const renderData = (
   data: Base64EncodedBytes[],
+  className: string = "",
   mode: string | ModeSpec<ModeSpecOptions> = {
     name: "javascript",
     json: true,
@@ -1007,7 +1016,9 @@ const renderData = (
     /* do nothing */
   }
   return (
-    <pre className="response-docs overflow-auto rounded border bg-black p-2 text-sm text-white">
+    <pre
+      className={`response-docs overflow-auto rounded border bg-black p-2 text-sm text-white ${className}`}
+    >
       <CM
         key={pretty}
         cfg={{


### PR DESCRIPTION
## What

* Add back the scrollbar to the tracing view (when the content is to big)
* Add "jump to logs" functionality (when you have logs)
* Add max height to the code parts of the tracing tooltips

## Why

If the request/response data is big then you have to scroll to get to the logs. Because we recently removed the scrollbar it became more cumbersome to get to the logs. 

## Screenshots

**Jump to logs**

![jump to logs](https://user-images.githubusercontent.com/1826823/191759270-7e861ec9-7ed8-4b6a-8dc9-26ae95138e9e.gif)

**Max height to code in tooltips**

![max height](https://user-images.githubusercontent.com/1826823/191759294-fa5157d6-b118-4f9a-8d73-d65fe67fafe6.gif)