### PR TITLE
Print message when encore logs is waiting for logs

### DIFF
--- a/cli/cmd/encore/logs.go
+++ b/cli/cmd/encore/logs.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/logrusorgru/aurora/v3"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 
@@ -94,7 +96,7 @@ func streamLogs(appRoot, envName string) {
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
 	if !logsQuiet {
-		os.Stdout.WriteString("Connected, waiting for logs...")
+		fmt.Println(aurora.Gray(12, "Connected, waiting for logs..."))
 	}
 
 	cw := zerolog.NewConsoleWriter()

--- a/cli/cmd/encore/logs.go
+++ b/cli/cmd/encore/logs.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	logsEnv  string
-	logsJSON bool
+	logsEnv   string
+	logsJSON  bool
+	logsQuiet bool
 )
 
 var logsCmd = &cobra.Command{
@@ -92,6 +93,10 @@ func streamLogs(appRoot, envName string) {
 	// Use the same configuration as the runtime
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
+	if !logsQuiet {
+		os.Stdout.WriteString("Connected, waiting for logs...")
+	}
+
 	cw := zerolog.NewConsoleWriter()
 	for {
 		_, message, err := logs.ReadMessage()
@@ -123,4 +128,5 @@ func init() {
 	rootCmd.AddCommand(logsCmd)
 	logsCmd.Flags().StringVarP(&logsEnv, "env", "e", "", "Environment name to stream logs from (defaults to the production environment)")
 	logsCmd.Flags().BoolVar(&logsJSON, "json", false, "Whether to print logs in raw JSON format")
+	logsCmd.Flags().BoolVarP(&logsQuiet, "quiet", "q", false, "Whether to print initial message when the command is waiting for logs")
 }


### PR DESCRIPTION
`encore logs` doesn't print any message when started, so you can't tell whether it's waiting for logs. This PR adds the code to print a message to standard output when `encore logs` is started.

The message can be omitted by passing the `-q` flag to `encore logs`, which might be useful when using this command for scripting.