### PR TITLE
runtime/et: rename new func to UpdateAuthInfo

### DIFF
--- a/e2e-tests/testdata/testscript/et_override_user.txt
+++ b/e2e-tests/testdata/testscript/et_override_user.txt
@@ -10,13 +10,13 @@ import (
     "encore.dev/et"
 )
 
-func TestOverrideUserInfo(t *testing.T) {
+func TestOverrideAuthInfo(t *testing.T) {
     curr, _ := auth.UserID()
     if curr != "" {
         t.Fatalf("got uid %q, want %q", curr, "")
     }
 
-    et.OverrideUserInfo("foo", nil)
+    et.OverrideAuthInfo("foo", nil)
 
     curr, _ = auth.UserID()
     if curr != "foo" {
@@ -24,14 +24,14 @@ func TestOverrideUserInfo(t *testing.T) {
     }
 }
 
-func TestOverrideUserInfo_ResetBetweenTests(t *testing.T) {
+func TestOverrideAuthInfo_ResetBetweenTests(t *testing.T) {
     curr, _ := auth.UserID()
     if curr != "" {
         t.Fatalf("got uid %q, want %q", curr, "")
     }
 }
 
-func TestOverrideUserInfo_PropagatesToAPICalls(t *testing.T) {
+func TestOverrideAuthInfo_PropagatesToAPICalls(t *testing.T) {
     resp, err := GetUser(context.Background())
     if err != nil {
         t.Fatal(err)
@@ -39,7 +39,7 @@ func TestOverrideUserInfo_PropagatesToAPICalls(t *testing.T) {
         t.Fatalf("got uid %q, want %q", resp.UserID, "")
     }
 
-    et.OverrideUserInfo("foo", nil)
+    et.OverrideAuthInfo("foo", nil)
 
     resp, err = GetUser(context.Background())
     if err != nil {
@@ -49,8 +49,8 @@ func TestOverrideUserInfo_PropagatesToAPICalls(t *testing.T) {
     }
 }
 
-func TestOverrideUserInfo_APICallOptsOverride(t *testing.T) {
-    et.OverrideUserInfo("foo", nil)
+func TestOverrideAuthInfo_APICallOptsOverride(t *testing.T) {
+    et.OverrideAuthInfo("foo", nil)
 
     ctx := auth.WithContext(context.Background(), "bar", nil)
     resp, err := GetUser(ctx)

--- a/e2e-tests/testdata/testscript/et_override_user_authdata.txt
+++ b/e2e-tests/testdata/testscript/et_override_user_authdata.txt
@@ -10,13 +10,13 @@ import (
     "encore.dev/et"
 )
 
-func TestOverrideUserInfo(t *testing.T) {
+func TestOverrideAuthInfo(t *testing.T) {
     curr, _ := auth.Data().(*AuthData)
     if curr != nil {
         t.Fatalf("got data %+v, want nil", curr)
     }
 
-    et.OverrideUserInfo("foo", &AuthData{"email"})
+    et.OverrideAuthInfo("foo", &AuthData{"email"})
 
     curr = auth.Data().(*AuthData)
     if curr == nil || curr.Email != "email" {
@@ -24,14 +24,14 @@ func TestOverrideUserInfo(t *testing.T) {
     }
 }
 
-func TestOverrideUserInfo_ResetBetweenTests(t *testing.T) {
+func TestOverrideAuthInfo_ResetBetweenTests(t *testing.T) {
     curr  := auth.Data()
     if curr != nil {
         t.Fatalf("got data %+v, want nil", curr)
     }
 }
 
-func TestOverrideUserInfo_PropagatesToAPICalls(t *testing.T) {
+func TestOverrideAuthInfo_PropagatesToAPICalls(t *testing.T) {
     resp, err := GetUser(context.Background())
     if err != nil {
         t.Fatal(err)
@@ -39,7 +39,7 @@ func TestOverrideUserInfo_PropagatesToAPICalls(t *testing.T) {
         t.Fatalf("got data %+v, want nil", resp.Data)
     }
 
-    et.OverrideUserInfo("foo", &AuthData{"email"})
+    et.OverrideAuthInfo("foo", &AuthData{"email"})
 
     resp, err = GetUser(context.Background())
     if err != nil {
@@ -49,8 +49,8 @@ func TestOverrideUserInfo_PropagatesToAPICalls(t *testing.T) {
     }
 }
 
-func TestOverrideUserInfo_APICallOptsOverride(t *testing.T) {
-    et.OverrideUserInfo("foo", &AuthData{"email"})
+func TestOverrideAuthInfo_APICallOptsOverride(t *testing.T) {
+    et.OverrideAuthInfo("foo", &AuthData{"email"})
 
     ctx := auth.WithContext(context.Background(), "bar", &AuthData{"email2"})
     resp, err := GetUser(ctx)

--- a/runtime/et/auth.go
+++ b/runtime/et/auth.go
@@ -7,7 +7,7 @@ import (
 	"encore.dev/beta/auth"
 )
 
-// OverrideUserInfo overrides the user info for the current request.
+// OverrideAuthInfo overrides the auth information for the current request.
 // Subsequent calls to auth.UserID and auth.Data() within the same request
 // will return the given uid and data, and API calls made from the request
 // will propagate the newly set user info.
@@ -22,17 +22,17 @@ import (
 // API calls made with these options will not be made and will immediately return
 // a client-side error.
 //
-// OverrideUserInfo is not safe for concurrent use with code that invokes
-// auth.UserID or auth.Data() in the same request.
-func OverrideUserInfo(uid auth.UID, data any) {
-	Singleton.OverrideUserInfo(uid, data)
+// OverrideAuthInfo is not safe for concurrent use with code that invokes
+// auth.UserID or auth.Data() within the same request.
+func OverrideAuthInfo(uid auth.UID, data any) {
+	Singleton.OverrideAuthInfo(uid, data)
 }
 
-func (mgr *Manager) OverrideUserInfo(uid auth.UID, authData any) {
+func (mgr *Manager) OverrideAuthInfo(uid auth.UID, authData any) {
 	if curr := mgr.rt.Current(); curr.Req != nil {
 		authDataType := mgr.cfg.Static.AuthData
 		if err := api.CheckAuthData(authDataType, uid, authData); err != nil {
-			panic(fmt.Errorf("override user info: %v", err))
+			panic(fmt.Errorf("override auth info: %v", err))
 		}
 		if rpcData := curr.Req.RPCData; rpcData != nil {
 			rpcData.UserID = uid

--- a/tools/publicapigen/main.go
+++ b/tools/publicapigen/main.go
@@ -111,12 +111,20 @@ func main() {
 			log.Fatal().Err(err).Str("dir", outputDir).Msg("unable to create output directory")
 		}
 
+		if isEmptyFile(formattedAST) {
+			continue
+		}
+
 		if err := os.WriteFile(outputFile, convertASTToFormattedSrc(formattedFset, formattedAST, fileName), 0644); err != nil {
 			log.Fatal().Err(err).Str("file", fileName).Msg("unable to write file")
 		}
 	}
 
 	log.Info().Msg("done")
+}
+
+func isEmptyFile(f *ast.File) bool {
+	return len(f.Decls) == 0 && f.Doc.Text() == ""
 }
 
 func convertASTToFormattedSrc(fset *token.FileSet, fAST *ast.File, fileName string) []byte {


### PR DESCRIPTION
The release hasn't gone out yet, so let's do it while we can.