### PR TITLE
Add experiment to support overriding secrets locally

### DIFF
--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -337,7 +337,7 @@ func (r *Run) buildAndStart(ctx context.Context, tracker *optracker.OpTracker) e
 			if r.App.PlatformID() == "" {
 				return fmt.Errorf("the app defines secrets, but is not yet linked to encore.dev; link it with `encore app link` to use secrets")
 			}
-			data, err := r.mgr.Secret.Get(ctx, r.App.PlatformID())
+			data, err := r.mgr.Secret.Get(ctx, r.App, expSet)
 			if err != nil {
 				return err
 			}

--- a/e2e-tests/app_test.go
+++ b/e2e-tests/app_test.go
@@ -74,6 +74,10 @@ func RunApp(c testing.TB, appRoot string, logger RunLogger, env []string) *RunAp
 	expSet, err := experiments.NewSet(nil, env)
 	assertNil(err)
 
+	secrets := secret.New()
+	secretData, err := secrets.Get(ctx, app, expSet)
+	assertNil(err)
+
 	p, err := run.StartProc(&StartProcParams{
 		Ctx:            ctx,
 		BuildDir:       build.Dir,
@@ -87,6 +91,7 @@ func RunApp(c testing.TB, appRoot string, logger RunLogger, env []string) *RunAp
 		Redis:          redisSrv,
 		ServiceConfigs: build.Configs,
 		Experiments:    expSet,
+		Secrets:        secretData.Values,
 	})
 	assertNil(err)
 	c.Cleanup(p.Close)

--- a/e2e-tests/testdata/testscript/experiment_local_secrets_override.txtar
+++ b/e2e-tests/testdata/testscript/experiment_local_secrets_override.txtar
@@ -1,0 +1,25 @@
+env ENCORE_EXPERIMENT=local-secrets-override
+run
+call GET /svc.GetFoo
+checkresp '{"Data": "bar"}'
+
+-- svc/svc.go --
+package svc
+
+import "context"
+
+type Resp struct {
+	Data string
+}
+
+var secrets struct {
+	Foo string
+}
+
+//encore:api public
+func GetFoo(ctx context.Context) (*Resp, error) {
+	return &Resp{Data: secrets.Foo}, nil
+}
+
+-- .secrets.local.cue --
+Foo: "bar"

--- a/internal/experiments/experiment.go
+++ b/internal/experiments/experiment.go
@@ -12,11 +12,18 @@ const envName = "ENCORE_EXPERIMENT"
 type Name string
 
 const (
-/* Current experiments are listed here */
+	/* Current experiments are listed here */
+
+	// LocalSecretsOverride is an experiment to allow for secrets
+	// to be overridden with values from a ".secrets.local" file.
+	LocalSecretsOverride Name = "local-secrets-override"
 )
 
+// Valid reports whether the given name is a known experiment.
 func (x Name) Valid() bool {
 	switch x {
+	case LocalSecretsOverride:
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
This adds an Encore experiment named `local-secrets-override`
that enables the ability to define a `.secrets.local.cue` file that
specifies local values for secrets to use instead of the ones stored
for the app as a whole.