### PR TITLE
cli/daemon/apps: fix app table lock

### DIFF
--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -81,21 +81,18 @@ func (mgr *Manager) FindLatestByPlatformID(platformID string) (*Instance, error)
 
 // List lists all known apps.
 func (mgr *Manager) List() ([]*Instance, error) {
-	rows, err := mgr.db.Query(`SELECT root FROM app`)
+	roots, err := mgr.listRoots()
 	if err != nil {
-		return nil, errors.Wrap(err, "query apps")
+		return nil, err
 	}
-	defer rows.Close()
 
 	var apps []*Instance
-	for rows.Next() {
-		var root string
-		if err := rows.Scan(&root); err != nil {
-			return nil, errors.Wrap(err, "scan row")
-		}
+	for _, root := range roots {
 		app, err := mgr.resolve(root)
 		if errors.Is(err, fs.ErrNotExist) {
 			log.Debug().Str("root", root).Msg("app no longer exists, skipping")
+			// Delete the
+			_, _ = mgr.db.Exec(`DELETE FROM app WHERE root = ?`, root)
 			continue
 		} else if err != nil {
 			log.Error().Err(err).Str("root", root).Msg("unable to resolve app")
@@ -104,8 +101,26 @@ func (mgr *Manager) List() ([]*Instance, error) {
 		apps = append(apps, app)
 	}
 
+	return apps, nil
+}
+
+func (mgr *Manager) listRoots() ([]string, error) {
+	rows, err := mgr.db.Query(`SELECT root FROM app`)
+	if err != nil {
+		return nil, errors.Wrap(err, "query app roots")
+	}
+	defer rows.Close()
+
+	var roots []string
+	for rows.Next() {
+		var root string
+		if err := rows.Scan(&root); err != nil {
+			return nil, errors.Wrap(err, "scan row")
+		}
+		roots = append(roots, root)
+	}
 	err = errors.Wrap(rows.Err(), "iterate rows")
-	return apps, err
+	return roots, err
 }
 
 // RegisterAppListener registers a callback that gets invoked every time


### PR DESCRIPTION
When we generate user-facing code for all tracked apps during
daemon startup we were doing so while holding the query cursor
open, causing issues with table locks preventing things like `encore run`
from running concurrently. Fix this by scanning the table once into a slice,
and then iterating over it without holding the database cursor open.