### PR TITLE
[ENC-966] Always report HTTP Status in Middleware

### DIFF
--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -7,6 +7,7 @@ import (
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
+	"encore.dev/beta/errs"
 	middleware "encore.dev/middleware"
 	"reflect"
 	_ "unsafe"
@@ -100,17 +101,20 @@ func main() {
 }
 
 var EncoreInternal_svcMyMiddleware = &api.Middleware{
-	PkgName: "svc",
-	Name:    "MyMiddleware",
-	Global:  false,
-	DefLoc:  40,
+	DefLoc: 40,
+	Global: false,
 	Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
 		svc, err := svc.EncoreInternal_ServiceService.Get()
 		if err != nil {
-			return middleware.Response{Err: err}
+			return middleware.Response{
+				Err:        err,
+				HTTPStatus: errs.HTTPStatus(err),
+			}
 		}
 		return svc.MyMiddleware(req, next)
 	},
+	Name:    "MyMiddleware",
+	PkgName: "svc",
 }
 
 

--- a/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGen_TestMain__variants.golden
@@ -7,6 +7,7 @@ import (
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
+	"encore.dev/beta/errs"
 	middleware "encore.dev/middleware"
 	"os"
 	"reflect"
@@ -91,17 +92,20 @@ func loadApp() *appinit.LoadData {
 }
 
 var EncoreInternal_svcMyMiddleware = &api.Middleware{
-	PkgName: "svc",
-	Name:    "MyMiddleware",
-	Global:  false,
-	DefLoc:  40,
+	DefLoc: 40,
+	Global: false,
 	Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
 		svc, err := svc.EncoreInternal_ServiceService.Get()
 		if err != nil {
-			return middleware.Response{Err: err}
+			return middleware.Response{
+				Err:        err,
+				HTTPStatus: errs.HTTPStatus(err),
+			}
 		}
 		return svc.MyMiddleware(req, next)
 	},
+	Name:    "MyMiddleware",
+	PkgName: "svc",
 }
 
 // pkg svc
@@ -113,6 +117,7 @@ import (
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app/appinit"
 	"encore.dev/appruntime/config"
+	"encore.dev/beta/errs"
 	middleware "encore.dev/middleware"
 	"os"
 	"reflect"
@@ -197,16 +202,19 @@ func loadApp() *appinit.LoadData {
 }
 
 var EncoreInternal_svcMyMiddleware = &api.Middleware{
-	PkgName: "svc",
-	Name:    "MyMiddleware",
-	Global:  false,
-	DefLoc:  40,
+	DefLoc: 40,
+	Global: false,
 	Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
 		svc, err := svc.EncoreInternal_ServiceService.Get()
 		if err != nil {
-			return middleware.Response{Err: err}
+			return middleware.Response{
+				Err:        err,
+				HTTPStatus: errs.HTTPStatus(err),
+			}
 		}
 		return svc.MyMiddleware(req, next)
 	},
+	Name:    "MyMiddleware",
+	PkgName: "svc",
 }
 

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -171,6 +171,7 @@ func (d *Desc[Req, Resp]) begin(c IncomingContext) (reqData Req, beginErr error)
 func (d *Desc[Req, Resp]) handleIncoming(c IncomingContext, reqData Req) (resp Resp, httpStatus int, respErr error) {
 	if err := d.validate(reqData); err != nil {
 		respErr = err
+		httpStatus = errs.HTTPStatus(err)
 		return
 	}
 
@@ -192,12 +193,14 @@ func (d *Desc[Req, Resp]) invokeHandlerNonRaw(mwReq middleware.Request, reqData 
 	handlerResp, handlerErr := d.AppHandler(mwReq.Context(), reqData)
 	if handlerErr != nil {
 		mwResp.Err = errs.Convert(handlerErr)
+		mwResp.HTTPStatus = errs.HTTPStatus(mwResp.Err)
 	} else {
 		// Only assign the payload if we're not dealing with *Void,
 		// otherwise we would end up making Payload a "typed nil".
 		if !isVoid[Resp]() {
 			mwResp.Payload = handlerResp
 		}
+		mwResp.HTTPStatus = 200
 	}
 	return mwResp
 }
@@ -245,6 +248,7 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 					stack := debug.Stack()
 					resp.Err = errs.B().Code(errs.Internal).Meta("panic_stack", string(stack)).Msgf("panic executing middleware %s.%s: %v\n%s",
 						mw.PkgName, mw.Name, e, stack).Err()
+					resp.HTTPStatus = 500
 				}
 			}()
 			return mw.Invoke(req, nextFn)
@@ -255,13 +259,15 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 				if e := recover(); e != nil {
 					stack := debug.Stack()
 					resp.Err = errs.B().Code(errs.Internal).Meta("panic_stack", string(stack)).Msgf("panic handling request: %v\n%s", e, stack).Err()
+					resp.HTTPStatus = 500
 				}
 			}()
 			return invokeHandler(req)
 
 		default:
 			return middleware.Response{
-				Err: errs.B().Code(errs.Internal).Msg("middleware called next() too many times").Err(),
+				Err:        errs.B().Code(errs.Internal).Msg("middleware called next() too many times").Err(),
+				HTTPStatus: 500,
 			}
 		}
 	}
