### PR TITLE
Disable JavaScript client generation for now

### DIFF
--- a/cli/cmd/encore/gen.go
+++ b/cli/cmd/encore/gen.go
@@ -57,7 +57,7 @@ Supported language codes are:
 				// Validate the user input for the language
 				l, err := clientgen.GetLang(lang)
 				if err != nil {
-					fatal(fmt.Sprintf("%s: supported langauges are `typescript`, `javascript`, and `go`", err))
+					fatal(fmt.Sprintf("%s: supported langauges are `typescript` and `go`", err))
 				}
 				lang = string(l)
 			}
@@ -117,15 +117,14 @@ which may require the user-facing wrapper code to be manually generated.`,
 	genCmd.AddCommand(genClientCmd)
 	genCmd.AddCommand(genWrappersCmd)
 
-	genClientCmd.Flags().StringVarP(&lang, "lang", "l", "", "The language to generate code for (\"typescript\", \"javascript\", and \"go\" are supported)")
+	genClientCmd.Flags().StringVarP(&lang, "lang", "l", "", "The language to generate code for (\"typescript\" and \"go\" are supported)")
 	_ = genClientCmd.RegisterFlagCompletionFunc("lang", autoCompleteFromStaticList(
 		"typescript\tA TypeScript client using the in-browser Fetch API",
-		"javascript\tA JavaScript client using the in-browser Fetch API",
 		"go\tA Go client using net/http",
 	))
 
 	genClientCmd.Flags().StringVarP(&output, "output", "o", "", "The filename to write the generated client code to")
-	_ = genClientCmd.MarkFlagFilename("output", "go", "ts", "tsx", "js", "jsx")
+	_ = genClientCmd.MarkFlagFilename("output", "go", "ts", "tsx")
 
 	genClientCmd.Flags().StringVarP(&envName, "env", "e", "", "The environment to fetch the API for (defaults to the primary environment)")
 	_ = genClientCmd.RegisterFlagCompletionFunc("env", autoCompleteEnvSlug)

--- a/cli/cmd/encore/gen.go
+++ b/cli/cmd/encore/gen.go
@@ -36,7 +36,6 @@ Use '--env=local' to generate it based on your local development version of the 
 
 Supported language codes are:
   typescript: A TypeScript-client using the in-browser Fetch API
-  javascript: A JavaScript client using the in-browser Fetch API
   go: A Go client using net/http"
 `,
 		Args: cobra.ExactArgs(1),
@@ -49,7 +48,8 @@ Supported language codes are:
 			if lang == "" {
 				var ok bool
 				l, ok := clientgen.Detect(output)
-				if !ok {
+				// Temporarily disable JavaScript in the CLI
+				if !ok || l == clientgen.LangJavascript {
 					fatal("could not detect language from output.\n\nNote: you can specify the language explicitly with --lang.")
 				}
 				lang = string(l)

--- a/internal/clientgen/client.go
+++ b/internal/clientgen/client.go
@@ -37,8 +37,8 @@ func Detect(path string) (lang Lang, ok bool) {
 	switch suffix {
 	case ".ts":
 		return LangTypeScript, true
-	/*case ".js":
-	return LangJavascript, true*/
+	case ".js":
+		return LangJavascript, true
 	case ".go":
 		return LangGo, true
 	default:
@@ -58,8 +58,8 @@ func Client(lang Lang, appSlug string, md *meta.Data) (code []byte, err error) {
 	switch lang {
 	case LangTypeScript:
 		gen = &typescript{generatorVersion: typescriptGenLatestVersion}
-	/*case LangJavascript:
-	gen = &javascript{generatorVersion: javascriptGenLatestVersion}*/
+	case LangJavascript:
+		gen = &javascript{generatorVersion: javascriptGenLatestVersion}
 	case LangGo:
 		gen = &golang{generatorVersion: goGenLatestVersion}
 	default:

--- a/internal/clientgen/client.go
+++ b/internal/clientgen/client.go
@@ -37,8 +37,8 @@ func Detect(path string) (lang Lang, ok bool) {
 	switch suffix {
 	case ".ts":
 		return LangTypeScript, true
-	case ".js":
-		return LangJavascript, true
+	/*case ".js":
+	return LangJavascript, true*/
 	case ".go":
 		return LangGo, true
 	default:
@@ -58,8 +58,8 @@ func Client(lang Lang, appSlug string, md *meta.Data) (code []byte, err error) {
 	switch lang {
 	case LangTypeScript:
 		gen = &typescript{generatorVersion: typescriptGenLatestVersion}
-	case LangJavascript:
-		gen = &javascript{generatorVersion: javascriptGenLatestVersion}
+	/*case LangJavascript:
+	gen = &javascript{generatorVersion: javascriptGenLatestVersion}*/
 	case LangGo:
 		gen = &golang{generatorVersion: goGenLatestVersion}
 	default:
@@ -78,8 +78,8 @@ func GetLang(lang string) (Lang, error) {
 	switch strings.TrimSpace(strings.ToLower(lang)) {
 	case "typescript", "ts":
 		return LangTypeScript, nil
-	case "javascript", "js":
-		return LangJavascript, nil
+	/*case "javascript", "js":
+	return LangJavascript, nil*/
 	case "go", "golang":
 		return LangGo, nil
 	default:

--- a/internal/clientgen/javascript.go
+++ b/internal/clientgen/javascript.go
@@ -559,7 +559,7 @@ if (authData) {
 					w.WriteString("\n")
 				}
 			} else {
-				w.WriteString("init.headers[\"Authorization\"] = \"Bearer \" + authData\n")
+				w.WriteString("init.headers[\"x-api-key\"] = \"Bearer \" + authData\n")
 			}
 		}
 


### PR DESCRIPTION
When I was investigating to make sure the JavaScript client was the same as the TYpeScript client, I noticed that the JS PR was merged before the JS client generation was properly disabled. According to the comment on my initial PR, I've created this follow up to make sure it's disabled if it's deemed necessary.