### PR TITLE
[ENC-796] Add support for Environmental selectors

### DIFF
--- a/cli/daemon/export/export.go
+++ b/cli/daemon/export/export.go
@@ -54,6 +54,13 @@ func Docker(ctx context.Context, req *daemonpb.ExportRequest, log zerolog.Logger
 		GOOS:                  req.Goos,
 		GOARCH:                req.Goarch,
 		KeepOutput:            false,
+
+		// Note: we do not pass any configuration meta data here, because we don't know how or where the
+		// generated image will be used. Thus we can't build a concrete configuration which relies on these values.
+		//
+		// However, if the user has not used the #Meta data in the CUE files, then we can still compute a concrete
+		// instance of their applications configuration.
+		Meta: nil,
 	}
 
 	log.Info().Msgf("compiling Encore application for %s/%s", req.Goos, req.Goarch)

--- a/cli/daemon/run/testdata/echo/echo/config.cue
+++ b/cli/daemon/run/testdata/echo/echo/config.cue
@@ -1,6 +1,13 @@
+import "encoding/base64"
+
 ReadOnlyMode: true
-PublicKey: "aGVsbG8gd29ybGQK" // "hello world" in Base64
-SubConfig: SubKey: MaxCount: 123
+PublicKey: base64.Decode(null, "aGVsbG8gd29ybGQK") // "hello world" in Base64
+
+SubConfig: SubKey: MaxCount: [
+	if #Meta.Environment.Type  == "test"  { 3 },
+	if #Meta.Environment.Cloud == "local" { 2 },
+	1
+][0]
 
 AdminUsers: [
 	"foo",

--- a/cli/daemon/run/testdata/echo/echo/config_test.go
+++ b/cli/daemon/run/testdata/echo/echo/config_test.go
@@ -1,0 +1,18 @@
+package echo
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestConfigValues(t *testing.T) {
+	values, err := ConfigValues(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if values.SubKeyCount != 3 {
+		t.Fatalf("expected 1, got %d", values.SubKeyCount)
+	}
+}

--- a/cli/daemon/run/testdata/echo/echo/encore.gen.cue
+++ b/cli/daemon/run/testdata/echo/echo/encore.gen.cue
@@ -7,18 +7,18 @@
 //
 // For more information about this file, see:
 // https://encore.dev/docs/develop/config
-package svc
+package echo
 
 // #Meta contains metadata about the running Encore application.
 // The values in this struct will be injected by Encore upon deployment and can be
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 
@@ -28,10 +28,9 @@ package svc
 // this definition is then immediately inlined, so any fields within it are expected
 // as fields at the package level.
 #Config: {
-	// The options for the HTTP server
-	HTTP: {
-		Enabled: bool   // Is this option enabled?
-		Port:    uint32 // What port should we run on?
-	}
+	ReadOnlyMode: bool
+	PublicKey:    bytes
+	AdminUsers: [...string]
+	SubConfig: SubKey: MaxCount: uint
 }
 #Config

--- a/cli/daemon/run/tests.go
+++ b/cli/daemon/run/tests.go
@@ -20,6 +20,7 @@ import (
 	"encr.dev/cli/internal/version"
 	"encr.dev/compiler"
 	"encr.dev/parser"
+	"encr.dev/pkg/cueutil"
 	"encr.dev/pkg/vcs"
 )
 
@@ -118,16 +119,18 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 		}
 	}
 
