### PR TITLE
cli: improve terminal screen clearing

### DIFF
--- a/cli/cmd/encore/run.go
+++ b/cli/cmd/encore/run.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
@@ -9,8 +10,10 @@ import (
 
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"encr.dev/cli/internal/onboarding"
+	"encr.dev/pkg/ansi"
 	daemonpb "encr.dev/proto/encore/daemon"
 )
 
@@ -63,6 +66,15 @@ func runApp(appRoot, wd string) {
 	})
 	if err != nil {
 		fatal(err)
+	}
+
+	// Clear the screen except for the first line.
+	if _, height, err := terminal.GetSize(int(os.Stdout.Fd())); err == nil {
+		count := height - 2
+		if count > 0 {
+			os.Stdout.Write(bytes.Repeat([]byte{'\n'}, count))
+		}
+		fmt.Fprint(os.Stdout, ansi.SetCursorPosition(2, 1)+ansi.ClearScreen(ansi.CursorToBottom))
 	}
 
 	code := streamCommandOutput(stream, convertJSONLogs())

--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -90,9 +90,6 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 		return nil
 	}
 
-	// Clear screen.
-	stderr.Write([]byte("\033[2J\033[H\n"))
-
 	ops := optracker.New(stderr, stream)
 
 	// Check for available update before we start the proc

--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -83,16 +83,17 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 	}
 	defer ln.Close()
 
+	app, err := s.apps.Track(req.AppRoot)
+	if err != nil {
+		fmt.Fprintln(stderr, aurora.Sprintf(aurora.Red("failed to resolve app: %v"), err))
+		sendExit(1)
+		return nil
+	}
+
 	// Clear screen.
 	stderr.Write([]byte("\033[2J\033[H\n"))
 
 	ops := optracker.New(stderr, stream)
-
-	app, err := s.apps.Track(req.AppRoot)
-	if err != nil {
-		sendExit(1)
-		return nil
-	}
 
 	// Check for available update before we start the proc
 	// so the output from the proc doesn't race with our

--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -1,0 +1,71 @@
+// Package ansi provides helper functions for writing ANSI terminal escape codes.
+package ansi
+
+import "fmt"
+
+// SetCursorPosition returns the ANSI escape code for setting the cursor position.
+// The rows and columns are one-based. If <=0 they default to the first row/column.
+func SetCursorPosition(row, col int) string {
+	if row <= 0 {
+		row = 1
+	}
+	if col <= 0 {
+		col = 1
+	}
+	return fmt.Sprintf("\u001b[%d;%dH", row, col)
+}
+
+type ClearScreenMethod int
+
+const (
+	CursorToBottom           ClearScreenMethod = 0
+	CursorToTop              ClearScreenMethod = 1
+	WholeScreen              ClearScreenMethod = 2
+	WholeScreenAndScrollback ClearScreenMethod = 3
+)
+
+// ClearScreen clears the screen according to the given method.
+func ClearScreen(method ClearScreenMethod) string {
+	return fmt.Sprintf("\u001b[%dJ", method)
+}
+
+type ClearLineMethod int
+
+const (
+	CursorToEnd   ClearLineMethod = 0 // cursor to end of line
+	CursorToStart ClearLineMethod = 1 // cursor to start of line
+	WholeLine     ClearLineMethod = 2
+)
+
+// ClearLine clears the current line according to the given method.
+// The cursor position within the line does not change.
+func ClearLine(method ClearLineMethod) string {
+	return fmt.Sprintf("\u001b[%dK", method)
+}
+
+const (
+	// SaveCursorPosition saves the current cursor position.
+	SaveCursorPosition = "\u001b[s"
+	// RestoreCursorPosition restores the cursor position to the saved position.
+	RestoreCursorPosition = "\u001b[u"
+)
+
+// MoveCursorLeft moves the cursor left n cells.
+// If the cursor is already at the edge of the screen it has no effect.
+// If n is negative it moves to the right instead.
+func MoveCursorLeft(n int) string {
+	if n < 0 {
+		return MoveCursorRight(-n)
+	}
+	return fmt.Sprintf("\u001b[%dD", n)
+}
+
+// MoveCursorRight moves the cursor right n cells.
+// If the cursor is already at the edge of the screen it has no effect.
+// If n is negative it moves to the left instead.
+func MoveCursorRight(n int) string {
+	if n < 0 {
+		return MoveCursorLeft(-n)
+	}
+	return fmt.Sprintf("\u001b[%dC", n)
+}


### PR DESCRIPTION
This improves terminal screen clearing when running `encore run`,
fixing several longstanding issues when trying to scroll the buffer
while the ops tracker is running.