### PR TITLE
Replace deprecated calls with recommended ones

### DIFF
--- a/cli/cmd/encore/app.go
+++ b/cli/cmd/encore/app.go
@@ -505,7 +505,7 @@ func slurpJSON(req *http.Request, respData interface{}) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("got non-200 response: %s: %s", resp.Status, body)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(respData); err != nil {
@@ -589,7 +589,7 @@ func addEncoreRemote(root, appID string) {
 func linkApp(appID string, force bool) {
 	root, _ := determineAppRoot()
 	filePath := filepath.Join(root, "encore.app")
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		fatal(err)
 		os.Exit(1)

--- a/cli/cmd/encore/secret.go
+++ b/cli/cmd/encore/secret.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"syscall"
 	"time"
@@ -64,7 +64,7 @@ Note that this strips trailing newlines from the secret value.`,
 			value = string(data)
 			fmt.Fprintln(os.Stderr)
 		} else {
-			data, err := ioutil.ReadAll(os.Stdin)
+			data, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				fatal(err)
 			}

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -179,7 +178,7 @@ func (h *handler) apiCall(ctx context.Context, reply jsonrpc2.Replier, p *apiCal
 		log.Error().Err(err).Msg("dash: api call failed")
 		return reply(ctx, nil, err)
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
 	// Encode the body back into a Go style struct

--- a/cli/daemon/engine/runtime.go
+++ b/cli/daemon/engine/runtime.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -52,7 +52,7 @@ func (s *server) RecordTrace(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/scanner"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -342,7 +341,7 @@ func (s *Server) OnError(r *run.Run, err *errlist.List) {
 // parseApp parses the app.
 func (s *Server) parseApp(appRoot, workingDir string, parseTests bool) (*parser.Result, error) {
 	modPath := filepath.Join(appRoot, "go.mod")
-	modData, err := ioutil.ReadFile(modPath)
+	modData, err := os.ReadFile(modPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -233,7 +233,7 @@ func (r *Run) start(ln net.Listener, tracker *optracker.OpTracker) (err error) {
 // parseApp parses the app and returns the parse result.
 func (r *Run) parseApp() (*parser.Result, error) {
 	modPath := filepath.Join(r.App.Root(), "go.mod")
-	modData, err := ioutil.ReadFile(modPath)
+	modData, err := os.ReadFile(modPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/update/update.go
+++ b/cli/internal/update/update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 )
@@ -32,7 +32,7 @@ func Check(ctx context.Context) (semver string, err error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("GET %s: responded with %s: %s", url, resp.Status, body)
 	}
 

--- a/compiler/build.go
+++ b/compiler/build.go
@@ -239,7 +239,7 @@ func (b *builder) endCodeGenTracker() error {
 // parseApp parses the app situated at appRoot.
 func (b *builder) parseApp() error {
 	modPath := filepath.Join(b.appRoot, "go.mod")
-	modData, err := ioutil.ReadFile(modPath)
+	modData, err := os.ReadFile(modPath)
 	if err != nil {
 		return err
 	}
@@ -348,11 +348,11 @@ func (b *builder) writeModFile() error {
 }
 
 func (b *builder) writeSumFile() error {
-	appSum, err := ioutil.ReadFile(filepath.Join(b.appRoot, "go.sum"))
+	appSum, err := os.ReadFile(filepath.Join(b.appRoot, "go.sum"))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	runtimeSum, err := ioutil.ReadFile(filepath.Join(b.cfg.EncoreRuntimePath, "go.sum"))
+	runtimeSum, err := os.ReadFile(filepath.Join(b.cfg.EncoreRuntimePath, "go.sum"))
 	if err != nil {
 		return err
 	}

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -311,7 +311,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -311,7 +311,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -296,7 +296,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -1838,7 +1838,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/docs/tutorials/slack-bot.md
+++ b/docs/tutorials/slack-bot.md
@@ -181,7 +181,7 @@ import (
 // verifyRequest verifies that a request is coming from Slack.
 func verifyRequest(req *http.Request) (body []byte, err error) {
 	eb := errs.B().Code(errs.InvalidArgument)
-	body, err = ioutil.ReadAll(req.Body)
+	body, err = io.ReadAll(req.Body)
 	if err != nil {
 		return nil, eb.Cause(err).Err()
 	}

--- a/e2e-tests/testdata/echo/test/endpoints.go
+++ b/e2e-tests/testdata/echo/test/endpoints.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -153,7 +152,7 @@ type response struct {
 func RawEndpoint(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 
-	bytes, err := ioutil.ReadAll(req.Body)
+	bytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e-tests/testdata/echo_client/client/client.go
+++ b/e2e-tests/testdata/echo_client/client/client.go
@@ -1182,7 +1182,7 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, heade
 	}()
 	if rawResponse.StatusCode >= 400 {
 		// Read the full body sent back
-		body, err := ioutil.ReadAll(rawResponse.Body)
+		body, err := io.ReadAll(rawResponse.Body)
 		if err != nil {
 			return nil, &APIError{
 				Code:    ErrUnknown,

--- a/internal/clientgen/testdata/expected_golang.go
+++ b/internal/clientgen/testdata/expected_golang.go
@@ -517,7 +517,7 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, heade
 	}()
 	if rawResponse.StatusCode >= 400 {
 		// Read the full body sent back
-		body, err := ioutil.ReadAll(rawResponse.Body)
+		body, err := io.ReadAll(rawResponse.Body)
 		if err != nil {
 			return nil, &APIError{
 				Code:    ErrUnknown,

--- a/internal/clientgen/testdata/expected_noauth_golang.go
+++ b/internal/clientgen/testdata/expected_noauth_golang.go
@@ -152,7 +152,7 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, heade
 	}()
 	if rawResponse.StatusCode >= 400 {
 		// Read the full body sent back
-		body, err := ioutil.ReadAll(rawResponse.Body)
+		body, err := io.ReadAll(rawResponse.Body)
 		if err != nil {
 			return nil, &APIError{
 				Code:    ErrUnknown,

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -131,7 +131,7 @@ func OriginalUser(configDir string) (cfg *Config, err error) {
 
 func readConf(configDir string) (*Config, error) {
 	path := filepath.Join(configDir, ".auth_token")
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/parser/dirs.go
+++ b/parser/dirs.go
@@ -84,7 +84,7 @@ func parseDir(buildContext build.Context, fset *token.FileSet, dir, relPath stri
 	for _, d := range list {
 		if strings.HasSuffix(d.Name(), ".go") && (filter == nil || filter(d)) {
 			filename := filepath.Join(dir, d.Name())
-			contents, err := ioutil.ReadFile(filename)
+			contents, err := os.ReadFile(filename)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -116,7 +116,7 @@ func TestMain(m *testing.M) {
 				return 1
 			}
 			modPath := filepath.Join(wd, "go.mod")
-			modData, err := ioutil.ReadFile(modPath)
+			modData, err := os.ReadFile(modPath)
 			if err != nil {
 				os.Stderr.WriteString(err.Error())
 				return 1


### PR DESCRIPTION
Fix two deprecated calls found when reading source code:
1. ioutil.ReadFile
2. ioutilo.ReadAll