+	apiBaseURL := fmt.Sprintf("http://localhost:%d", mgr.RuntimePort)
+
 	runtimeJSON, err := json.Marshal(&config.Runtime{
 		AppID:         "test",
 		AppSlug:       params.App.PlatformID(),
-		APIBaseURL:    fmt.Sprintf("http://localhost:%d", mgr.RuntimePort),
+		APIBaseURL:    apiBaseURL,
 		DeployID:      fmt.Sprintf("clitest_%s", xid.New()),
 		DeployedAt:    time.Now(),
 		EnvID:         "test",
 		EnvName:       "local",
 		EnvCloud:      string(encore.CloudLocal),
-		EnvType:       string(encore.EnvLocal),
+		EnvType:       string(encore.EnvTest),
 		TraceEndpoint: "http://localhost:" + strconv.Itoa(mgr.RuntimePort) + "/trace",
 		SQLDatabases:  sqlDBs,
 		SQLServers:    sqlServers,
@@ -146,6 +149,12 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 		EncoreRuntimePath:     env.EncoreRuntimePath(),
 		EncoreGoRoot:          env.EncoreGoRoot(),
 		BuildTags:             []string{"encore_local"},
+		Meta: &cueutil.Meta{
+			APIBaseURL: apiBaseURL,
+			EnvName:    "local",
+			EnvType:    cueutil.EnvType_Test,
+			CloudType:  cueutil.CloudType_Local,
+		},
 		Test: &compiler.TestConfig{
 			Env: append(params.Environ,
 				"ENCORE_RUNTIME_CONFIG="+base64.RawURLEncoding.EncodeToString(runtimeJSON),

--- a/compiler/build.go
+++ b/compiler/build.go
@@ -26,6 +26,7 @@ import (
 	"encr.dev/internal/optracker"
 	"encr.dev/parser"
 	"encr.dev/parser/est"
+	"encr.dev/pkg/cueutil"
 )
 
 type Config struct {
@@ -73,6 +74,10 @@ type Config struct {
 
 	// Test is the specific settings for running tests.
 	Test *TestConfig
+
+	// The meta config we pass to CUE when computing the runtime configuration for the services within this
+	// application
+	Meta *cueutil.Meta
 
 	// If Parse is set, the build will skip parsing the app again
 	// and use the information provided.

--- a/compiler/config.go
+++ b/compiler/config.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"encr.dev/compiler/internal/cueutil"
 	"encr.dev/parser/est"
+	"encr.dev/pkg/cueutil"
 	"encr.dev/pkg/eerror"
 	"encr.dev/pkg/vfs"
 )
@@ -38,7 +38,7 @@ func (b *builder) pickupConfigFiles() error {
 
 // computeConfigForService takes a given service and computes the configuration needed for it
 func (b *builder) computeConfigForService(service *est.Service) error {
-	cfg, err := cueutil.LoadFromFS(b.configFiles, service.Root.RelPath)
+	cfg, err := cueutil.LoadFromFS(b.configFiles, service.Root.RelPath, b.cfg.Meta)
 	if err != nil {
 		return err
 	}

--- a/compiler/internal/cuegen/testdata/basic_config_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_config_svc.cue
@@ -9,12 +9,33 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-Name:     string // The users name
-Port:     uint16
-ReadOnly: bool // true if we're in read only mode
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
 
-// MagicNumber is complicated and requires
-// a multi-line comment to explain it.
-MagicNumber: int
-ID:          string // An ID
-PublicKey:   bytes
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	Name:     string // The users name
+	Port:     uint16
+	ReadOnly: bool // true if we're in read only mode
+
+	// MagicNumber is complicated and requires
+	// a multi-line comment to explain it.
+	MagicNumber: int
+	ID:          string // An ID
+	PublicKey:   bytes
+}
+#Config

--- a/compiler/internal/cuegen/testdata/basic_lists_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_lists_svc.cue
@@ -9,5 +9,26 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-Ages: [...int32]
-OtherBits: [...string]
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	Ages: [...int32]
+	OtherBits: [...string]
+}
+#Config

--- a/compiler/internal/cuegen/testdata/basic_maps_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_maps_svc.cue
@@ -9,4 +9,25 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-Ages: [string]: int
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	Ages: [string]: int
+}
+#Config

--- a/compiler/internal/cuegen/testdata/basic_named_struct_multiple_uses_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_named_struct_multiple_uses_svc.cue
@@ -9,12 +9,33 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	HTTP: #ServerOptions // The options for the HTTP server
+	TCP:  #ServerOptions // The options for the TCP server
+	GRPC: #ServerOptions // The options for the GRPC server
+}
+#Config
+
 // ServerOptions represent options for a server
 #ServerOptions: {
 	Enabled: bool   // Is this option enabled?
 	Port:    uint32 // What port should we run on?
 }
-
-HTTP: #ServerOptions // The options for the HTTP server
-TCP:  #ServerOptions // The options for the TCP server
-GRPC: #ServerOptions // The options for the GRPC server

--- a/compiler/internal/cuegen/testdata/basic_named_struct_single_use_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_named_struct_single_use_svc.cue
@@ -9,8 +9,29 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-// The options for the HTTP server
-HTTP: {
-	Enabled: bool   // Is this option enabled?
-	Port:    uint32 // What port should we run on?
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
 }
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	// The options for the HTTP server
+	HTTP: {
+		Enabled: bool   // Is this option enabled?
+		Port:    uint32 // What port should we run on?
+	}
+}
+#Config

--- a/compiler/internal/cuegen/testdata/basic_with_cue_imports_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_with_cue_imports_svc.cue
@@ -9,6 +9,26 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
 import "time"
 
-SomeTime: time.Time
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	SomeTime: time.Time
+}
+#Config

