### PR TITLE
[ENC-832] Error if config is referenced outside the service

### DIFF
--- a/parser/resources.go
+++ b/parser/resources.go
@@ -124,3 +124,28 @@ func registerResourceUsageParser(resourceType est.ResourceType, name string, par
 		Parse:            parse,
 	}
 }
+
+type resourceReferenceParserFunc func(*parser, *est.File, est.Resource, *walker.Cursor)
+
+type resourceReferenceParser struct {
+	Resource *resource                   // The type of resource being referenced
+	Parse    resourceReferenceParserFunc // The function to call to parse the reference
+}
+
+// resourceReferenceRegistry is a map of resource type => parser
+var resourceReferenceRegistry = map[est.ResourceType]*resourceReferenceParser{}
+
+// registerResourceReferenceParser is used by resources to register any references to a resource instance.
+//
+// It will panic if the resource type is not registered already.
+func registerResourceReferenceParser(resourceType est.ResourceType, parse resourceReferenceParserFunc) {
+	res, ok := resourceTypes[resourceType]
+	if !ok {
+		panic("registerResourceReferenceParser: unknown resource type")
+	}
+
+	resourceReferenceRegistry[resourceType] = &resourceReferenceParser{
+		Resource: res,
+		Parse:    parse,
+	}
+}

--- a/parser/testdata/config_err_use_from_other_service.txt
+++ b/parser/testdata/config_err_use_from_other_service.txt
@@ -1,0 +1,38 @@
+# Verify calls to config.Load are called
+! parse
+stderr 'A config instance can only be referenced from within the service that the call to'
+
+-- svc/svc.go --
+package svc
+
+import (
+    "context"
+
+    "encore.dev/config"
+)
+
+type Config struct {
+    FooEnabled bool
+}
+
+var Cfg = config.Load[Config]()
+
+
+//encore:api
+func Subscriber1(ctx context.Context) error {
+    return nil
+}
+
+
+-- libraries/foo/foo.go --
+package foo
+
+import (
+    "test/svc"
+)
+
+func init() {
+    if svc.Cfg.FooEnabled {
+        // do something
+    }
+}


### PR DESCRIPTION
This commit adds a new check that prevents a configuration variable from being referenced from outside the service. This behaviour is needed as each service loads it's own unique configuration, and services will not be awaire of each others configurations at runtime.

Configuration passing can be achieved via API calls, rather than direct variable refernces.