### PR TITLE
Made file paths in errors clickable

### DIFF
--- a/pkg/errinsrc/srcrender.go
+++ b/pkg/errinsrc/srcrender.go
@@ -50,7 +50,10 @@ func renderSrc(builder *strings.Builder, causes SrcLocations) {
 	// Render the filename
 	builder.WriteString(strings.Repeat(" ", numDigitsInLineNumbers+1))
 	builder.WriteString(aurora.Gray(grayLevelOnLineNumbers, fmt.Sprintf(" %c%c%c", set.LeftTop, set.HorizontalBar, set.LeftBracket)).String())
-	builder.WriteString(aurora.Cyan(fmt.Sprintf("%s:%d:%d",
+	// Note the space on both sides of this string is important
+	// as it allows editors (such as GoLand) to pickup the filename in
+	// terminal output and convert it into a clickable link into the code
+	builder.WriteString(aurora.Cyan(fmt.Sprintf(" %s:%d:%d ",
 		causes[0].File.RelPath,
 		causes[0].Start.Line,
 		causes[0].Start.Col,

--- a/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_following_lines_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_following_lines_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ,-[/test.cue:5:7]
+   ,-[ /test.cue:5:7 ]
    |
  3 | // This is a sample file
  4 | blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_following_lines_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_following_lines_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ╭─[/test.cue:5:7]
+   ╭─[ /test.cue:5:7 ]
    │
  3 │ // This is a sample file
  4 │ blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_same_line_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_same_line_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ,-[/test.cue:5:7]
+   ,-[ /test.cue:5:7 ]
    |
  3 | // This is a sample file
  4 | blah: {
@@ -14,7 +14,7 @@ There has been a simple error in your code
  7 | }
 ---'
 
-   ,-[/test.cue:5:2]
+   ,-[ /test.cue:5:2 ]
    |
  3 | // This is a sample file
  4 | blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_same_line_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__on_same_line_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ╭─[/test.cue:5:7]
+   ╭─[ /test.cue:5:7 ]
    │
  3 │ // This is a sample file
  4 │ blah: {
@@ -14,7 +14,7 @@ There has been a simple error in your code
  7 │ }
 ───╯
 
-   ╭─[/test.cue:5:2]
+   ╭─[ /test.cue:5:2 ]
    │
  3 │ // This is a sample file
  4 │ blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__spaced_apart_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__spaced_apart_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ,-[/test.cue:5:7]
+    ,-[ /test.cue:5:7 ]
     |
   3 | // This is a sample file
   4 | blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__spaced_apart_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MultipleSeperateInSameFile__spaced_apart_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ╭─[/test.cue:5:7]
+    ╭─[ /test.cue:5:7 ]
     │
   3 │ // This is a sample file
   4 │ blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_MutlilineError_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MutlilineError_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ,-[/test.cue:4:7]
+    ,-[ /test.cue:4:7 ]
     |
   2 |     
   3 |     // This is a sample file

--- a/pkg/errinsrc/testdata/Test_renderSrc_MutlilineError_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_MutlilineError_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ╭─[/test.cue:4:7]
+    ╭─[ /test.cue:4:7 ]
     │
   2 │     
   3 │     // This is a sample file

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__error_no_text_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__error_no_text_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ,-[/test.cue:5:7]
+   ,-[ /test.cue:5:7 ]
    |
  3 | // This is a sample file
  4 | blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__error_no_text_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__error_no_text_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ╭─[/test.cue:5:7]
+   ╭─[ /test.cue:5:7 ]
    │
  3 │ // This is a sample file
  4 │ blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__multiline_message_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__multiline_message_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ,-[/test.cue:1:9]
+   ,-[ /test.cue:1:9 ]
    |
  1 | package test_cue
    :         ---v----

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__multiline_message_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__multiline_message_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ╭─[/test.cue:1:9]
+   ╭─[ /test.cue:1:9 ]
    │
  1 │ package test_cue
    ⋮         ───┬────

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_error_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_error_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ,-[/test.cue:5:2]
+   ,-[ /test.cue:5:2 ]
    |
  3 | // This is a sample file
  4 | blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_error_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_error_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-   ╭─[/test.cue:5:2]
+   ╭─[ /test.cue:5:2 ]
    │
  3 │ // This is a sample file
  4 │ blah: {

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_help_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_help_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ,-[/test.cue:13:4]
+    ,-[ /test.cue:13:4 ]
     |
  11 | 
  12 | // If foo then bar is 12

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_help_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_help_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ╭─[/test.cue:13:4]
+    ╭─[ /test.cue:13:4 ]
     │
  11 │ 
  12 │ // If foo then bar is 12

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_warning_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_warning_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ,-[/test.cue:10:7]
+    ,-[ /test.cue:10:7 ]
     |
   8 | 
   9 | // Let's set foo to true

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_warning_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__simple_warning_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ╭─[/test.cue:10:7]
+    ╭─[ /test.cue:10:7 ]
     │
   8 │ 
   9 │ // Let's set foo to true

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__single_character_error_ascii.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__single_character_error_ascii.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ,-[/test.cue:13:13]
+    ,-[ /test.cue:13:13 ]
     |
  11 | 
  12 | // If foo then bar is 12

--- a/pkg/errinsrc/testdata/Test_renderSrc_Simple__single_character_error_unicode.golden
+++ b/pkg/errinsrc/testdata/Test_renderSrc_Simple__single_character_error_unicode.golden
@@ -3,7 +3,7 @@
 
 There has been a simple error in your code
 
-    ╭─[/test.cue:13:13]
+    ╭─[ /test.cue:13:13 ]
     │
  11 │ 
  12 │ // If foo then bar is 12


### PR DESCRIPTION
This commit adds a space into errors which make them detectable by GoLand as file links, and allows it to automatically make those links clickable.

### Before
<img width="717" alt="Screenshot 2022-10-13 at 13 49 28" src="https://user-images.githubusercontent.com/236641/195601258-c4eb2768-f561-4930-b9e0-9f78da062d3a.png">

### After
<img width="721" alt="Screenshot 2022-10-13 at 13 50 40" src="https://user-images.githubusercontent.com/236641/195601282-fb3f41b9-48e6-4b08-a028-0b0eed48b4e5.png">

