### PR TITLE
Reset clients on logout

### DIFF
--- a/cli/internal/conf/conf.go
+++ b/cli/internal/conf/conf.go
@@ -92,6 +92,8 @@ func Logout() error {
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	DefaultTokenSource = &TokenSource{}
+	AuthClient = oauth2.NewClient(nil, DefaultTokenSource)
 	return nil
 }
 


### PR DESCRIPTION
We need to recreate the default token source and auth client to actually logout without restarting the daemon