### PR TITLE
compiler: set linkmode external for static linking

### DIFF
--- a/compiler/build.go
+++ b/compiler/build.go
@@ -408,7 +408,7 @@ func (b *builder) buildMain() error {
 		"-o=" + filepath.Join(b.workdir, "out"+b.exe()),
 	}
 	if b.cfg.StaticLink {
-		args = append(args, "-ldflags", `-extldflags "-static"`)
+		args = append(args, "-ldflags", `-linkmode external -extldflags "-static"`)
 	}
 
 	args = append(args, fmt.Sprintf("./%s/%s", encorePkgDir, mainPkgName))

--- a/compiler/test.go
+++ b/compiler/test.go
@@ -138,7 +138,7 @@ func (b *builder) runTests(ctx context.Context) error {
 		"-vet=off",
 	}
 	if b.cfg.StaticLink {
-		args = append(args, "-ldflags", `-extldflags "-static"`)
+		args = append(args, "-ldflags", `-linkmode external -extldflags "-static"`)
 	}
 
 	args = append(args, b.cfg.Test.Args...)


### PR DESCRIPTION
This is necessary for static linking of some libraries
like sqlite.