### PR TITLE
compiler: only use external linking with cgo

### DIFF
--- a/compiler/build.go
+++ b/compiler/build.go
@@ -408,7 +408,15 @@ func (b *builder) buildMain() error {
 		"-o=" + filepath.Join(b.workdir, "out"+b.exe()),
 	}
 	if b.cfg.StaticLink {
-		args = append(args, "-ldflags", `-linkmode external -extldflags "-static"`)
+		var ldflags string
+	
+		// Enable external linking if we use cgo.
+		if b.cfg.CgoEnabled {
+			ldflags = "-linkmode external "
+		}
+
+		ldflags += `-extldflags "-static"`
+		args = append(args, "-ldflags", ldflags)
 	}
 
 	args = append(args, fmt.Sprintf("./%s/%s", encorePkgDir, mainPkgName))

--- a/compiler/test.go
+++ b/compiler/test.go
@@ -137,8 +137,17 @@ func (b *builder) runTests(ctx context.Context) error {
 		"-mod=mod",
 		"-vet=off",
 	}
+
 	if b.cfg.StaticLink {
-		args = append(args, "-ldflags", `-linkmode external -extldflags "-static"`)
+		var ldflags string
+
+		// Enable external linking if we use cgo.
+		if b.cfg.CgoEnabled {
+			ldflags = "-linkmode external "
+		}
+
+		ldflags += `-extldflags "-static"`
+		args = append(args, "-ldflags", ldflags)
 	}
 
 	args = append(args, b.cfg.Test.Args...)


### PR DESCRIPTION
External linking only makes sense with cgo,
this was an unintended interaction.