### PR TITLE
[ENC-957] Fix compile errors with Config pointers

### DIFF
--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -1541,10 +1541,21 @@ calls to config.Load[T]().
 // Concrete unmarshalers for all config.Load calls, including those using generic types.
 // These instances are used directly by calls to `config.Load[T]()`.
 var (
-	encoreInternalConfigUnmarshaler_Cfg            = encoreInternalTypeConfigUnmarshaler_Cfg
-	encoreInternalConfigUnmarshaler_Optional_bool_ = encoreInternalTypeConfigUnmarshaler_Optional[bool](func(itr *jsoniter.Iterator, path []string) bool {
-		return itr.ReadBool()
-	})
+	encoreInternalConfigUnmarshaler_Cfg                = encoreInternalTypeConfigUnmarshaler_Cfg
+	encoreInternalConfigUnmarshaler_ptr_Optional_bool_ = func(itr *jsoniter.Iterator, path []string) *Optional[bool] {
+		return func() *Optional[bool] {
+			// If the value is null, we return nil
+			if itr.ReadNil() {
+				return nil
+			}
+
+			// Otherwise we unmarshal the value and return a pointer to it
+			obj := encoreInternalTypeConfigUnmarshaler_Optional[bool](func(itr *jsoniter.Iterator, path []string) bool {
+				return itr.ReadBool()
+			})(itr, append(path))
+			return &obj
+		}()
+	}
 )
 
 // encoreInternalTypeConfigUnmarshaler_FooParams will unmarshal the JSON representation into the given type, taking account for

--- a/compiler/internal/codegen/testdata/variants.txt
+++ b/compiler/internal/codegen/testdata/variants.txt
@@ -62,7 +62,7 @@ type Cfg struct {
 
 var _ = config.Load[Cfg]()
 
-var _ = config.Load[Optional[bool]]()
+var _ = config.Load[*Optional[bool]]()
 
 //encore:api public
 func One(ctx context.Context) error {

--- a/compiler/rewrite.go
+++ b/compiler/rewrite.go
@@ -110,7 +110,7 @@ func (b *builder) rewritePkg(pkg *est.Package, targetDir string) error {
 				var buf bytes.Buffer
 				buf.WriteString(strconv.Quote(pkg.Service.Name))
 				buf.WriteString(", ")
-				buf.WriteString(codegen.ConfigUnmarshalFuncName(res.ConfigStruct.Type, b.res.Meta))
+				buf.WriteString(codegen.ConfigUnmarshalFuncName(res.ConfigStruct, b.res.Meta))
 				ep := fset.Position(res.FuncCall.Rparen)
 				_, _ = fmt.Fprintf(&buf, "/*line :%d:%d*/", ep.Line, ep.Column)
 				rw.Replace(res.FuncCall.Lparen+1, res.FuncCall.Rparen, buf.Bytes())

--- a/e2e-tests/testdata/echo/echo/config.go
+++ b/e2e-tests/testdata/echo/echo/config.go
@@ -20,7 +20,7 @@ type SubCfgType[T any] struct {
 	MaxCount T
 }
 
-var cfg = config.Load[CfgType[uint]]()
+var cfg = config.Load[*CfgType[uint]]()
 
 type ConfigResponse struct {
 	ReadOnlyMode bool

--- a/parser/est/est.go
+++ b/parser/est/est.go
@@ -179,6 +179,19 @@ func (p *Param) IsPointer() bool {
 	return p.IsPtr || p.Type.GetPointer() != nil
 }
 
+// GetWithPointer ensures that if the parameter is marked as a pointer
+// you get the pointer schema.type back
+func (p *Param) GetWithPointer() *schema.Type {
+	// If the parameter is a pointer, but the schema isn't a pointer, then
+	// we need to update the typ to a pointer so that the unmarshaler generates as the
+	// correct type
+	typ := p.Type
+	if p.IsPtr && typ.GetPointer() == nil {
+		typ = &schema.Type{Typ: &schema.Type_Pointer{Pointer: &schema.Pointer{Base: typ}}}
+	}
+	return typ
+}
+
 type AccessType string
 
 const (


### PR DESCRIPTION
This commit fixes an issue where if a pointer type was used directly like `config.Load[*T]` the generated code would be to unmarshal a pointer, and would then cause a Go compile error.