### PR TITLE
[ENC-931] Allow middleware to publish to pubsub

### DIFF
--- a/parser/est/est.go
+++ b/parser/est/est.go
@@ -163,6 +163,10 @@ func (p *PubSubSubscriber) AllowOnlyParsedUsage() bool { return true }
 
 type PubSubPublisher struct {
 	DeclFile *File // The file the publisher is declared in
+
+	// One of
+	Service          *Service    // The service the publisher is declared in
+	GlobalMiddleware *Middleware // The name of the middleware target
 }
 
 type Param struct {

--- a/parser/est/est.go
+++ b/parser/est/est.go
@@ -113,6 +113,7 @@ func (cj *CronJob) IsValid() (bool, error) {
 
 type PubSubTopic struct {
 	Name              string          // The unique name of the pub sub topic
+	NameAST           ast.Node        // The AST node that defines the name of the pub sub topic
 	Doc               string          // The documentation on the pub sub topic
 	DeliveryGuarantee PubSubGuarantee // What guarantees does the pub sub topic have?
 	OrderingKey       string          // What field in the message type should be used to ensure First-In-First-Out (FIFO) for messages with the same key
@@ -139,6 +140,7 @@ const (
 
 type PubSubSubscriber struct {
 	Name     string       // The unique name of the subscriber
+	NameAST  ast.Node     // The AST node that defines the name of the subscriber
 	Topic    *PubSubTopic // The topic the subscriber is registered against
 	CallSite ast.Node     // The AST node representing the creation of the subscriber
 	Func     ast.Node     // The function that is the subscriber (either a *ast.FuncLit or a *ast.FuncDecl)

--- a/parser/est/selectors.go
+++ b/parser/est/selectors.go
@@ -48,3 +48,69 @@ func (a *Application) MatchingMiddleware(rpc *RPC) []*Middleware {
 	}
 	return matches
 }
+
+// SelectorLookup is a helper cache for looking up services and RPC's by selector
+type SelectorLookup struct {
+	services map[selector.Selector]map[*Service]struct{}
+	rpcs     map[selector.Selector]map[*RPC]struct{}
+}
+
+// SelectorLookup creates a selector lookup from this application
+func (a *Application) SelectorLookup() *SelectorLookup {
+	s := &SelectorLookup{
+		services: make(map[selector.Selector]map[*Service]struct{}),
+		rpcs:     make(map[selector.Selector]map[*RPC]struct{}),
+	}
+
+	// Record all RPC's
+	for _, svc := range a.Services {
+		for _, rpc := range svc.RPCs {
+			// Track against all
+			s.recordRPC(selector.Selector{Type: selector.All}, rpc)
+
+			// Track against any defined tags
+			for _, tag := range rpc.Tags {
+				s.recordRPC(tag, rpc)
+			}
+		}
+	}
+
+	return s
+}
+
+// recordRPC tracks both the RPC for the selector, but also the service the RPC is in
+func (sm *SelectorLookup) recordRPC(s selector.Selector, rpc *RPC) {
+	if sm.rpcs[s] == nil {
+		sm.rpcs[s] = make(map[*RPC]struct{})
+	}
+	sm.rpcs[s][rpc] = struct{}{}
+
+	if sm.services[s] == nil {
+		sm.services[s] = make(map[*Service]struct{})
+	}
+	sm.services[s][rpc.Svc] = struct{}{}
+}
+
+// GetRPCs returns all the rpcs which match any of the given selectors
+func (sm *SelectorLookup) GetRPCs(targets selector.Set) (rtn []*RPC) {
+	for _, s := range targets {
+		if rpcs, found := sm.rpcs[s]; found {
+			for rpc := range rpcs {
+				rtn = append(rtn, rpc)
+			}
+		}
+	}
+	return
+}
+
+// GetServices returns all services which match any of the given selectors
+func (sm *SelectorLookup) GetServices(targets selector.Set) (rtn []*Service) {
+	for _, s := range targets {
+		if services, found := sm.services[s]; found {
+			for svc := range services {
+				rtn = append(rtn, svc)
+			}
+		}
+	}
+	return
+}

--- a/parser/feature_pubsub.go
+++ b/parser/feature_pubsub.go
@@ -302,6 +302,14 @@ func (p *parser) parsePubSubPublish(file *est.File, resource est.Resource, _ *wa
 		return
 	}
 
+	// FIXME: this is a temporary error, while we fix it at a deeper level
+	if file.Pkg.Service == nil {
+		p.err(
+			callExpr.Args[1].Pos(),
+			"pubsub.Publish can only be used within a service. Currently the call is not declared within a service.",
+		)
+	}
+
 	// Record the publisher
 	topic.Publishers = append(topic.Publishers, &est.PubSubPublisher{
 		DeclFile: file,

--- a/parser/feature_pubsub.go
+++ b/parser/feature_pubsub.go
@@ -296,7 +296,6 @@ func (p *parser) parsePubSubPublish(file *est.File, resource est.Resource, c *wa
 		middleware := p.findContainingMiddlewareDefinition(c)
 		if middleware == nil || !middleware.Global {
 			p.errInSrc(srcerrors.PubSubPublishInvalidLocation(p.fset, callExpr))
-			panic("needs to be in a service or global middleware")
 		}
 
 		publisher.GlobalMiddleware = middleware

--- a/parser/feature_pubsub.go
+++ b/parser/feature_pubsub.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"go/ast"
 	"reflect"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"encr.dev/parser/est"
 	"encr.dev/parser/internal/locations"
 	"encr.dev/parser/internal/walker"
+	"encr.dev/pkg/errinsrc/srcerrors"
 	schema "encr.dev/proto/encore/parser/schema/v1"
 )
 
@@ -64,7 +66,7 @@ func init() {
 
 func (p *parser) parsePubSubTopic(file *est.File, cursor *walker.Cursor, ident *ast.Ident, callExpr *ast.CallExpr) est.Resource {
 	if len(callExpr.Args) != 2 {
-		p.errf(callExpr.Pos(), "pubsub.NewTopic requires at least one argument, the topic name given as a string literal. For example `pubsub.NewTopic[MyMessage](\"my-topic\")`")
+		p.errInSrc(srcerrors.PubSubNewTopicInvalidArgCount(p.fset, callExpr))
 		return nil
 	}
 
@@ -77,7 +79,7 @@ func (p *parser) parsePubSubTopic(file *est.File, cursor *walker.Cursor, ident *
 	// check the topic isn't already declared somewhere else
 	for _, topic := range p.pubSubTopics {
 		if strings.EqualFold(topic.Name, topicName) {
-			p.errf(callExpr.Args[0].Pos(), "Pubsub topic names must be unique, \"%s\" was previously declared in %s/%s: if you wish to reuse the same topic, then you can export the original Topic object from %s and reuse it here.", topic.Name, topic.DeclFile.Pkg.Name, topic.DeclFile.Name, topic.DeclFile.Pkg.Name)
+			p.errInSrc(srcerrors.PubSubTopicNameNotUnique(p.fset, topic.NameAST, callExpr.Args[0]))
 			return nil
 		}
 	}
@@ -92,18 +94,18 @@ func (p *parser) parsePubSubTopic(file *est.File, cursor *walker.Cursor, ident *
 	}
 	if !cfg.FullyConstant() {
 		for fieldName, expr := range cfg.DynamicFields() {
-			p.errf(expr.Pos(), "All values in pubsub.TopicConfig must be a constant, however %s was not a constant, got %s", fieldName, prettyPrint(expr))
+			p.errInSrc(srcerrors.PubSubTopicConfigNotConstant(p.fset, fieldName, expr))
 		}
 		return nil
 	}
 
 	if !cfg.IsSet("DeliveryGuarantee") {
-		p.errf(cfg.Pos("DeliveryGuarantee"), "pubsub.NewTopic requires the configuration field named \"DeliveryGuarantee\" to be explicitly set.")
+		p.errInSrc(srcerrors.PubSubTopicConfigMissingField(p.fset, "DeliveryGuarantee", callExpr.Args[1]))
 		return nil
 	}
 	deliveryGuarantee := cfg.Int64("DeliveryGuarantee", 0)
 	if deliveryGuarantee != 1 {
-		p.errf(cfg.Pos("DeliveryGuarantee"), "pubsub.NewTopic requires the configuration field named \"DeliveryGuarantee\" to a valid value such as \"pubsub.AtLeastOnce\".")
+		p.errInSrc(srcerrors.PubSubTopicConfigInvalidField(p.fset, "DeliveryGuarantee", "`pubsub.AtLeastOnce`", cfg.Expr("DeliveryGuarantee")))
 		return nil
 	}
 
@@ -125,17 +127,18 @@ func (p *parser) parsePubSubTopic(file *est.File, cursor *walker.Cursor, ident *
 				}
 
 				if !found || !ast.IsExported(orderingKey) {
-					p.errf(cfg.Pos("OrderingKey"), "pubsub.NewTopic requires the configuration field named \"OrderingKey\" to be a one of the exported fields on the message type.")
+					p.errInSrc(srcerrors.PubSubOrderingKeyMustBeExported(p.fset, cfg.Expr("OrderingKey")))
 				}
 			}
 		} else {
-			p.errf(cfg.Pos("OrderingKey"), "pubsub.NewTopic requires the configuration field named \"OrderingKey\" to either not be set, or be set to a non empty string referencing the field in the message type you want to order messages by.")
+			p.errInSrc(srcerrors.PubSubOrderingKeyNotStringLiteral(p.fset, cfg.Expr("OrderingKey")))
 		}
 	}
 
 	// Record the topic
 	topic := &est.PubSubTopic{
 		Name:              topicName,
+		NameAST:           callExpr.Args[0],
 		Doc:               cursor.DocComment(),
 		DeliveryGuarantee: est.AtLeastOnce,
 		OrderingKey:       orderingKey,
@@ -152,25 +155,18 @@ func (p *parser) parsePubSubTopic(file *est.File, cursor *walker.Cursor, ident *
 
 func (p *parser) parsePubSubSubscription(file *est.File, cursor *walker.Cursor, ident *ast.Ident, callExpr *ast.CallExpr) est.Resource {
 	if len(callExpr.Args) != 3 {
-		p.err(
-			callExpr.Pos(),
-			"pubsub.NewSubscription requires three arguments, the topic, the subscription name given as a string literal and the subscription configuration",
-		)
+		p.errInSrc(srcerrors.PubSubSubscriptionArguments(p.fset, callExpr))
 		return nil
 	}
 
 	resource := p.resourceFor(file, callExpr.Args[0])
 	if resource == nil {
-		p.errf(callExpr.Args[0].Pos(), "pubsub.NewSubscription requires the first argument to reference to pubsub topic, was given %v.", prettyPrint(callExpr.Args[0]))
+		p.errInSrc(srcerrors.PubSubSubscriptionTopicNotResource(p.fset, callExpr.Args[0], ""))
 		return nil
 	}
 	topic, ok := resource.(*est.PubSubTopic)
 	if !ok {
-		p.errf(
-			callExpr.Fun.Pos(),
-			"pubsub.NewSubscription can only be used on a pubsub topic, was given a %v.",
-			reflect.TypeOf(resource),
-		)
+		p.errInSrc(srcerrors.PubSubSubscriptionTopicNotResource(p.fset, callExpr.Args[0], fmt.Sprintf("got a %T", reflect.TypeOf(resource))))
 		return nil
 	}
 
@@ -183,11 +179,7 @@ func (p *parser) parsePubSubSubscription(file *est.File, cursor *walker.Cursor, 
 	// check the subscription isn't already declared somewhere else
 	for _, subscriber := range topic.Subscribers {
 		if strings.EqualFold(subscriber.Name, subscriberName) {
-			p.errf(
-				callExpr.Args[1].Pos(),
-				"Subscriptions on topics must be unique, \"%s\" was previously declared in %s/%s.",
-				subscriber.Name, subscriber.DeclFile.Pkg.Name, subscriber.DeclFile.Name,
-			)
+			p.errInSrc(srcerrors.PubSubSubscriptionNameNotUnique(p.fset, subscriber.NameAST, callExpr.Args[1]))
 			return nil
 		}
 	}
@@ -203,7 +195,7 @@ func (p *parser) parsePubSubSubscription(file *est.File, cursor *walker.Cursor, 
 	ok = true
 	for fieldName, expr := range cfg.DynamicFields() {
 		if fieldName != "Handler" {
-			p.errf(expr.Pos(), "All values in pubsub.SubscriptionConfig must be a constant, however %s was not a constant, got %s", fieldName, prettyPrint(expr))
+			p.errInSrc(srcerrors.PubSubSubscriptionConfigNotConstant(p.fset, fieldName, expr))
 			ok = false
 		}
 	}
@@ -213,7 +205,7 @@ func (p *parser) parsePubSubSubscription(file *est.File, cursor *walker.Cursor, 
 
 	handler := cfg.Expr("Handler")
 	if handler == nil {
-		p.errf(callExpr.Args[2].Pos(), "pubsub.NewSubscription requires the configuration field named \"Handler\" to populated with the subscription handler function.")
+		p.errInSrc(srcerrors.PubSubSubscriptionRequiresHandler(p.fset, callExpr.Args[2]))
 		return nil
 	}
 	p.validRPCReferences[handler] = true
@@ -233,52 +225,45 @@ func (p *parser) parsePubSubSubscription(file *est.File, cursor *walker.Cursor, 
 	}
 
 	if funcFile.Pkg.Service == nil {
-		p.err(
-			callExpr.Args[1].Pos(),
-			"The function passed to `pubsub.NewSubscription` must be declared in the same service. Currently the handler is not declared within a service.",
-		)
+		p.errInSrc(srcerrors.PubSubSubscriptionHandlerNotInService(p.fset, handler, funcDecl))
 		return nil
 	}
 
 	if funcFile.Pkg.Service != file.Pkg.Service {
-		p.errf(
-			callExpr.Args[1].Pos(),
-			"The call to `pubsub.NewSubscription` must be declared in the same service as the handler passed in"+
-				". The call was made in %s, but the handler function was declared in %s.",
-			file.Pkg.Service.Name, funcFile.Pkg.Service.Name,
-		)
+		p.errInSrc(srcerrors.PubSubSubscriptionHandlerNotInService(p.fset, handler, funcDecl))
 		return nil
 	}
 
 	// Verify other configuration
 	ackDeadline := time.Duration(cfg.Int64("AckDeadline", int64(30*time.Second)))
 	if ackDeadline < 1*time.Second {
-		p.errf(cfg.Pos("AckDeadline"), "AckDeadline must be at least 1 second, was %s", ackDeadline)
+		p.errInSrc(srcerrors.PubSubSubscriptionInvalidField(p.fset, "AckDeadline", "at least 1 second", cfg.Expr("AckDeadline"), ackDeadline.String()))
 	}
 
 	messageRetention := time.Duration(cfg.Int64("MessageRetention", int64(7*24*time.Hour)))
 	if messageRetention < 1*time.Minute {
-		p.errf(cfg.Pos("MessageRetention"), "MessageRetention must be at least 1 minute, was %s", messageRetention)
+		p.errInSrc(srcerrors.PubSubSubscriptionInvalidField(p.fset, "MessageRetention", "at least 1 minute", cfg.Expr("MessageRetention"), messageRetention.String()))
 	}
 
 	minRetryBackoff := time.Duration(cfg.Int64("RetryPolicy.MinBackoff", int64(10*time.Second)))
 	if minRetryBackoff < 1*time.Second {
-		p.errf(cfg.Pos("RetryPolicy.MinBackoff"), "RetryPolicy.MinBackoff must be at least 1 second, was %s", minRetryBackoff)
+		p.errInSrc(srcerrors.PubSubSubscriptionInvalidField(p.fset, "RetryPolicy.MinBackoff", "at least 1 second", cfg.Expr("RetryPolicy.MinBackoff"), minRetryBackoff.String()))
 	}
 
 	maxRetryBackoff := time.Duration(cfg.Int64("RetryPolicy.MaxBackoff", int64(10*time.Minute)))
 	if maxRetryBackoff < 1*time.Second {
-		p.errf(cfg.Pos("RetryPolicy.MaxBackoff"), "RetryPolicy.MaxBackoff must be at least 1 second, was %s", minRetryBackoff)
+		p.errInSrc(srcerrors.PubSubSubscriptionInvalidField(p.fset, "RetryPolicy.MaxBackoff", "at least 1 second", cfg.Expr("RetryPolicy.MaxBackoff"), maxRetryBackoff.String()))
 	}
 
 	maxRetries := cfg.Int64("RetryPolicy.MaxRetries", 100)
 	if maxRetries < -2 {
-		p.errf(cfg.Pos("RetryPolicy.MaxRetries"), "RetryPolicy.MaxRetries must be a positive number or the constants `pubsub.InfiniteRetries` or `pubsub.NoRetries`, was %d", maxRetries)
+		p.errInSrc(srcerrors.PubSubSubscriptionInvalidField(p.fset, "RetryPolicy.MaxRetries", "a positive number or the constants `pubsub.InfiniteRetries` or `pubsub.NoRetries`", cfg.Expr("RetryPolicy.MaxRetries"), fmt.Sprintf("%d", maxRetries)))
 	}
 
 	// Record the subscription
 	subscription := &est.PubSubSubscriber{
 		Name:             subscriberName,
+		NameAST:          callExpr.Args[1],
 		Topic:            topic,
 		CallSite:         callExpr,
 		Func:             funcDecl,
@@ -298,16 +283,9 @@ func (p *parser) parsePubSubSubscription(file *est.File, cursor *walker.Cursor, 
 func (p *parser) parsePubSubPublish(file *est.File, resource est.Resource, _ *walker.Cursor, callExpr *ast.CallExpr) {
 	topic, ok := resource.(*est.PubSubTopic)
 	if !ok {
-		p.errf(callExpr.Fun.Pos(), "pubsub.Publish can only be used on a pubsub topic, was given a %v.", reflect.TypeOf(resource))
+		// This is an internal error, so we panic rather than report an error
+		panic(fmt.Sprintf("expected a PubSubTopic, got %T", resource))
 		return
-	}
-
-	// FIXME: this is a temporary error, while we fix it at a deeper level
-	if file.Pkg.Service == nil {
-		p.err(
-			callExpr.Args[1].Pos(),
-			"pubsub.Publish can only be used within a service. Currently the call is not declared within a service.",
-		)
 	}
 
 	// Record the publisher
@@ -323,6 +301,6 @@ func (p *parser) parsePubSubPublish(file *est.File, resource est.Resource, _ *wa
 
 func (p *parser) parsePubSubAttr(rawTag *ast.BasicLit, parsedTag *structtag.Tag, structType *schema.Struct, fieldName string, fieldType *schema.Type) {
 	if strings.HasPrefix(strings.ToLower(parsedTag.Name), "encore") {
-		p.errf(rawTag.Pos(), "Pubsub attribute tags must not start with \"encore\". The field %s currently has an attribute tag of \"%s\".", fieldName, parsedTag.Name)
+		p.errInSrc(srcerrors.PubSubAttrInvalidTag(p.fset, rawTag, parsedTag.Name))
 	}
 }

--- a/parser/internal/walker/cursor.go
+++ b/parser/internal/walker/cursor.go
@@ -132,8 +132,8 @@ func GetFurthestAncestor[T ast.Node](cursor *Cursor) T {
 	}
 }
 
-// getAncestor returns true if the current node has an ancestor of the given type and the index
-// into the parents slice where it was found.
+// getAncestor checks if the current node has an ancestor of the given type and returns
+// that ancestor and the index into the parents slice where it was found.
 func getAncestor[T ast.Node](cursor *Cursor, startIdx int) (T, int) {
 	for i := startIdx; i < len(cursor.parents); i++ {
 		if val, ok := cursor.parents[i].(T); ok {

--- a/parser/internal/walker/cursor.go
+++ b/parser/internal/walker/cursor.go
@@ -32,8 +32,10 @@ func (c *Cursor) Location() (loc locations.Location) {
 				loc |= locations.Variable
 			}
 		case *ast.FuncDecl:
-			if parent.Name.Name == "init" && getAncestor[*ast.FuncDecl](c, idx+1) == nil {
-				loc |= locations.InitFunction
+			if parent.Name.Name == "init" {
+				if f, _ := getAncestor[*ast.FuncDecl](c, idx+1); f == nil {
+					loc |= locations.InitFunction
+				}
 			}
 
 			loc |= locations.Function
@@ -109,19 +111,36 @@ func (c *Cursor) DocComment() string {
 	return ""
 }
 
-// GetAncestor returns the closest ancestor of the given type.
+// GetAncestor returns the closest ancestor of the given type
 func GetAncestor[T ast.Node](cursor *Cursor) T {
-	return getAncestor[T](cursor, 0)
+	rtn, _ := getAncestor[T](cursor, 0)
+	return rtn
 }
 
-// HasAncestor returns true if the current node has an ancestor of the given type.
-func getAncestor[T ast.Node](cursor *Cursor, startIdx int) T {
+// GetFurthestAncestor returns the furthest ancestor of the given type
+func GetFurthestAncestor[T ast.Node](cursor *Cursor) T {
+	var rtn T
+	idx := -1
+	for {
+		found, foundIdx := getAncestor[T](cursor, idx+1)
+		if foundIdx <= -1 {
+			// If not found, return the last found value
+			return rtn
+		}
+
+		rtn, idx = found, foundIdx
+	}
+}
+
+// getAncestor returns true if the current node has an ancestor of the given type and the index
+// into the parents slice where it was found.
+func getAncestor[T ast.Node](cursor *Cursor, startIdx int) (T, int) {
 	for i := startIdx; i < len(cursor.parents); i++ {
 		if val, ok := cursor.parents[i].(T); ok {
-			return val
+			return val, i
 		}
 	}
 
 	var defaultValue T
-	return defaultValue
+	return defaultValue, -1
 }

--- a/parser/meta.go
+++ b/parser/meta.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"encr.dev/parser/est"
+	"encr.dev/parser/selector"
 	"encr.dev/pkg/errinsrc"
 	"encr.dev/pkg/errinsrc/srcerrors"
 	meta "encr.dev/proto/encore/parser/meta/v1"
@@ -50,12 +51,18 @@ func ParseMeta(appRevision string, appHasUncommittedChanges bool, appRoot string
 		pkgMap[p.RelPath] = p
 	}
 
+	selectorMap := newSelectorMap()
+
 	for _, svc := range app.Services {
 		s, err := parseSvc(appRoot, svc)
 		if err != nil {
 			return nil, nil, err
 		}
 		data.Svcs = append(data.Svcs, s)
+
+		for _, rpc := range svc.RPCs {
+			selectorMap.TrackRPC(rpc)
+		}
 	}
 
 	// Populate rpc calls based on rewrite information
@@ -91,7 +98,7 @@ func ParseMeta(appRevision string, appHasUncommittedChanges bool, appRoot string
 	}
 
 	for _, topic := range app.PubSubTopics {
-		t := parsePubsubTopic(topic)
+		t := parsePubsubTopic(topic, selectorMap)
 		data.PubsubTopics = append(data.PubsubTopics, t)
 	}
 
@@ -111,10 +118,19 @@ func ParseMeta(appRevision string, appHasUncommittedChanges bool, appRoot string
 	return data, nodes, nil
 }
 
-func parsePubsubTopic(topic *est.PubSubTopic) *meta.PubSubTopic {
+func parsePubsubTopic(topic *est.PubSubTopic, selectorMap *selectorMap) *meta.PubSubTopic {
 	parsePublisher := func(pubs ...*est.PubSubPublisher) (rtn []*meta.PubSubTopic_Publisher) {
 		for _, p := range pubs {
-			rtn = append(rtn, &meta.PubSubTopic_Publisher{ServiceName: p.DeclFile.Pkg.Service.Name})
+			switch {
+			case p.Service != nil:
+				rtn = append(rtn, &meta.PubSubTopic_Publisher{ServiceName: p.Service.Name})
+			case p.GlobalMiddleware != nil:
+				for _, svc := range selectorMap.GetServices(p.GlobalMiddleware.Target) {
+					rtn = append(rtn, &meta.PubSubTopic_Publisher{ServiceName: svc.Name})
+				}
+			default:
+				panic("impossible publish without a service or middleware reference")
+			}
 		}
 		return rtn
 	}
@@ -572,4 +588,49 @@ func sortedRefs(refs map[ast.Node]*est.Node) []refPair {
 		return p[i].AST.Pos() < p[j].AST.Pos()
 	})
 	return p
+}
+
+type selectorMap struct {
+	services map[selector.Selector]map[*est.Service]struct{}
+	rpcs     map[selector.Selector]map[*est.RPC]struct{}
+}
+
+func newSelectorMap() *selectorMap {
+	return &selectorMap{
+		services: make(map[selector.Selector]map[*est.Service]struct{}),
+		rpcs:     make(map[selector.Selector]map[*est.RPC]struct{}),
+	}
+}
+
+func (sm *selectorMap) recordRPC(s selector.Selector, rpc *est.RPC) {
+	if sm.rpcs[s] == nil {
+		sm.rpcs[s] = make(map[*est.RPC]struct{})
+	}
+	sm.rpcs[s][rpc] = struct{}{}
+
+	if sm.services[s] == nil {
+		sm.services[s] = make(map[*est.Service]struct{})
+	}
+	sm.services[s][rpc.Svc] = struct{}{}
+}
+
+func (sm *selectorMap) TrackRPC(rpc *est.RPC) {
+	// Track against all
+	sm.recordRPC(selector.Selector{Type: selector.All}, rpc)
+
+	// Track against any defined tags
+	for _, s := range rpc.Tags {
+		sm.recordRPC(s, rpc)
+	}
+}
+
+func (sm *selectorMap) GetServices(targets selector.Set) (rtn []*est.Service) {
+	for _, s := range targets {
+		if services, found := sm.services[s]; found {
+			for svc := range services {
+				rtn = append(rtn, svc)
+			}
+		}
+	}
+	return
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -457,6 +457,8 @@ func (p *parser) parseReferences() {
 						// pubsub topic definitions are allowed outside of services
 					case est.CacheClusterDefNode:
 						// cache cluster definitions are allowed outside of services
+					case est.PubSubPublisherNode:
+						// we verify this inside the pubsub publisher parser
 					default:
 						p.errf(astNode.Pos(), "invalid reference outside of a service\n\tpackage %s is not considered a service (it has no APIs or pubsub subscribers defined)", pkg.Name)
 					}
@@ -589,7 +591,8 @@ func (p *parser) validateApp() {
 			}
 
 			for node, ref := range f.References {
-				if res := ref.Res; ref.Res != nil {
+				if res := ref.Res; ref.Res != nil &&
+					res.Type() != est.PubSubTopicResource { // PubSub topics are allow to be published to in global middleware, so it's ok to reference a topic outside a service
 					if ff := res.File(); ff.Pkg.Service != nil && (pkg.Service == nil || pkg.Service.Name != ff.Pkg.Service.Name) {
 						p.errf(node.Pos(), "cannot reference resource %s.%s outside the service", ff.Pkg.Name, res.Ident().Name)
 					}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -162,7 +162,12 @@ func TestMain(m *testing.M) {
 				fmt.Fprintf(os.Stdout, "pubsubTopic %s\n", topic.Name)
 
 				for _, pub := range topic.Publishers {
-					fmt.Fprintf(os.Stdout, "pubsubPublisher %s %s\n", topic.Name, pub.DeclFile.Pkg.Service.Name)
+					if pub.Service != nil {
+						fmt.Fprintf(os.Stdout, "pubsubPublisher %s %s\n", topic.Name, pub.Service.Name)
+					}
+					if pub.GlobalMiddleware != nil {
+						fmt.Fprintf(os.Stdout, "pubsubPublisher middlware %s %s\n", topic.Name, pub.GlobalMiddleware.Name)
+					}
 				}
 
 				for _, sub := range topic.Subscribers {

--- a/parser/testdata/pubsub_err_attributes_not_start_encore.txt
+++ b/parser/testdata/pubsub_err_attributes_not_start_encore.txt
@@ -1,6 +1,6 @@
 # Verify that pub sub is parsed
 ! parse
-stderr 'Pubsub attribute tags must not start with "encore". The field Name currently has an attribute tag'
+stderr 'PubSub message attributes must not be prefixed with "encore".'
 
 -- shared/topics.go --
 package shared
@@ -14,18 +14,3 @@ type MessageType struct {
 }
 
 var BasicTopic = pubsub.NewTopic[*MessageType]("same-name", pubsub.TopicConfig{ DeliveryGuarantee: pubsub.AtLeastOnce })
-
--- svc/svc.go --
-package svc
-
-import (
-    "context"
-
-    "encore.dev/pubsub"
-)
-
-type MessageType struct {
-    Name string
-}
-
-var AnotherTopic = pubsub.NewTopic[*MessageType]("same-Name", pubsub.TopicConfig{ DeliveryGuarantee: pubsub.AtLeastOnce })

--- a/parser/testdata/pubsub_err_duplicate_subscription_names.txt
+++ b/parser/testdata/pubsub_err_duplicate_subscription_names.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'Subscriptions on topics must be unique, "same-name" was previously declared in foo/code.go.'
+stderr 'Subscriptions names on topics must be unique.'
 
 -- shared/topics.go --
 package shared

--- a/parser/testdata/pubsub_err_subscriber_different_service.txt
+++ b/parser/testdata/pubsub_err_subscriber_different_service.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'The call to `pubsub.NewSubscription` must be declared in the same service as the handler passed in.'
+stderr 'The function passed to `pubsub.NewSubscription` must be declared in the the same service as the'
 
 -- shared/shared.go --
 package shared

--- a/parser/testdata/pubsub_err_subscriber_not_function.txt
+++ b/parser/testdata/pubsub_err_subscriber_not_function.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'The function passed to `pubsub.NewSubscription` must be declared in the same service. Currently the'
+stderr 'The function passed to `pubsub.NewSubscription` must be declared in the the same service'
 
 -- svc/svc.go --
 package svc

--- a/parser/testdata/pubsub_err_subscription_func_not_in_service.txt
+++ b/parser/testdata/pubsub_err_subscription_func_not_in_service.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'The call to `pubsub.NewSubscription` must be declared in the same service as the handler passed in.'
+stderr 'The function passed to `pubsub.NewSubscription` must be declared in the the same service as the'
 
 -- shared/shared.go --
 package shared

--- a/parser/testdata/pubsub_err_subscription_name_invalid.txt
+++ b/parser/testdata/pubsub_err_subscription_name_invalid.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'pubsub.NewSubscription requires the subscription name to be between "kebab-case". It must start'
+stderr 'The pubsub.NewSubscription must be subscription name be defined in "kebab-case"'
 
 -- svc/svc.go --
 package svc

--- a/parser/testdata/pubsub_err_topic_must_be_unique.txt
+++ b/parser/testdata/pubsub_err_topic_must_be_unique.txt
@@ -1,6 +1,6 @@
 # Verify that pub sub is parsed
 ! parse
-stderr 'Pubsub topic names must be unique, "same-name" was previously declared in shared/topics.go'
+stderr 'A PubSub topic name must be unique within an application.'
 
 -- shared/topics.go --
 package shared

--- a/parser/testdata/pubsub_err_topic_name_invalid.txt
+++ b/parser/testdata/pubsub_err_topic_name_invalid.txt
@@ -1,5 +1,5 @@
 ! parse
-stderr 'pubsub.NewTopic requires the topic name to be between "kebab-case". It must start with a letter,'
+stderr 'The pubsub.NewTopic must be topic name be defined in "kebab-case"'
 
 -- svc/svc.go --
 package svc

--- a/parser/testdata/pubsub_publish_in_middleware.txt
+++ b/parser/testdata/pubsub_publish_in_middleware.txt
@@ -1,0 +1,44 @@
+parse
+stdout 'pubsubPublisher middlware basic MiddlewareFunc'
+
+-- svc/svc.go --
+package svc
+
+import (
+    "context"
+
+    "encore.dev/pubsub"
+)
+
+type MessageType struct {
+    Name string
+}
+
+var (
+    BasicTopic = pubsub.NewTopic[*MessageType]("basic", pubsub.TopicConfig{ DeliveryGuarantee: pubsub.AtLeastOnce })
+)
+
+// encore:api
+func DoStuff(ctx context.Context) error {
+    return BasicTopic.Publish(ctx, &MessageType{Name: "foo"})
+}
+
+
+-- middleware/middleware.go --
+package middleware
+
+import (
+	"time"
+
+	"encore.dev/middleware"
+	"encore.dev/pubsub"
+
+	"test/svc"
+)
+
+//encore:middleware global target=all
+func MiddlewareFunc(req middleware.Request, next middleware.Next) middleware.Response {
+    svc.BasicTopic.Publish(req.Context(), &svc.MessageType{Name: "bar"})
+
+	return next(req)
+}

--- a/parser/util.go
+++ b/parser/util.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"encr.dev/parser/est"
+	"encr.dev/parser/internal/walker"
 )
 
 // findFuncFor will either return a *ast.FuncDecl, *ast.FuncLit or nil in case of an error.
@@ -64,6 +65,20 @@ func (p *parser) findFuncFor(node ast.Node, from *est.File, errPrefix string) (a
 	}
 
 	return decl.Func, decl.File
+}
+
+// Given a cursor in the AST, this function will return the the middleware that
+// the cursor is currently in.
+func (p *parser) findContainingMiddlewareDefinition(c *walker.Cursor) *est.Middleware {
+	f := walker.GetFurthestAncestor[*ast.FuncDecl](c)
+
+	for _, middleware := range p.middleware {
+		if middleware.Func == f {
+			return middleware
+		}
+	}
+
+	return nil
 }
 
 // walkerFunc allows us to pass a function to ast.Walk which will recursively descend the AST until the function returns false

--- a/pkg/errinsrc/internal/golocation.go
+++ b/pkg/errinsrc/internal/golocation.go
@@ -8,6 +8,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+func FromGoASTNodeWithTypeAndText(fileset *token.FileSet, node ast.Node, typ LocationType, text string) *SrcLocation {
+	loc := FromGoASTNode(fileset, node)
+	loc.Type = typ
+	loc.Text = text
+	return loc
+}
+
 // FromGoASTNode returns a SrcLocation from a Go AST node storing the start and end
 // locations of that node.
 func FromGoASTNode(fileset *token.FileSet, node ast.Node) *SrcLocation {

--- a/pkg/errinsrc/srcerrors/errors.go
+++ b/pkg/errinsrc/srcerrors/errors.go
@@ -469,3 +469,15 @@ func PubSubAttrInvalidTag(fileset *token.FileSet, node ast.Node, fieldName strin
 		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, fmt.Sprintf("try \"%s\"", fieldName[6:]))},
 	}, false)
 }
+
+func PubSubPublishInvalidLocation(fileset *token.FileSet, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:    35,
+		Title:   "Invalid PubSub publish",
+		Summary: "PubSub publish calls must be made in the either from within a service or from within a global middleware function",
+		Detail: combine(
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNode(fileset, node)},
+	}, false)
+}

--- a/pkg/errinsrc/srcerrors/errors.go
+++ b/pkg/errinsrc/srcerrors/errors.go
@@ -9,6 +9,7 @@ import (
 
 	"encr.dev/pkg/errinsrc"
 	. "encr.dev/pkg/errinsrc/internal"
+	"encr.dev/pkg/idents"
 )
 
 // UnhandledPanic is an error we use to wrap a panic that was not handled
@@ -24,7 +25,6 @@ func UnhandledPanic(recovered any) error {
 	if err, ok := recovered.(error); ok {
 		srcError = err
 	}
-
 	// If we get here, it's an unhandled panic / error
 	return errinsrc.New(ErrParams{
 		Code:    1,
@@ -213,5 +213,259 @@ func ConfigTypeHasUnexportFields(fileset *token.FileSet, loadCall ast.Node, fiel
 		Summary:   fmt.Sprintf("Field %s is not exported and is in a datatype which is used by a call to `config.Load[T]()`. Unexported fields cannot be initialised by Encore, thus are not allowed in this context.", field.Names[0].Name),
 		Detail:    configHelp,
 		Locations: SrcLocations{FromGoASTNode(fileset, field), loadLoc},
+	}, false)
+}
+
+func ResourceNameNotStringLiteral(fileset *token.FileSet, node ast.Node, resourceType string, paramName string) error {
+	return errinsrc.New(ErrParams{
+		Code:      17,
+		Title:     "Invalid resource name",
+		Summary:   fmt.Sprintf("A %s requires the %s given as a string literal.", resourceType, paramName),
+		Detail:    resourceNameHelp(resourceType, paramName),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, fmt.Sprintf("was given %s", nodeType(node)))},
+	}, false)
+}
+
+func ResourceNameWrongLength(fileset *token.FileSet, node ast.Node, resourceType string, paramName string, name string) error {
+	return errinsrc.New(ErrParams{
+		Code:      18,
+		Title:     "Invalid resource name",
+		Summary:   fmt.Sprintf("The %s %s needs to be between 1 and 63 characters long.", resourceType, paramName),
+		Detail:    resourceNameHelp(resourceType, paramName),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, fmt.Sprintf("is %d characters long", len(name)))},
+	}, false)
+}
+
+func ResourceNameNotKebabCase(fileset *token.FileSet, node ast.Node, resourceType string, paramName string, name string) error {
+	proposedName := idents.GenerateSuggestion(name, idents.KebabCase)
+
+	return errinsrc.New(ErrParams{
+		Code:      19,
+		Title:     "Invalid resource name",
+		Summary:   fmt.Sprintf("The %s must be %s be defined in \"kebab-case\"", resourceType, paramName),
+		Detail:    resourceNameHelp(resourceType, paramName),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, fmt.Sprintf("try \"%s\"?", proposedName))},
+	}, false)
+}
+
+func PubSubNewTopicInvalidArgCount(fileset *token.FileSet, node *ast.CallExpr) error {
+	start := fileset.Position(node.Lparen + 1)
+	end := fileset.Position(node.Rparen)
+
+	return errinsrc.New(ErrParams{
+		Code:    20,
+		Title:   "Invalid call to pubsub.NewTopic",
+		Summary: "A call to pubsub.NewTopic requires two arguments, the topic name and the topic configuration",
+		Detail: combine(
+			pubsubNewTopicHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoTokenPositions(start, end)},
+	}, false)
+}
+
+func PubSubTopicNameNotUnique(fileset *token.FileSet, firstDefinition ast.Node, secondDefinition ast.Node) error {
+	first := FromGoASTNode(fileset, firstDefinition)
+	second := FromGoASTNode(fileset, secondDefinition)
+
+	first.Text = "originally defined here"
+	first.Type = LocHelp
+
+	second.Text = "redefined here"
+
+	return errinsrc.New(ErrParams{
+		Code:    21,
+		Title:   "Duplicate PubSub topic name",
+		Summary: "A PubSub topic name must be unique within an application.",
+		Detail: combine(
+			resourceNameHelp("pub sub topic", "name"),
+			"If you wish to reuse the same topic, then you can export the original Topic object import it here.",
+			pubsubHelp,
+		),
+		Locations: SrcLocations{first, second},
+	}, false)
+}
+
+func PubSubTopicConfigNotConstant(fileset *token.FileSet, fieldName string, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:    22,
+		Title:   "Invalid PubSub topic config",
+		Summary: fmt.Sprintf("All values in pubsub.TopicConfig must be a constant, however %s was not a constant.", fieldName),
+		Detail: combine(
+			pubsubNewTopicHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, "got "+nodeType(node))},
+	}, false)
+}
+
+func PubSubTopicConfigMissingField(fileset *token.FileSet, fieldName string, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:    23,
+		Title:   "Invalid PubSub topic config",
+		Summary: fmt.Sprintf("pubsub.NewTopic requires the configuration field named \"%s\" to be explicitly set.", fieldName),
+		Detail: combine(
+			pubsubNewTopicHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, "got "+nodeType(node))},
+	}, false)
+}
+
+func PubSubTopicConfigInvalidField(fileset *token.FileSet, fieldName string, exampleValue string, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:    24,
+		Title:   "Invalid PubSub topic config",
+		Summary: fmt.Sprintf("pubsub.NewTopic requires the configuration field named \"%s\" to a valid value", fieldName),
+		Detail: combine(
+			pubsubNewTopicHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, "try %s "+exampleValue)},
+	}, false)
+}
+
+func PubSubOrderingKeyMustBeExported(fileset *token.FileSet, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:      25,
+		Title:     "Invalid PubSub topic config",
+		Summary:   "The configuration field named \"OrderingKey\" must be a one of the exported fields on the message type.",
+		Detail:    pubsubHelp,
+		Locations: SrcLocations{FromGoASTNode(fileset, node)},
+	}, false)
+}
+
+func PubSubOrderingKeyNotStringLiteral(fileset *token.FileSet, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:      26,
+		Title:     "Invalid PubSub topic config",
+		Summary:   "pubsub.NewTopic requires the configuration field named \"OrderingKey\" to either not be set, or be set to a non empty string referencing the field in the message type you want to order messages by.",
+		Detail:    pubsubHelp,
+		Locations: SrcLocations{FromGoASTNode(fileset, node)},
+	}, false)
+}
+
+func PubSubSubscriptionArguments(fileset *token.FileSet, node *ast.CallExpr) error {
+	start := fileset.Position(node.Lparen + 1)
+	end := fileset.Position(node.Rparen)
+
+	return errinsrc.New(ErrParams{
+		Code:    27,
+		Title:   "Invalid call to pubsub.NewSubscription",
+		Summary: "A call to pubsub.NewSubscription requires three arguments, the topic, the subscription name given as a string literal and the subscription configuration",
+		Detail: combine(
+			pubsubNewSubscriptionHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoTokenPositions(start, end)},
+	}, false)
+}
+
+func PubSubSubscriptionTopicNotResource(fileset *token.FileSet, node ast.Expr, got string) error {
+	if got == "" {
+		got = "got " + nodeType(node)
+	}
+
+	return errinsrc.New(ErrParams{
+		Code:    28,
+		Title:   "Invalid call to pubsub.NewSubscription",
+		Summary: "pubsub.NewSubscription requires the first argument to reference to pubsub topic",
+		Detail: combine(
+			pubsubNewSubscriptionHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, got)},
+	}, false)
+}
+
+func PubSubSubscriptionNameNotUnique(fileset *token.FileSet, firstDefinition ast.Node, secondDefinition ast.Node) error {
+	first := FromGoASTNode(fileset, firstDefinition)
+	second := FromGoASTNode(fileset, secondDefinition)
+
+	first.Text = "originally defined here"
+	first.Type = LocHelp
+
+	second.Text = "redefined here"
+
+	return errinsrc.New(ErrParams{
+		Code:    29,
+		Title:   "Invalid PubSub subscription config",
+		Summary: "Subscriptions names on topics must be unique.",
+		Detail: combine(
+			resourceNameHelp("pubsub subscription", "name"),
+			pubsubHelp,
+		),
+		Locations: SrcLocations{first, second},
+	}, false)
+}
+
+func PubSubSubscriptionConfigNotConstant(fileset *token.FileSet, fieldName string, node ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:    30,
+		Title:   "Invalid PubSub subscription config",
+		Summary: fmt.Sprintf("All values in pubsub.SubscriptionConfig must be a constant, however %s was not a constant.", fieldName),
+		Detail: combine(
+			pubsubNewSubscriptionHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, "got "+nodeType(node))},
+	}, false)
+}
+
+func PubSubSubscriptionRequiresHandler(fileset *token.FileSet, cfgNode ast.Node) error {
+	return errinsrc.New(ErrParams{
+		Code:    31,
+		Title:   "Invalid PubSub subscription config",
+		Summary: "pubsub.NewSubscription requires the configuration field named \"Handler\" to populated with the subscription handler function.",
+		Detail: combine(
+			pubsubNewSubscriptionHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNode(fileset, cfgNode)},
+	}, false)
+}
+
+func PubSubSubscriptionHandlerNotInService(fileset *token.FileSet, funcRef ast.Node, funcDecl ast.Node) error {
+	locations := SrcLocations{FromGoASTNode(fileset, funcDecl)}
+
+	if funcRef != nil {
+		locations[0].Text = "defined here"
+		locations = append(locations, FromGoASTNodeWithTypeAndText(fileset, funcRef, LocHelp, "passed to the config here"))
+	}
+
+	return errinsrc.New(ErrParams{
+		Code:    32,
+		Title:   "Invalid PubSub subscription config",
+		Summary: "The function passed to `pubsub.NewSubscription` must be declared in the the same service as the subscription.",
+		Detail: combine(
+			pubsubNewSubscriptionHelp,
+			pubsubHelp,
+		),
+		Locations: locations,
+	}, false)
+}
+
+func PubSubSubscriptionInvalidField(fileset *token.FileSet, fieldName string, requirement string, node ast.Node, was string) error {
+	return errinsrc.New(ErrParams{
+		Code:    33,
+		Title:   "Invalid PubSub subscription config",
+		Summary: fmt.Sprintf("%s must be %s.", fieldName, requirement),
+		Detail: combine(
+			pubsubNewSubscriptionHelp,
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, "was "+was)},
+	}, false)
+}
+
+func PubSubAttrInvalidTag(fileset *token.FileSet, node ast.Node, fieldName string) error {
+	return errinsrc.New(ErrParams{
+		Code:    34,
+		Title:   "Invalid PubSub message attribute",
+		Summary: "PubSub message attributes must not be prefixed with \"encore\".",
+		Detail: combine(
+			pubsubHelp,
+		),
+		Locations: SrcLocations{FromGoASTNodeWithTypeAndText(fileset, node, LocError, fmt.Sprintf("try \"%s\"", fieldName[6:]))},
 	}, false)
 }