--- a/compiler/internal/cuegen/testdata/basic_wrappers_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_wrappers_svc.cue
@@ -9,16 +9,36 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
 import "time"
 
-Name:     string // The users name
-Port:     uint16
-ReadOnly: bool // true if we're in read only mode
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	Name:     string // The users name
+	Port:     uint16
+	ReadOnly: bool // true if we're in read only mode
 
-// MagicNumber is complicated and requires
-// a multi-line comment to explain it.
-MagicNumber: int
-Start:       time.Time // The time at which the service was first started
-ID:          string    // An ID
-PublicKey:   bytes
-AdminUsers: [...string]
+	// MagicNumber is complicated and requires
+	// a multi-line comment to explain it.
+	MagicNumber: int
+	Start:       time.Time // The time at which the service was first started
+	ID:          string    // An ID
+	PublicKey:   bytes
+	AdminUsers: [...string]
+}
+#Config

--- a/compiler/internal/cuegen/testdata/cue_optional_tag_svc.cue
+++ b/compiler/internal/cuegen/testdata/cue_optional_tag_svc.cue
@@ -9,12 +9,33 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	HTTP:    #ServerOption
+	Another: #ServerOption
+	TCP?:    #ServerOption
+	GRPC?:   #ServerOption
+}
+#Config
+
 #ServerOption: {
 	Option:    int64
 	Disabled?: bool // True if this is disabled
 }
-
-HTTP:    #ServerOption
-Another: #ServerOption
-TCP?:    #ServerOption
-GRPC?:   #ServerOption

--- a/compiler/internal/cuegen/testdata/cue_tags_svc.cue
+++ b/compiler/internal/cuegen/testdata/cue_tags_svc.cue
@@ -9,6 +9,27 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-A: int
-B: int & A+C
-C: int & B-A
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	A: int
+	B: int & A+C
+	C: int & B-A
+}
+#Config

--- a/compiler/internal/cuegen/testdata/generic_named_types_svc.cue
+++ b/compiler/internal/cuegen/testdata/generic_named_types_svc.cue
@@ -9,6 +9,38 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	HTTP:    #DisablableOption_uint16 // The options for the HTTP server
+	Another: #DisablableOption_uint64
+	TCP:     #DisablableOption_uint16 // The options for the TCP server
+	GRPC:    #DisablableOption_uint64 // The options for the GRPC server
+	List1:   #List_string             // A list of strings
+	List2:   #List_string
+	List3: [...int]
+	Map1: #Map_string_string
+	Map2: [int]: string
+	Map3: #Map_string_string
+}
+#Config
+
 // Generic option which can be disbaled
 #DisablableOption_uint16: {
 	Option:   uint16
@@ -27,14 +59,3 @@ package svc
 #Map_string_string: {
 	[string]: string
 }
-
-HTTP:    #DisablableOption_uint16 // The options for the HTTP server
-Another: #DisablableOption_uint64
-TCP:     #DisablableOption_uint16 // The options for the TCP server
-GRPC:    #DisablableOption_uint64 // The options for the GRPC server
-List1:   #List_string             // A list of strings
-List2:   #List_string
-List3: [...int]
-Map1: #Map_string_string
-Map2: [int]: string
-Map3: #Map_string_string

--- a/compiler/internal/cuegen/testdata/generic_top_level_type_svc.cue
+++ b/compiler/internal/cuegen/testdata/generic_top_level_type_svc.cue
@@ -9,4 +9,25 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-value?: uint // Some config
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	value?: uint // Some config
+}
+#Config

--- a/compiler/internal/cuegen/testdata/json_tags_svc.cue
+++ b/compiler/internal/cuegen/testdata/json_tags_svc.cue
@@ -9,12 +9,33 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	HTTP:          #ServerOption
+	a_n_o_t_h_e_r: #ServerOption
+	TCP?:          #ServerOption
+	GRPC?:         #ServerOption
+}
+#Config
+
 #ServerOption: {
 	Option:    int64
 	Disabled?: bool // True if this is disabled
 }
-
-HTTP:          #ServerOption
-a_n_o_t_h_e_r: #ServerOption
-TCP?:          #ServerOption
-GRPC?:         #ServerOption

