### PR TITLE
[ENC-889] Use original files for compile errors

### DIFF
--- a/pkg/errinsrc/srcrender.go
+++ b/pkg/errinsrc/srcrender.go
@@ -63,7 +63,9 @@ func renderSrc(builder *strings.Builder, causes SrcLocations) {
 
 	var currentLine int
 	gapRenderedUntil := currentCause.Start.Line
-	sc := bufio.NewScanner(bytes.NewBuffer(causes[0].File.Contents))
+	bBuffer := new(bytes.Buffer)
+	bBuffer.Write(causes[0].File.Contents)
+	sc := bufio.NewScanner(bBuffer)
 	for sc.Scan() {
 		currentLine++
 


### PR DESCRIPTION
This commit fixes an issue where for compiler errors, we where using the file which had been passed to the compiler. However due to `/*line :blah` directives inserted by Encore during the rewrite process, the rendered error lines did no align with the original source.

To fix it, we check if the file exists within the original app folder, if it does we rewrite the filename to that file, if it doesn't (i.e. it's an Encore generated file) we leave the filename as it was.