--- a/pkg/errinsrc/srcerrors/helpers.go
+++ b/pkg/errinsrc/srcerrors/helpers.go
@@ -1,6 +1,12 @@
 package srcerrors
 
 import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"reflect"
+	"strings"
+
 	cueerrors "cuelang.org/go/cue/errors"
 
 	"encr.dev/pkg/errinsrc"
@@ -32,5 +38,85 @@ func handleCUEError(err error, pathPrefix string, param ErrParams) error {
 		return toReturn[0]
 	default:
 		return toReturn
+	}
+}
+
+// Converts a node to a string which looks like the original go code.
+// such as a ast.SelectorExpr will become "foo.Blah"
+//
+// It's not intended to be an exact representation, but rather a helperful
+// representation for error messages.
+func nodeAsGoSrc(node ast.Node) string {
+	switch node := node.(type) {
+	case *ast.Ident:
+		return node.Name
+
+	case *ast.SelectorExpr:
+		return fmt.Sprintf("%s.%s", nodeAsGoSrc(node.X), node.Sel.Name)
+
+	case *ast.IndexExpr:
+		return fmt.Sprintf("%s[%s]", nodeAsGoSrc(node.X), nodeAsGoSrc(node.Index))
+
+	case *ast.IndexListExpr:
+		indices := make([]string, 0, len(node.Indices))
+		for _, n := range node.Indices {
+			indices = append(indices, nodeAsGoSrc(n))
+		}
+		return fmt.Sprintf("%s[%s]", nodeAsGoSrc(node.X), strings.Join(indices, ", "))
+
+	case *ast.FuncLit:
+		return "a function literal"
+
+	case *ast.BasicLit:
+		return node.Value
+
+	case *ast.CallExpr:
+		return fmt.Sprintf("%s(...)", nodeAsGoSrc(node.Fun))
+
+	default:
+		return fmt.Sprintf("a %v", reflect.TypeOf(node))
+	}
+}
+
+// Converts a node to a string that can be used in an error message.
+// such as a ast.CallExpr will return "a function call to foo.Blah"
+func nodeType(node ast.Node) string {
+	switch node := node.(type) {
+	case *ast.Ident:
+		return "an identifier"
+
+	case *ast.SelectorExpr:
+		return "an identifier"
+
+	case *ast.IndexExpr:
+		return "a identifier"
+
+	case *ast.IndexListExpr:
+		return "a identifier"
+
+	case *ast.FuncLit:
+		return "a function literal"
+
+	case *ast.BasicLit:
+		switch node.Kind {
+		case token.INT:
+			return "an integer literal"
+		case token.FLOAT:
+			return "a float literal"
+		case token.IMAG:
+			return "an imaginary literal"
+		case token.CHAR:
+			return "a character literal"
+		case token.STRING:
+			return "a string literal"
+		default:
+			return "a literal"
+		}
+
+	case *ast.CallExpr:
+		return fmt.Sprintf("a function call to %s", nodeAsGoSrc(node.Fun))
+
+	default:
+		return fmt.Sprintf("a %v", reflect.TypeOf(node))
 	}
 }

