### PR TITLE
[ENC-799] Error on Unexported Config Fields

### DIFF
--- a/cli/daemon/run/testdata/echo_client/client/client.go
+++ b/cli/daemon/run/testdata/echo_client/client/client.go
@@ -89,9 +89,9 @@ func WithHTTPClient(client HTTPDoer) Option {
 }
 
 // WithAuth allows you to set the authentication data to be used with each request
-func WithAuth(auth *EchoAuthParams) Option {
+func WithAuth(auth EchoAuthParams) Option {
 	return func(base *baseClient) error {
-		base.authGenerator = func(_ context.Context) (*EchoAuthParams, error) {
+		base.authGenerator = func(_ context.Context) (EchoAuthParams, error) {
 			return auth, nil
 		}
 		return nil
@@ -99,7 +99,7 @@ func WithAuth(auth *EchoAuthParams) Option {
 }
 
 // WithAuthFunc allows you to pass a function which is called for each request to return the authentication data to be used with each request
-func WithAuthFunc(authGenerator func(ctx context.Context) (*EchoAuthParams, error)) Option {
+func WithAuthFunc(authGenerator func(ctx context.Context) (EchoAuthParams, error)) Option {
 	return func(base *baseClient) error {
 		base.authGenerator = authGenerator
 		return nil
@@ -1101,10 +1101,10 @@ type HTTPDoer interface {
 
 // baseClient holds all the information we need to make requests to an Encore application
 type baseClient struct {
-	authGenerator func(ctx context.Context) (*EchoAuthParams, error) // The function which will add the authentication data to the requests
-	httpClient    HTTPDoer                                           // The HTTP client which will be used for all API requests
-	baseURL       *url.URL                                           // The base URL which API requests will be made against
-	userAgent     string                                             // What user agent we will use in the API requests
+	authGenerator func(ctx context.Context) (EchoAuthParams, error) // The function which will add the authentication data to the requests
+	httpClient    HTTPDoer                                          // The HTTP client which will be used for all API requests
+	baseURL       *url.URL                                          // The base URL which API requests will be made against
+	userAgent     string                                            // What user agent we will use in the API requests
 }
 
 // Do sends the req to the Encore application adding the authorization token as required.
@@ -1116,7 +1116,7 @@ func (b *baseClient) Do(req *http.Request) (*http.Response, error) {
 	if b.authGenerator != nil {
 		if authData, err := b.authGenerator(req.Context()); err != nil {
 			return nil, fmt.Errorf("unable to create authorization token for api request: %w", err)
-		} else if authData != nil {
+		} else {
 			authEncoder := &serde{}
 
 			// Add the auth fields to the query string

--- a/cli/daemon/run/testdata/echo_client/main.go
+++ b/cli/daemon/run/testdata/echo_client/main.go
@@ -142,7 +142,7 @@ func main() {
 	{
 		api, err := client.New(
 			client.BaseURL(fmt.Sprintf("http://%s", os.Args[1])),
-			client.WithAuth(&client.EchoAuthParams{
+			client.WithAuth(client.EchoAuthParams{
 				Authorization: "Bearer tokendata",
 			}),
 		)
@@ -158,8 +158,8 @@ func main() {
 		tokenToReturn := "tokendata"
 		api, err := client.New(
 			client.BaseURL(fmt.Sprintf("http://%s", os.Args[1])),
-			client.WithAuthFunc(func(ctx context.Context) (*client.EchoAuthParams, error) {
-				return &client.EchoAuthParams{
+			client.WithAuthFunc(func(ctx context.Context) (client.EchoAuthParams, error) {
+				return client.EchoAuthParams{
 					Authorization: "Bearer " + tokenToReturn,
 				}, nil
 			}),
@@ -181,7 +181,7 @@ func main() {
 	{
 		api, err := client.New(
 			client.BaseURL(fmt.Sprintf("http://%s", os.Args[1])),
-			client.WithAuth(&client.EchoAuthParams{
+			client.WithAuth(client.EchoAuthParams{
 				NewAuth: true,
 				Header:  "102",
 				Query:   []int{42, 100, -50, 10},
@@ -198,7 +198,7 @@ func main() {
 	{
 		api, err := client.New(
 			client.BaseURL(fmt.Sprintf("http://%s", os.Args[1])),
-			client.WithAuth(&client.EchoAuthParams{
+			client.WithAuth(client.EchoAuthParams{
 				Authorization: "Bearer tokendata",
 			}),
 		)
@@ -249,7 +249,7 @@ func main() {
 	{
 		api, err := client.New(
 			client.BaseURL(fmt.Sprintf("http://%s", os.Args[1])),
-			client.WithAuth(&client.EchoAuthParams{
+			client.WithAuth(client.EchoAuthParams{
 				Header: "fail-validation",
 			}),
 		)

--- a/cli/internal/codegen/testdata/expected_golang.go
+++ b/cli/internal/codegen/testdata/expected_golang.go
@@ -77,9 +77,9 @@ func WithHTTPClient(client HTTPDoer) Option {
 }
 
 // WithAuth allows you to set the authentication data to be used with each request
-func WithAuth(auth *AuthenticationAuthData) Option {
+func WithAuth(auth AuthenticationAuthData) Option {
 	return func(base *baseClient) error {
-		base.authGenerator = func(_ context.Context) (*AuthenticationAuthData, error) {
+		base.authGenerator = func(_ context.Context) (AuthenticationAuthData, error) {
 			return auth, nil
 		}
 		return nil
@@ -87,7 +87,7 @@ func WithAuth(auth *AuthenticationAuthData) Option {
 }
 
 // WithAuthFunc allows you to pass a function which is called for each request to return the authentication data to be used with each request
-func WithAuthFunc(authGenerator func(ctx context.Context) (*AuthenticationAuthData, error)) Option {
+func WithAuthFunc(authGenerator func(ctx context.Context) (AuthenticationAuthData, error)) Option {
 	return func(base *baseClient) error {
 		base.authGenerator = authGenerator
 		return nil
@@ -446,10 +446,10 @@ type HTTPDoer interface {
 
 // baseClient holds all the information we need to make requests to an Encore application
 type baseClient struct {
-	authGenerator func(ctx context.Context) (*AuthenticationAuthData, error) // The function which will add the authentication data to the requests
-	httpClient    HTTPDoer                                                   // The HTTP client which will be used for all API requests
-	baseURL       *url.URL                                                   // The base URL which API requests will be made against
-	userAgent     string                                                     // What user agent we will use in the API requests
+	authGenerator func(ctx context.Context) (AuthenticationAuthData, error) // The function which will add the authentication data to the requests
+	httpClient    HTTPDoer                                                  // The HTTP client which will be used for all API requests
+	baseURL       *url.URL                                                  // The base URL which API requests will be made against
+	userAgent     string                                                    // What user agent we will use in the API requests
 }
 
 // Do sends the req to the Encore application adding the authorization token as required.
@@ -461,7 +461,7 @@ func (b *baseClient) Do(req *http.Request) (*http.Response, error) {
 	if b.authGenerator != nil {
 		if authData, err := b.authGenerator(req.Context()); err != nil {
 			return nil, fmt.Errorf("unable to create authorization token for api request: %w", err)
-		} else if authData != nil {
+		} else {
 			authEncoder := &serde{}
 
 			// Add the auth fields to the headers

--- a/parser/feature_config.go
+++ b/parser/feature_config.go
@@ -191,6 +191,10 @@ func (p *parser) validateConfigTypes() {
 							return errors.New("the type of config.Value[T] cannot be another config.Value[T]")
 						}
 					}
+				case *schema.Struct:
+					if field, found := p.structsWithUnexportedFields[node]; found {
+						p.errf(field.Pos(), "field %s is not exported and is in a datatype which is used by a call to `config.Load[T]()`. Unexported fields cannot be initialised by Encore, thus are not allowed in this context.", field.Names[0].Name)
+					}
 				}
 				return nil
 			})

--- a/parser/feature_config.go
+++ b/parser/feature_config.go
@@ -192,7 +192,7 @@ func (p *parser) validateConfigTypes() {
 						}
 					}
 				case *schema.Struct:
-					if field, found := p.structsWithUnexportedFields[node]; found {
+					if field, found := p.hasUnexportedFields[node]; found {
 						p.errf(field.Pos(), "field %s is not exported and is in a datatype which is used by a call to `config.Load[T]()`. Unexported fields cannot be initialised by Encore, thus are not allowed in this context.", field.Names[0].Name)
 					}
 				}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -59,7 +59,7 @@ type parser struct {
 	decls                       []*schema.Decl
 	paths                       paths.Set                          // RPC paths
 	resourceMap                 map[string]map[string]est.Resource // pkg/path -> name -> resource
-	structsWithUnexportedFields map[*schema.Struct]*ast.Field      // A struct will be in this map if it has unexported fields
+	hasUnexportedFields map[*schema.Struct]*ast.Field      // A struct will be in this map if it has unexported fields
 
 	// validRPCReferences is a set of ast nodes that are allowed to
 	// reference RPCs without calling them.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -41,24 +41,25 @@ type parser struct {
 	cfg *Config
 
 	// accumulated results
-	fset          *token.FileSet
-	errors        *errlist.List
-	pkgs          []*est.Package
-	pkgMap        map[string]*est.Package // import path -> pkg
-	svcs          []*est.Service
-	jobs          []*est.CronJob
-	svcMap        map[string]*est.Service // name -> svc
-	svcPkgPaths   map[string]*est.Service // pkg path -> svc
-	jobsMap       map[string]*est.CronJob // ID -> job
-	pubSubTopics  []*est.PubSubTopic
-	cacheClusters []*est.CacheCluster
-	names         names.Application
-	authHandler   *est.AuthHandler
-	middleware    []*est.Middleware
-	declMap       map[string]*schema.Decl // pkg/path.Name -> decl
-	decls         []*schema.Decl
-	paths         paths.Set                          // RPC paths
-	resourceMap   map[string]map[string]est.Resource // pkg/path -> name -> resource
+	fset                        *token.FileSet
+	errors                      *errlist.List
+	pkgs                        []*est.Package
+	pkgMap                      map[string]*est.Package // import path -> pkg
+	svcs                        []*est.Service
+	jobs                        []*est.CronJob
+	svcMap                      map[string]*est.Service // name -> svc
+	svcPkgPaths                 map[string]*est.Service // pkg path -> svc
+	jobsMap                     map[string]*est.CronJob // ID -> job
+	pubSubTopics                []*est.PubSubTopic
+	cacheClusters               []*est.CacheCluster
+	names                       names.Application
+	authHandler                 *est.AuthHandler
+	middleware                  []*est.Middleware
+	declMap                     map[string]*schema.Decl // pkg/path.Name -> decl
+	decls                       []*schema.Decl
+	paths                       paths.Set                          // RPC paths
+	resourceMap                 map[string]map[string]est.Resource // pkg/path -> name -> resource
+	structsWithUnexportedFields map[*schema.Struct]*ast.Field      // A struct will be in this map if it has unexported fields
 
 	// validRPCReferences is a set of ast nodes that are allowed to
 	// reference RPCs without calling them.
@@ -78,11 +79,12 @@ type Config struct {
 
 func Parse(cfg *Config) (*Result, error) {
 	p := &parser{
-		cfg:                cfg,
-		declMap:            make(map[string]*schema.Decl),
-		validRPCReferences: make(map[ast.Node]bool),
-		jobsMap:            make(map[string]*est.CronJob),
-		resourceMap:        make(map[string]map[string]est.Resource),
+		cfg:                         cfg,
+		declMap:                     make(map[string]*schema.Decl),
+		validRPCReferences:          make(map[ast.Node]bool),
+		jobsMap:                     make(map[string]*est.CronJob),
+		resourceMap:                 make(map[string]map[string]est.Resource),
+		structsWithUnexportedFields: make(map[*schema.Struct]*ast.Field),
 	}
 	return p.Parse()
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -41,24 +41,24 @@ type parser struct {
 	cfg *Config
 
 	// accumulated results
-	fset                        *token.FileSet
-	errors                      *errlist.List
-	pkgs                        []*est.Package
-	pkgMap                      map[string]*est.Package // import path -> pkg
-	svcs                        []*est.Service
-	jobs                        []*est.CronJob
-	svcMap                      map[string]*est.Service // name -> svc
-	svcPkgPaths                 map[string]*est.Service // pkg path -> svc
-	jobsMap                     map[string]*est.CronJob // ID -> job
-	pubSubTopics                []*est.PubSubTopic
-	cacheClusters               []*est.CacheCluster
-	names                       names.Application
-	authHandler                 *est.AuthHandler
-	middleware                  []*est.Middleware
-	declMap                     map[string]*schema.Decl // pkg/path.Name -> decl
-	decls                       []*schema.Decl
-	paths                       paths.Set                          // RPC paths
-	resourceMap                 map[string]map[string]est.Resource // pkg/path -> name -> resource
+	fset                *token.FileSet
+	errors              *errlist.List
+	pkgs                []*est.Package
+	pkgMap              map[string]*est.Package // import path -> pkg
+	svcs                []*est.Service
+	jobs                []*est.CronJob
+	svcMap              map[string]*est.Service // name -> svc
+	svcPkgPaths         map[string]*est.Service // pkg path -> svc
+	jobsMap             map[string]*est.CronJob // ID -> job
+	pubSubTopics        []*est.PubSubTopic
+	cacheClusters       []*est.CacheCluster
+	names               names.Application
+	authHandler         *est.AuthHandler
+	middleware          []*est.Middleware
+	declMap             map[string]*schema.Decl // pkg/path.Name -> decl
+	decls               []*schema.Decl
+	paths               paths.Set                          // RPC paths
+	resourceMap         map[string]map[string]est.Resource // pkg/path -> name -> resource
 	hasUnexportedFields map[*schema.Struct]*ast.Field      // A struct will be in this map if it has unexported fields
 
 	// validRPCReferences is a set of ast nodes that are allowed to
@@ -79,12 +79,12 @@ type Config struct {
 
 func Parse(cfg *Config) (*Result, error) {
 	p := &parser{
-		cfg:                         cfg,
-		declMap:                     make(map[string]*schema.Decl),
-		validRPCReferences:          make(map[ast.Node]bool),
-		jobsMap:                     make(map[string]*est.CronJob),
-		resourceMap:                 make(map[string]map[string]est.Resource),
-		structsWithUnexportedFields: make(map[*schema.Struct]*ast.Field),
+		cfg:                 cfg,
+		declMap:             make(map[string]*schema.Decl),
+		validRPCReferences:  make(map[ast.Node]bool),
+		jobsMap:             make(map[string]*est.CronJob),
+		resourceMap:         make(map[string]map[string]est.Resource),
+		hasUnexportedFields: make(map[*schema.Struct]*ast.Field),
 	}
 	return p.Parse()
 }

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -146,7 +146,7 @@ func (p *parser) resolveType(pkg *est.Package, file *est.File, expr ast.Expr, ty
 			for _, name := range field.Names {
 				// Skip unexported fields
 				if !ast.IsExported(name.Name) {
-					p.structsWithUnexportedFields[st] = field
+					p.hasUnexportedFields[st] = field
 					continue
 				}
 				// Use the documentation block above the field by default,

--- a/parser/schema.go
+++ b/parser/schema.go
@@ -146,6 +146,7 @@ func (p *parser) resolveType(pkg *est.Package, file *est.File, expr ast.Expr, ty
 			for _, name := range field.Names {
 				// Skip unexported fields
 				if !ast.IsExported(name.Name) {
+					p.structsWithUnexportedFields[st] = field
 					continue
 				}
 				// Use the documentation block above the field by default,

--- a/parser/testdata/config_err_unexported_field.txt
+++ b/parser/testdata/config_err_unexported_field.txt
@@ -1,0 +1,28 @@
+! parse
+stderr 'field subField is not exported and is in a datatype which is used by a call'
+
+-- svc/svc.go --
+package svc
+
+import (
+    "context"
+
+    "encore.dev/config"
+)
+
+type SubType struct {
+    subField string
+}
+
+type Config struct {
+    FooEnabled bool
+    Sub        SubType
+}
+
+var Cfg = config.Load[Config]()
+
+
+//encore:api
+func Subscriber1(ctx context.Context) error {
+    return nil
+}


### PR DESCRIPTION
If a data type has unexported fields and is used by a call to `config.Load[T]()` then we will now report an error to the user. This error is to prevent undefined behaviour when a user expects to be able to load an unexported field and is not able to.

This error will only occur on unexported fields used by config, unexported fields used by any other Encore feature will be unaffected.