### PR TITLE
Modify develop documentation pages with improvements

### DIFF
--- a/docs/develop/client-generation.md
+++ b/docs/develop/client-generation.md
@@ -9,7 +9,7 @@ The same approach applies to how Encore generates API clients; it generates an A
 Go function, with the same parameters and response signature as the server.
 
 The generated clients are all designed to be single files written in the same way you would write them without using
-any additional dependencies apart from the standard functionality of the target language with full typesafety.
+any additional dependencies apart from the standard functionality of the target language with full type safety.
 This is to allow anybody to look at the generated client and understand exactly how it works.
 
 The precise structure of the generated code depends on the language, to make sure it's idiomatic and easy to use,
@@ -50,7 +50,7 @@ special environment name `local` (you'll need to be running the application firs
 
 <Callout type="info">
 
-The generated client can be used with any environment, not just the one it was generated for. However, the API's, datastructures
+The generated client can be used with any environment, not just the one it was generated for. However, the APIs, data structures
 and marshalling logic will be based on whatever is present and running in that environment at the point in time the client is generated.
 
 </Callout>
@@ -100,7 +100,7 @@ used as the BaseURL.
 
 If your application has any API's which require [authentication](/docs/develop/auth), then additional options will generated
 into the client, which can be used when constructing the client. Just like with API's schemas, the data type required by
-your applications `authandler` will be part of the client library, allowing you to set it in two ways:
+your application's `auth handler` will be part of the client library, allowing you to set it in two ways:
 
 If your credentials wont change during the lifetime of the client, simply passing the authentication data to the client
 through the `WithAuth` (Go) or `auth` (TypeScript) options.
@@ -161,7 +161,7 @@ func main() {
     ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
     defer cancel()
 
-    // Call the Shorten functon in the URL service
+    // Call the Shorten function in the URL service
     resp, err := client.Url.Shorten(
         ctx,
         client.UrlShortenParams{ URL: os.Args[1] },

--- a/docs/develop/errors.md
+++ b/docs/develop/errors.md
@@ -7,7 +7,7 @@ Encore supports returning structured error information from your APIs.
 
 The key piece is the [encore.dev/beta/errs](https://pkg.go.dev/encore.dev/beta/errs) package.
 
-These errors are propagated accross the network to the [generated clients](/docs/develop/client-generation) and can be
+These errors are propagated across the network to the [generated clients](/docs/develop/client-generation) and can be
 used within your front-ends without having to build any custom marshalling code.
 
 ## The errs.Error type

--- a/docs/develop/metadata.md
+++ b/docs/develop/metadata.md
@@ -86,7 +86,7 @@ import "encore.dev"
 func Signup(ctx context.Context, params *SignupParams) (*SignupResponse, error) {
     // ...
 
-    // If this is a testing enviroment, skip sending the verification email
+    // If this is a testing environment, skip sending the verification email
     switch encore.Meta().Environment.Type {
     case encore.EnvLocal, encore.EnvDevelopment:
         if err := MarkEmailVerified(ctx, userID); err != nil {

--- a/docs/develop/pubsub.md
+++ b/docs/develop/pubsub.md
@@ -69,7 +69,7 @@ from the rest of the application.
 
 In parallel, the `email` and `analytics` services will receive the signup event from the `signups` topic and will then
 perform their respective tasks. If either service returns an error, the event will automatically be backed off and retried
-until the service is able to process the event successfully, or reaches the maximumn number of attempts and is placed
+until the service is able to process the event successfully, or reaches the maximum number of attempts and is placed
 into the deadletter queue (DLQ).
 
 </div>
@@ -80,7 +80,7 @@ into the deadletter queue (DLQ).
 
 <Callout type="info">
 
-Notice how in this version, the processing time of the two other services did not impact the end user and infact the `user`
+Notice how in this version, the processing time of the two other services did not impact the end user and in fact the `user`
 service is not even aware of the `email` and `analytics` services. This means that new systems which need to know about
 new users signing up can be added to the application, without the need to change the `user` service or impacting its
 performance.
@@ -140,7 +140,7 @@ import (
 )
 
 //encore:api public
-func Register(ctx context.Context, params *RegisterationParams) error {
+func Register(ctx context.Context, params *RegistrationParams) error {
     tx, err := sqldb.Begin(ctx) // start a database transaction
     defer tx.Rollback() // rollback the transaction if we don't commit it
 
@@ -155,7 +155,7 @@ func Register(ctx context.Context, params *RegisterationParams) error {
 
     // then commit the transaction, this way if the publishing of the event fails
     // the user isn't created, however if it succeeds then we can return OK now
-    // and let the other processes handle the event asynchroniously without risking
+    // and let the other processes handle the event asynchronously without risking
     // the user being created without the event being published.
     if err := tx.Commit(); err != nil {
         return err


### PR DESCRIPTION
Modified certain develop documentation pages with minor improvements meant to fix typos, grammatical mistakes, and add spaces between certain words which shouldn't be concatenated together.