### PR TITLE
pkg/ansi: fix cursor save/restore

### DIFF
--- a/e2e-tests/testdata/echo/go.mod
+++ b/e2e-tests/testdata/echo/go.mod
@@ -2,7 +2,6 @@ module encore.app
 
 go 1.18
 
-require "encore.dev" v1.1.0
+require "encore.dev" v1.9.3
 
-replace encore.dev => ../../../../../runtime
-
+replace encore.dev => ../../../runtime

--- a/pkg/ansi/ansi.go
+++ b/pkg/ansi/ansi.go
@@ -45,9 +45,9 @@ func ClearLine(method ClearLineMethod) string {
 
 const (
 	// SaveCursorPosition saves the current cursor position.
-	SaveCursorPosition = "\u001b[s"
+	SaveCursorPosition = "\u001b7"
 	// RestoreCursorPosition restores the cursor position to the saved position.
-	RestoreCursorPosition = "\u001b[u"
+	RestoreCursorPosition = "\u001b8"
 )
 
 // MoveCursorLeft moves the cursor left n cells.


### PR DESCRIPTION
It turns out the terminal escape codes we used were not
supported by all terminals, notably macOS's Terminal.app.

Fix this by using a different terminal escape code that does work.
