### PR TITLE
runtime: add redis TLS override

### DIFF
--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -229,6 +229,10 @@ type RedisServer struct {
 	User     string `json:"user,omitempty"`
 	Password string `json:"password,omitempty"`
 
+	// EnableTLS specifies whether or not to use TLS to connect.
+	// If ServerCACert, ClientCert, or ClientKey are provided it is
+	// automatically enabled regardless of the value.
+	EnableTLS bool `json:"enable_tls"`
 	// ServerCACert is the PEM-encoded server CA cert, or "" if not required.
 	ServerCACert string `json:"server_ca_cert,omitempty"`
 	// ClientCert is the PEM-encoded client cert, or "" if not required.

--- a/runtime/storage/cache/manager_internal.go
+++ b/runtime/storage/cache/manager_internal.go
@@ -112,7 +112,7 @@ func (mgr *Manager) newClient(rdb *config.RedisDatabase) (*redis.Client, error) 
 		opts.Network = "unix"
 	}
 
-	if srv.ServerCACert != "" || srv.ClientCert != "" {
+	if srv.EnableTLS || srv.ServerCACert != "" || srv.ClientCert != "" {
 		opts.TLSConfig = &tls.Config{}
 		if srv.ServerCACert != "" {
 			caCertPool := x509.NewCertPool()


### PR DESCRIPTION
For AWS's Redis TLS support we don't need a custom
cert, but still want to enable TLS. Add a config setting
that enables TLS even if there are no custom certs.