### PR TITLE
parser: fix method API name resolution

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -200,6 +200,13 @@ func collectPackages(fs *token.FileSet, rootDir, rootImportPath string, mode gop
 	var pkgs []*est.Package
 	var errors scanner.ErrorList
 	filter := func(f os.FileInfo) bool {
+		// Don't parse encore.gen.go files, since they're not intended to be checked in.
+		// We've had several issues where things work locally but not in CI/CD because
+		// the encore.gen.go file was parsed for local development which papered over issues.
+		if strings.Contains(f.Name(), "encore.gen.go") {
+			return false
+		}
+
 		return parseTests || !strings.HasSuffix(f.Name(), "_test.go")
 	}
 


### PR DESCRIPTION
For Encore APIs defined as methods Encore generates
a user-facing `encore.gen.go` file that includes package-level
func wrappers for calling that API. That file is not intended
to be checked in to source control.

As a result we ended up with subtle bugs where the parsing
behavior depended on whether or not that file existed.
It existed during local development but not in CI/CD.

Fix this by ignoring that file during parsing to ensure consistent
behavior, and introduce a synthetic node in the name resolution
algorithm for method-based APIs to fix the underlying problem.