--- a/compiler/internal/cuegen/testdata/merge_identical_comments_svc.cue
+++ b/compiler/internal/cuegen/testdata/merge_identical_comments_svc.cue
@@ -9,7 +9,28 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-// Multiline test
-// comment to deduplicate.
-// Some extra comment
-Foo: string
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	// Multiline test
+	// comment to deduplicate.
+	// Some extra comment
+	Foo: string
+}
+#Config

--- a/compiler/internal/cuegen/testdata/multiple_configs_in_service_svc.cue
+++ b/compiler/internal/cuegen/testdata/multiple_configs_in_service_svc.cue
@@ -9,11 +9,32 @@
 // https://encore.dev/docs/develop/config
 package svc
 
-// Foo is great in Otherconfig
-// And even better in ThisConfig
-Foo:      string
-Bar:      int
-Name:     string // The users name
-Port:     uint16
-ReadOnly: bool // true if we're in read only mode
-Baz:      bool
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	// Foo is great in Otherconfig
+	// And even better in ThisConfig
+	Foo:      string
+	Bar:      int
+	Name:     string // The users name
+	Port:     uint16
+	ReadOnly: bool // true if we're in read only mode
+	Baz:      bool
+}
+#Config

--- a/compiler/internal/cuegen/testdata/types_from_multiple_packages_svc.cue
+++ b/compiler/internal/cuegen/testdata/types_from_multiple_packages_svc.cue
@@ -9,6 +9,33 @@
 // https://encore.dev/docs/develop/config
 package svc
 
+// #Meta contains metadata about the running Encore application.
+// The values in this struct will be injected by Encore upon deployment and can be
+// referenced from other config values for example when configuring a callback URL:
+//    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
+#Meta: {
+	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	Environment: {
+		Name:  string                                                        @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+	}
+}
+
+// #Config is the top level configuration for the application and is generated
+// from the Go types you've passed into `config.Load[T]()`. Encore uses a definition
+// of this struct which is closed, such that the CUE tooling can any typos of field names.
+// this definition is then immediately inlined, so any fields within it are expected
+// as fields at the package level.
+#Config: {
+	A: #ExtraConfig
+	B: #ExtraConfig_1
+	C: #ExtraConfig
+	D: #ExtraConfig_1
+	E: Lock: bool
+}
+#Config
+
 #ExtraConfig: {
 	Foo: string
 	Baz: bytes
@@ -18,9 +45,3 @@ package svc
 	Foo: string
 	Bar: int
 }
-
-A: #ExtraConfig
-B: #ExtraConfig_1
-C: #ExtraConfig
-D: #ExtraConfig_1
-E: Lock: bool

--- a/compiler/test.go
+++ b/compiler/test.go
@@ -39,6 +39,7 @@ func Test(ctx context.Context, appRoot string, cfg *Config) error {
 		cfg:        cfg,
 		appRoot:    appRoot,
 		forTesting: true,
+		configs:    make(map[string]string),
 	}
 	return b.Test(ctx)
 }
