### PR TITLE
[ENC-804] Remove sorting of Parser errors

### DIFF
--- a/e2e-tests/testdata/echo/echo/echo.go
+++ b/e2e-tests/testdata/echo/echo/echo.go
@@ -114,7 +114,7 @@ func Publish(ctx context.Context) error {
 }
 
 //encore:api private
-func Consumer(ctx context.Context, msg *Message, a int) error {
+func Consumer(ctx context.Context, msg *Message) error {
 	if msg.Attr != "Attr" {
 		return errors.New("incorrect Attr value")
 	}

--- a/e2e-tests/testdata/echo/echo/echo.go
+++ b/e2e-tests/testdata/echo/echo/echo.go
@@ -113,7 +113,8 @@ func Publish(ctx context.Context) error {
 	return nil
 }
 
-func Consumer(ctx context.Context, msg *Message) error {
+//encore:api private
+func Consumer(ctx context.Context, msg *Message, a int) error {
 	if msg.Attr != "Attr" {
 		return errors.New("incorrect Attr value")
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -121,7 +121,6 @@ func (p *parser) Parse() (res *Result, err error) {
 		}
 
 		if err == nil {
-			p.errors.Sort()
 			p.errors.MakeRelative(p.cfg.AppRoot, p.cfg.WorkingDir)
 			err = p.errors.Err()
 		}

--- a/pkg/errlist/errlist.go
+++ b/pkg/errlist/errlist.go
@@ -7,7 +7,6 @@ import (
 	"go/token"
 	"io"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"encr.dev/pkg/errinsrc"
@@ -201,11 +200,6 @@ func (l *List) Error() string {
 
 func (l *List) ErrorList() []*errinsrc.ErrInSrc {
 	return l.List
-}
-
-// Sort sorts the error list.
-func (l *List) Sort() {
-	sort.Sort(l.List)
 }
 
 // MakeRelative rewrites the errors by making filenames within the


### PR DESCRIPTION
This commit removes the code which caused the parser to "sort" orders. While this seems like it made sense, the issue is the order in which the parser encounters errors is important as the first error can cause an inconsistent state within the parser, which results in more errors being detected and reported.

This was evident in the usecase where you had an API being referenced by a pubsub subscriber. If you caused the API to have some parser failure; such as an invalid signature, the PubSub subscriber would then report that you can't reference the API in that way.

The problem was in some examples, the PubSub error would be sorted first, resulting in the user thinking that PubSub can't access an API directly - where in reality they just had an issue with the way one of the API's was written.