@@ -273,12 +279,24 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 	mwResp := nextFn(mwReq)
 
 	if mwResp.Err != nil {
-		return resp, mwResp.HTTPStatus, mwResp.Err
-	} else {
-		if resp, ok := mwResp.Payload.(Resp); ok || isVoid[Resp]() {
-			return resp, mwResp.HTTPStatus, nil
+		httpStatus := mwResp.HTTPStatus
+		if httpStatus == 0 {
+			// If no explicit HTTP status has been set, then we use the default for the type of error
+			httpStatus = errs.HTTPStatus(mwResp.Err)
 		}
-		return resp, mwResp.HTTPStatus, errs.B().Code(errs.Internal).Msgf(
+		return resp, httpStatus, mwResp.Err
+	} else {
+		httpStatus := mwResp.HTTPStatus
+		if httpStatus == 0 {
+			// If no explicit HTTP status has been set, then we use 200 OK
+			httpStatus = 200
+		}
+
+		if resp, ok := mwResp.Payload.(Resp); ok || isVoid[Resp]() {
+			return resp, httpStatus, nil
+		}
+
+		return resp, 500, errs.B().Code(errs.Internal).Msgf(
 			"invalid middleware: cannot return payload of type %T for endpoint %s.%s (expected type %T)",
 			mwResp.Payload, d.Service, d.Endpoint, resp,
 		).Err()
@@ -358,7 +376,10 @@ func (d *Desc[Req, Resp]) Call(c CallContext, req Req) (resp Resp, respErr error
 
 		if rpcErr == nil {
 			r, rpcErr = d.CloneResp(r)
-			httpStatus = errs.HTTPStatus(errs.Convert(rpcErr))
+			if rpcErr != nil {
+				// only override the http status if an error occurred trying to clone the response
+				httpStatus = errs.HTTPStatus(errs.Convert(rpcErr))
+			}
 		}
 		if rpcErr != nil {
 			respErr = errs.RoundTrip(rpcErr)

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -287,9 +287,8 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 	})
 	mwResp := nextFn(mwReq)
 
-	if mwResp.Payload == nil {
-		var defaultValue Resp
-		return defaultValue, mwResp.HTTPStatus, mwResp.Err
+	if mwResp.Err != nil {
+		return resp, mwResp.HTTPStatus, mwResp.Err
 	} else {
 		if resp, ok := mwResp.Payload.(Resp); ok || isVoid[Resp]() {
 			return resp, mwResp.HTTPStatus, mwResp.Err

--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -133,7 +133,7 @@ func (s *Server) finishRequest(output [][]byte, err error, httpStatus int) {
 	case model.AuthHandler:
 		req.Logger.Info().Dur("duration", dur).Msg("auth handler completed")
 	default:
-		if httpStatus != 0 {
+		if httpStatus != errs.HTTPStatus(err) {
 			code := errs.HTTPStatusToCode(httpStatus).String()
 			req.Logger.Info().Dur("duration", dur).Str("code", code).Int("http_code", httpStatus).Msg("request completed")
 			metrics.ReqEnd(req.Service, req.Endpoint, dur.Seconds(), code)

--- a/runtime/middleware/middleware.go
+++ b/runtime/middleware/middleware.go
@@ -83,9 +83,9 @@ type Response struct {
 
 	// HTTPStatus is the HTTP status code the response is written with.
 	//
-	// For non-raw handlers it is zero by default and Encore chooses an appropriate
+	// For non-raw handlers it is initially Encore chooses an appropriate
 	// status code depending on the type of error being returned (or 200 for success),
-	// but setting HTTPStatus to a non-zero value causes Encore to write the response
+	// but setting HTTPStatus to another non-zero value causes Encore to write the response
 	// with that HTTP status code value instead.
 	//
 	// For raw handlers it is automatically populated with the status code

--- a/runtime/middleware/middleware.go
+++ b/runtime/middleware/middleware.go
@@ -83,13 +83,13 @@ type Response struct {
 
 	// HTTPStatus is the HTTP status code the response is written with.
 	//
-	// For non-raw handlers it is initially Encore chooses an appropriate
-	// status code depending on the type of error being returned (or 200 for success),
-	// but setting HTTPStatus to another non-zero value causes Encore to write the response
-	// with that HTTP status code value instead.
+	// If zero is returned from middleware, Encore will choose an appropriate status code based
+	// status code depending on the type of error being returned (or 200 for success).
 	//
-	// For raw handlers it is automatically populated with the status code
-	// written by the API handler, and middleware cannot modify this as it has already
+	// If a non-zero value is returned from a middleware, Encore will use that status code
+	// regardless of what Err is set to.
+	//
+	// For raw handlers middleware cannot modify this as it has already
 	// been written to the network.
 	HTTPStatus int
 }


### PR DESCRIPTION
This commit changes middleware to always return an HTTP status code in the middleware response.