### PR TITLE
cli/daemon/run: track app compilation

### DIFF
--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -279,7 +279,7 @@ func (r *Run) buildAndStart(ctx context.Context, tracker *optracker.OpTracker) e
 	}
 
 	var build *compiler.Result
-	jobs.Go("Compiling application source code", false, 0, func(ctx context.Context) (err error) {
+	jobs.Go("Compiling Encore application", true, 0, func(ctx context.Context) (err error) {
 		cfg := &compiler.Config{
 			Revision:              parse.Meta.AppRevision,
 			UncommittedChanges:    parse.Meta.UncommittedChanges,


### PR DESCRIPTION
This makes the compilation step tracked by Encore
to ensure compilation errors are always printed.

Fixes #393