--- a/pkg/errinsrc/srcerrors/helptext.go
+++ b/pkg/errinsrc/srcerrors/helptext.go
@@ -1,6 +1,7 @@
 package srcerrors
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -16,4 +17,23 @@ const (
 		"or more API's declared within them or a PubSub subscription."
 
 	configHelp = "For more information on configuration, see https://encore.dev/docs/develop/config"
+
+	pubsubNewTopicHelp = "For example `pubsub.NewTopic[MyMessage](\"my-topic\", pubsub.TopicConfig{ DeliveryGuarantee: pubsub.AtLeastOnce })`"
+
+	pubsubNewSubscriptionHelp = "A pubsub subscription must have a unique name per topic and be given a handler function for processing the message. " +
+		"The handler for the subscription must be defined in the same service as the call to pubsub.NewSubscription and can be an inline function. " +
+		"For example:\n" +
+		"\tpubsub.NewSubscription(myTopic, \"subscription-name\", pubsub.SubscriptionConfig[MyMessage]{\n" +
+		"\t\tHandler: func(ctx context.Context, event MyMessage) error { return nil },\n" +
+		"\t})"
+
+	pubsubHelp = "For more information on PubSub, see https://encore.dev/docs/develop/pubsub"
 )
+
+func resourceNameHelp(resourceName string, paramName string) string {
+	return fmt.Sprintf("%s %s's must be defined as string literals, "+
+		"be between 1 and 63 characters long, and defined in \"kebab-case\", meaning it must start with a letter, end with a letter "+
+		"or number and only contain lower case letters, numbers and dashes.",
+		resourceName, paramName,
+	)
+}

