### PR TITLE
Pass computed Config to Tests

### DIFF
--- a/pkg/errinsrc/errinsrc.go
+++ b/pkg/errinsrc/errinsrc.go
@@ -37,7 +37,7 @@ func New(params ErrParams, alwaysIncludeStack bool) *ErrInSrc {
 	var stack []*StackFrame
 
 	//goland:noinspection GoBoolExpressions
-	if includeStackByDefault || alwaysIncludeStack {
+	if IncludeStackByDefault || alwaysIncludeStack {
 		stack = GetStack()
 	}
 

--- a/pkg/errinsrc/stack_dev.go
+++ b/pkg/errinsrc/stack_dev.go
@@ -2,4 +2,6 @@
 
 package errinsrc
 
-var includeStackByDefault = true
+// IncludeStackByDefault is whether to include the stack by default on all errors.
+// This is exported to allow Encore's CI platform to set this to true for CI/CD builds.
+var IncludeStackByDefault = true

--- a/pkg/errinsrc/stack_release.go
+++ b/pkg/errinsrc/stack_release.go
@@ -2,4 +2,6 @@
 
 package errinsrc
 
-var includeStackByDefault = false
+// IncludeStackByDefault is whether to include the stack by default on all errors.
+// This is exported to allow Encore's CI platform to set this to true for CI/CD builds.
+var IncludeStackByDefault = false

--- a/runtime/config/config.go
+++ b/runtime/config/config.go
@@ -12,6 +12,12 @@ import (
 	"os"
 
 	jsoniter "github.com/json-iterator/go"
+
+	// We need to force the appinit package to run first, as during tests
+	// we embed config into the built binary, and we need to make sure that
+	// appinit has run before we try and load any config, otherwise those
+	// embedded configs will not be found.
+	_ "encore.dev/appruntime/app/appinit"
 )
 
 var json = jsoniter.Config{


### PR DESCRIPTION
This commit adds support to `encore test` for the new config system, and will pass the computed config into any tests, allowing them to opperate off those tests.