### PR TITLE
cli/daemon/sqldb: cache cluster status

### DIFF
--- a/cli/daemon/sqldb/proxy.go
+++ b/cli/daemon/sqldb/proxy.go
@@ -67,11 +67,11 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 	password := startup.Password
 	cluster, ok := cm.LookupPassword(password)
 	if !ok {
-		cm.log.Error().Interface("cluster", cluster.ID).Msg("dbproxy: could not find cluster")
+		cm.log.Error().Msg("dbproxy: could not find cluster")
 		_ = cl.Backend.Send(&pgproto3.ErrorResponse{
 			Severity: "FATAL",
 			Code:     "08006",
-			Message:  "database cluster not running",
+			Message:  "database cluster not found or invalid connection string",
 		})
 		return nil
 	}


### PR DESCRIPTION
We've observed ~200ms connection establishment
times when using Encore's postgres proxy.

Profiling showed it came from calling docker
to get the container's port. Introduce a cache
that stores the most recently observed value
and periodically refetch it, instead of checking
it every time a connection is established.

This reduces the connection time from 200ms
to 35ms on my machine.