--- a/pkg/errinsrc/utils.go
+++ b/pkg/errinsrc/utils.go
@@ -39,6 +39,9 @@ func ExtractFromPanic(recovered any) error {
 				return err.List
 			case interface{ Unwrap() error }:
 				unwrapped = err.Unwrap()
+			default:
+				// If we get here, it's not an errinsrc or error list, so return nil
+				return nil
 			}
 		}
 	}

--- a/pkg/idents/identifiers.go
+++ b/pkg/idents/identifiers.go
@@ -134,3 +134,27 @@ func stringIsOnly(str string, predicate func(r rune) bool) bool {
 	}
 	return true
 }
+
+// GenerateSuggestion creates a suggestion for an identifier in the given format
+// from the given input string.
+func GenerateSuggestion(input string, format IdentFormat) string {
+	// Clean the string up first and remove unsupported characters
+	input = strings.TrimSpace(input)
+	input = strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsSpace(r) || r == '_' || r == '-' {
+			return r
+		}
+		return -1
+	}, input)
+
+	// Remove any leading or trailing characters which are not letters
+	input = strings.TrimLeftFunc(input, func(r rune) bool {
+		return !unicode.IsLetter(r)
+	})
+	input = strings.TrimRightFunc(input, func(r rune) bool {
+		return !unicode.IsLetter(r)
+	})
+
+	// Now convert the cleaned input into the desired format
+	return Convert(input, format)
+}

