### PR TITLE
cli: limit trace storage to last 100 traces

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/app/AppTraces.tsx
+++ b/cli/daemon/dash/dashapp/src/components/app/AppTraces.tsx
@@ -43,7 +43,11 @@ export default class AppTraces extends React.Component<Props, State> {
     if (msg.method === "trace/new") {
       const tr = msg.params as Trace;
       this.setState((st) => {
-        return { traces: [tr, ...st.traces] };
+        let traces = [tr, ...st.traces];
+        if (traces.length > 100) {
+          traces = traces.slice(0, 100)
+        }
+        return { traces };
       });
     }
   }

--- a/cli/daemon/engine/trace/trace.go
+++ b/cli/daemon/engine/trace/trace.go
@@ -60,6 +60,13 @@ func (st *Store) Store(ctx context.Context, tr *TraceMeta) error {
 	appID := tr.App.PlatformOrLocalID()
 	st.trmu.Lock()
 	st.traces[appID] = append(st.traces[appID], tr)
+
+	const limit = 100
+	// Remove earlier traces if we exceed the limit.
+	if n := len(st.traces[appID]); n > limit {
+		st.traces[appID] = st.traces[appID][n-limit:]
+	}
+
 	st.trmu.Unlock()
 
 	st.lnmu.Lock()


### PR DESCRIPTION
The memory usage on the backend is manageable
but the browser does not handle displaying a large
amount of traces due to DOM and memory overhead.