### PR TITLE
Use 'encore' to keep track of the upstream repository

### DIFF
--- a/cli/cmd/encore/app.go
+++ b/cli/cmd/encore/app.go
@@ -92,7 +92,7 @@ func init() {
 
 		DisableFlagsInUseLine: true,
 		Run: func(c *cobra.Command, args []string) {
-			cmdArgs := append([]string{"clone", defaultGitRemoteURL + args[0]}, args[1:]...)
+			cmdArgs := append([]string{"clone", "--origin", defaultGitRemoteName, defaultGitRemoteURL + args[0]}, args[1:]...)
 			cmd := exec.Command("git", cmdArgs...)
 			cmd.Stdin = os.Stdin
 			cmd.Stdout = os.Stdout


### PR DESCRIPTION
`encore clone` uses `origin` to keep track of the upstream repository. Instead, it should use `encore` for `git push encore` to work.

This PR adds a flag `--origin` to the `git clone` command (which is called by `encore clone`) to use the name `encore` to keep track of the upstream repository.