@@ -69,6 +70,7 @@ func (b *builder) Test(ctx context.Context) (err error) {
 		b.writePackages,
 		b.writeHandlers,
 		b.writeTestMains,
+		b.writeConfigUnmarshallers,
 		b.writeEtypePkg,
 	} {
 		if err := fn(); err != nil {

--- a/pkg/cueutil/build.go
+++ b/pkg/cueutil/build.go
@@ -27,7 +27,7 @@ import (
 
 // LoadFromFS takes a given filesystem object and the app-relative path to the service's root package
 // and loads the full configuration needed for that service.
-func LoadFromFS(filesys fs.FS, serviceRelPath string) (cue.Value, error) {
+func LoadFromFS(filesys fs.FS, serviceRelPath string, meta *Meta) (cue.Value, error) {
 	// Work out of a temporary directory
 	tmpPath, err := os.MkdirTemp("", "encr-cfg-")
 	if err != nil {
@@ -51,6 +51,7 @@ func LoadFromFS(filesys fs.FS, serviceRelPath string) (cue.Value, error) {
 	loaderCfg := &load.Config{
 		Dir:   tmpPath,
 		Tools: true,
+		Tags:  meta.ToTags(),
 	}
 	pkgs := load.Instances(configFilesForService, loaderCfg)
 	for _, pkg := range pkgs {

--- a/pkg/cueutil/types.go
+++ b/pkg/cueutil/types.go
@@ -1,0 +1,44 @@
+package cueutil
+
+type EnvType string
+
+const (
+	EnvType_Production  EnvType = "production"
+	EnvType_Development EnvType = "development"
+	EnvType_Ephemeral   EnvType = "ephemeral"
+	EnvType_Test        EnvType = "test"
+)
+
+type CloudType string
+
+const (
+	CloudType_AWS    CloudType = "aws"
+	CloudType_Azure  CloudType = "azure"
+	CloudType_GCP    CloudType = "gcp"
+	CloudType_Encore CloudType = "encore"
+	CloudType_Local  CloudType = "local"
+)
+
+type Meta struct {
+	APIBaseURL string
+	EnvName    string
+	EnvType    EnvType
+	CloudType  CloudType
+}
+
+func (m *Meta) ToTags() []string {
+	if m == nil {
+		return nil
+	}
+
+	return []string{
+		tag("APIBaseURL", m.APIBaseURL),
+		tag("EnvName", m.EnvName),
+		tag("EnvType", m.EnvType),
+		tag("CloudType", m.CloudType),
+	}
+}
+
+func tag[T ~string](name string, value T) string {
+	return name + "=" + string(value)
+}

--- a/pkg/errlist/errlist_dev.go
+++ b/pkg/errlist/errlist_dev.go
@@ -19,7 +19,7 @@ var projectSourcePath = getProjectSrcPath()
 // addErrToList adds a parse error to the list, but also captures
 // the position within our parse that the error originated.
 func addErrToList(list *scanner.ErrorList, position token.Position, msg string) {
-	list.Add(position, msg+getStack())
+	list.Add(position, msg+GetStack())
 }
 
 // getRepoPath returns the path to this repo on the local system.
@@ -36,8 +36,8 @@ func getProjectSrcPath() string {
 	return fmt.Sprintf("%s%c", encoreProjectPath, os.PathSeparator)
 }
 
-// getStack returns a human readable stack trace.
-func getStack() string {
+// GetStack returns a human readable stack trace.
+func GetStack() string {
 	ret := make([]uintptr, 100)
 
 	index := runtime.Callers(1, ret)

--- a/pkg/errlist/errlist_release.go
+++ b/pkg/errlist/errlist_release.go
@@ -12,3 +12,7 @@ import (
 func addErrToList(list *scanner.ErrorList, position token.Position, msg string) {
 	list.Add(position, msg)
 }
+
+func GetStack() string {
+	return ""
+}

--- a/runtime/meta.go
+++ b/runtime/meta.go
@@ -122,8 +122,8 @@ const (
 	// that only exist while a particular pull request is open.
 	EnvEphemeral EnvironmentType = "ephemeral"
 
-	// EnvLocal represents the local development environment when using 'encore run' or `encore test`.
-	EnvLocal EnvironmentType = "local"
+	// EnvTest represents a running unit test
+	EnvTest EnvironmentType = "test"
 )
 
 // CloudProvider represents the cloud provider this application is running in.


### PR DESCRIPTION
This commit adds support for environmental selectors to the CUE configuration system allowed in Encore applications.

We've decided to embed the configuration in a definition called `#Meta` which can easily be referenced but shouldn't interfere too much with the end users' own CUE definitions.

We've also moved the application's own config into a `#Config` definition which is closed. That `#Config` is then inlined, which right now has no behaviour difference from how we were doing it. However, in an upcoming version of CUE, an inlined definition will be considered closed and will cause an error _if_ a field is added to the config file which is not present in the closed definition. i.e. this will detect typos.

With this change, the follow configuration resulted in `encore run` logging `932` for `FieldC`, however `encore test` on the exact same code, resulted in `FieldC` logging `1337`.

```cue
FieldC: [
	if #Meta.Environment.Type  == "test"  { 1337 },
	if #Meta.Environment.Cloud == "local" { 932 },
	42
][0]
```

![Screenshot 2022-10-03 at 15 59 33](https://user-images.githubusercontent.com/236641/193625231-7829f645-af9d-4a76-9f7e-1205c92e03d7.png)

**Breaking Changes**

This commit removes the `EnvironmentType` `EnvLocal` and adds a new `EnvTest` from the meta data API. This allows an Encore app to understand if it's running within a unit test or not. I believe this makes more sense as an app running under `encore run` will now have an environment of `EnvDevelopment` and a `CloudProvider` of `CloudLocal`. However running under `encore test`, it will be `EnvTest` && `CloudLocal`.