### PR TITLE
[ENC-973] Recognise service structs as service creators

### DIFF
--- a/parser/svc.go
+++ b/parser/svc.go
@@ -60,6 +60,11 @@ func (p *parser) registerService(svc *est.Service) {
 	svc.Root.Service = svc
 	p.svcPkgPaths[svc.Root.ImportPath] = svc
 	if svc2 := p.svcMap[svc.Name]; svc2 != nil {
+		if svc2 == svc {
+			// It's the same service we've already registered, so it's good to return nil here
+			return
+		}
+
 		p.errf(svc.Root.AST.Pos(), "service %s defined twice (previous definition at %s)",
 			svc.Name, p.fset.Position(svc2.Root.Files[0].AST.Pos()))
 	}
@@ -376,6 +381,9 @@ func (p *parser) initServiceStruct(ss *est.ServiceStruct) {
 	}
 	svc := ss.Svc
 	svc.Struct = ss
+
+	// If a service struct is defined in a package, we immediately recognise it as being a service
+	p.registerService(svc)
 }
 
 // resolveServiceStruct resolves the service struct a receiver type refers to.

--- a/parser/testdata/servicestruct_creates_service.txt
+++ b/parser/testdata/servicestruct_creates_service.txt
@@ -1,0 +1,15 @@
+# Verify that a service struct forces the creation of a service
+# even if it has no API's defined.
+
+parse
+stdout 'svc foobar '
+
+-- foobar/svc.go --
+package foobar
+
+import (
+	"context"
+)
+
+//encore:service
+type Service struct {}


### PR DESCRIPTION
This commit makes it so if a service struct is defined, Encore will recongise that package as the root of a service - even if no API's exist.

This is to allow services which perform background tasks to poll for events.