### PR TITLE
[ENC-800] Error if `config.Value` types are nested

### DIFF
--- a/compiler/internal/cuegen/testdata/basic_config_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_config_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/basic_inline_struct_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_inline_struct_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/basic_lists_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_lists_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/basic_maps_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_maps_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/basic_named_struct_multiple_uses_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_named_struct_multiple_uses_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/basic_named_struct_single_use_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_named_struct_single_use_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/basic_with_cue_imports_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_with_cue_imports_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 import "time"

--- a/compiler/internal/cuegen/testdata/basic_wrappers_svc.cue
+++ b/compiler/internal/cuegen/testdata/basic_wrappers_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 import "time"

--- a/compiler/internal/cuegen/testdata/cue_optional_tag_svc.cue
+++ b/compiler/internal/cuegen/testdata/cue_optional_tag_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/cue_tags_svc.cue
+++ b/compiler/internal/cuegen/testdata/cue_tags_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/generic_named_types_svc.cue
+++ b/compiler/internal/cuegen/testdata/generic_named_types_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/generic_top_level_type_svc.cue
+++ b/compiler/internal/cuegen/testdata/generic_top_level_type_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/json_tags_svc.cue
+++ b/compiler/internal/cuegen/testdata/json_tags_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/merge_identical_comments_svc.cue
+++ b/compiler/internal/cuegen/testdata/merge_identical_comments_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/multiple_configs_in_service_svc.cue
+++ b/compiler/internal/cuegen/testdata/multiple_configs_in_service_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/compiler/internal/cuegen/testdata/types_from_multiple_packages_svc.cue
+++ b/compiler/internal/cuegen/testdata/types_from_multiple_packages_svc.cue
@@ -14,11 +14,11 @@ package svc
 // referenced from other config values for example when configuring a callback URL:
 //    CallbackURL: "\(#Meta.APIBaseURL)/webhooks.Handle`"
 #Meta: {
-	APIBaseURL: string @tag(ApiURL) // The base URL which can be used to call the API of this running application.
+	APIBaseURL: string @tag(APIBaseURL) // The base URL which can be used to call the API of this running application.
 	Environment: {
-		Name:  string                                                        @tag(EnvName)   // The name of this environment
-		Type:  "production" | "development" | "ephemeral" | "local" | "test" @tag(EnvType)   // The type of environment that the application is running in
-		Cloud: "aws" | "azure" | "gcp" | "encore" | "local" | "test"         @tag(CloudType) // The cloud provider that the application is running in
+		Name:  string                                              @tag(EnvName)   // The name of this environment
+		Type:  "production" | "development" | "ephemeral" | "test" @tag(EnvType)   // The type of environment that the application is running in
+		Cloud: "aws" | "azure" | "gcp" | "encore" | "local"        @tag(CloudType) // The cloud provider that the application is running in
 	}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -602,6 +602,7 @@ func (p *parser) validateApp() {
 	}
 
 	p.validateCacheKeyspacePathConflicts()
+	p.validateConfigTypes()
 }
 
 func (p *parser) validateTypeDoesntUseConfigTypes(pos token.Pos, param *est.Param) {

--- a/parser/svc.go
+++ b/parser/svc.go
@@ -556,6 +556,9 @@ func (p *parser) parseAuthHandler(h *est.AuthHandler) {
 	// Second param must be string or named type pointing to a struct
 	authInfo, _ := getField(params, 1)
 	paramType := p.resolveType(h.Svc.Root, h.File, authInfo.Type, nil)
+	if pointer := paramType.GetPointer(); pointer != nil {
+		paramType = pointer.Base
+	}
 	switch typ := paramType.Typ.(type) {
 	case *schema.Type_Named:
 		decl := p.decls[typ.Named.Id]

--- a/parser/testdata/config_err_wrapper_used_in_wrapper.txt
+++ b/parser/testdata/config_err_wrapper_used_in_wrapper.txt
@@ -1,0 +1,23 @@
+! parse
+stderr 'the type of config.Value'
+
+-- svc/svc.go --
+package svc
+
+import (
+    "context"
+
+    "encore.dev/config"
+)
+
+type Config struct {
+    Name config.Value[config.Value[string]]
+}
+
+var cfg = config.Load[Config]()
+
+
+// encore:api
+func Subscriber1(ctx context.Context) error {
+    return nil
+}

--- a/runtime/meta.go
+++ b/runtime/meta.go
@@ -122,6 +122,13 @@ const (
 	// that only exist while a particular pull request is open.
 	EnvEphemeral EnvironmentType = "ephemeral"
 
+	// EnvLocal represents the local development environment when using 'encore run' or `encore test`.
+	//
+	// Deprecated: EnvLocal is deprecated and Encore will no longer return this value. A locally running environment
+	// can be identified by the combination of EnvDevelopment && CloudLocal. This constant will be removed in a future
+	// version of Encore.
+	EnvLocal EnvironmentType = "local"
+
 	// EnvTest represents a running unit test
 	EnvTest EnvironmentType = "test"
 )


### PR DESCRIPTION
This commit adds a new parser check to validate we don't have nested `config.Value[config.Value[T]]` types, as that could lead to unexpected behaviour.

Also fixes the test data for the `cuegen` as it hadn't been updated.

Finnaly I've re-introduced teh `EnvLocal` constant, but marked it as deprecated.