--- a/pkg/idents/identifiers_test.go
+++ b/pkg/idents/identifiers_test.go
@@ -24,6 +24,7 @@ func Test_parseIdentifier(t *testing.T) {
 		{"RenderHTML", []string{"render", "HTML"}},
 		{"getVersion2", []string{"get", "version2"}},
 		{"GetAPIDocs", []string{"get", "API", "docs"}},
+		{"This is a full sentence... with \"random! bits-and_pieces123 blah", []string{"this", "is", "a", "full", "sentence", "with", "random", "bits", "and", "pieces123", "blah"}},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -208,7 +208,7 @@ func (d *Desc[Req, Resp]) invokeHandlerRaw(mwReq middleware.Request, c IncomingC
 		panic("invokeHandlerRaw called on non-Raw endpoint")
 	}
 
-	// GlobalMiddleware can override the context, so check if the context is different
+	// Middleware can override the context, so check if the context is different
 	// and if so change the request context.
 	httpReq := c.req
 	if ctx := mwReq.Context(); ctx != c.req.Context() {

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -208,7 +208,7 @@ func (d *Desc[Req, Resp]) invokeHandlerRaw(mwReq middleware.Request, c IncomingC
 		panic("invokeHandlerRaw called on non-Raw endpoint")
 	}
 
-	// Middleware can override the context, so check if the context is different
+	// GlobalMiddleware can override the context, so check if the context is different
 	// and if so change the request context.
 	httpReq := c.req
 	if ctx := mwReq.Context(); ctx != c.req.Context() {

--- a/runtime/middleware/middleware.go
+++ b/runtime/middleware/middleware.go
@@ -15,7 +15,7 @@ import (
 // The implementation must return a Response which then
 // becomes the API's response.
 //
-// Middleware processing forms a chain, where the first
+// GlobalMiddleware processing forms a chain, where the first
 // defined middleware is called first. The provided next
 // function is used to invoke the next middleware in the
 // chain, or the actual API handler if it's the last middleware.

--- a/runtime/middleware/middleware.go
+++ b/runtime/middleware/middleware.go
@@ -15,7 +15,7 @@ import (
 // The implementation must return a Response which then
 // becomes the API's response.
 //
-// GlobalMiddleware processing forms a chain, where the first
+// Middleware processing forms a chain, where the first
 // defined middleware is called first. The provided next
 // function is used to invoke the next middleware in the
 // chain, or the actual API handler if it's the last middleware.


### PR DESCRIPTION
This commit modifies Pubsub such that you can now publish
to pubsub topics from global middleware. To do this we track
if the publish is within a service _or_ if it is directly called
by middleware, if it's called by middleware we then track
which middleware is doing the call, and what that middleware
is targeting.

When we convert the EST into metadata, we expand the middleware
targets out into the services which have the middleware installed.

I've also moved all pubsub errors over to the new error format