### PR TITLE
Small improvements to the ent ORM documentation page

### DIFF
--- a/docs/how-to/entgo-orm.md
+++ b/docs/how-to/entgo-orm.md
@@ -58,7 +58,7 @@ database exists and the migrations can be created.
 
 First, create the `migrations` directory in the `usr` system and add an empty migration named `1_init.up.sql`. This
 migration is necessary for encore to pick up the system as a [database](../develop/databases.md) system. Run this
-command to have Encore build the application and create teh database:
+command to have Encore build the application and create the database:
 
 ```bash
 encore run


### PR DESCRIPTION
The documentation page had a few issues that were highlighted on Slack and while building a good example app, namely:

- The URL for installing ent changed, which send the reader on the wrong page and wasn't clear on how to install ent in an existing codebase.
- If setting up ent in a clean database, the database wouldn't exist, which would make the migrations fail. I added a section to clear this up.
- The review on the example app PR had a great suggestion to clean up the migration generation code. I've added it here too.
- There was a possible confusion where readers may try to use ent types as params or return types in Encore. That won't work, I added an example and a disclaimer.

This should make the docs a bit easier to follow and unblock any reader who tried to set it up in a new codebase.