### PR TITLE
Handle walking of recursive types

### DIFF
--- a/parser/testdata/recursive_types.txt
+++ b/parser/testdata/recursive_types.txt
@@ -1,0 +1,33 @@
+parse
+-- foo.go --
+package foo
+
+import "context"
+
+// We must reference these types in an RPC parameter to actually validate them.
+type Params struct {
+    A *SelfRecursive
+    B *MutuallyRecursive
+    C *Generic[Generic]
+}
+
+//encore:api public
+func Dummy(ctx context.Context, p *Params) error {
+    return nil
+}
+
+type SelfRecursive struct {
+    A *SelfRecursive
+}
+
+type MutuallyRecursive struct {
+    Other *Other
+}
+
+type Other struct {
+    Original *MutuallyRecursive
+}
+
+type Generic[T any] struct {
+    Val *T
+}

--- a/proto/encore/parser/schema/v1/walk_test.go
+++ b/proto/encore/parser/schema/v1/walk_test.go
@@ -1,0 +1,77 @@
+package v1
+
+import "testing"
+
+// TestWalk_RecursiveDataStructure tests that Walk gracefully handles
+// recursive and mutually recursive data structures.
+func TestWalk_RecursiveDataStructure(t *testing.T) {
+	selfRecursive := &Decl{
+		Id: 0,
+		Type: &Type{
+			Typ: &Type_Named{
+				Named: &Named{
+					Id: 0,
+				},
+			},
+		},
+	}
+
+	mutualRecursiveOne := &Decl{
+		Id: 1,
+		Type: &Type{
+			Typ: &Type_Struct{
+				Struct: &Struct{
+					Fields: []*Field{
+						{
+							Typ: &Type{Typ: &Type_Named{
+								Named: &Named{Id: 1},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	mutualRecursiveTwo := &Decl{
+		Id: 1,
+		Type: &Type{
+			Typ: &Type_Struct{
+				Struct: &Struct{
+					Fields: []*Field{
+						{
+							Typ: &Type{Typ: &Type_Named{
+								Named: &Named{Id: 0},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		decls []*Decl
+		node  any
+	}{
+		{
+			name:  "self_recursive",
+			decls: []*Decl{selfRecursive},
+			node:  selfRecursive.Type,
+		},
+		{
+			name:  "mutual_recursive",
+			decls: []*Decl{mutualRecursiveOne, mutualRecursiveTwo},
+			node:  mutualRecursiveOne.Type,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			visitor := func(node any) error { return nil }
+			if err := Walk(tt.decls, tt.node, visitor); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For recursive and mutually recursive types we ended up
with a stack overflow from infinite recursion in the new
schema walker introduced in Encore v1.8.0.

Fix this by keeping track of which named types have
already been seen.

Fixes #438