### PR TITLE
runtime: explicitly set content type

### DIFF
--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -113,6 +113,8 @@ func (d *Desc[Req, Resp]) Handle(c IncomingContext) {
 	}
 
 	if !d.Raw {
+		c.w.Header().Set("Content-Type", "application/json")
+		c.w.Header().Set("X-Content-Type-Options", "nosniff")
 		resp.Err = d.EncodeResp(c.w, c.server.json, respData)
 	}
 	c.server.finishRequest(resp)


### PR DESCRIPTION
net/http's content type detection is not very
accurate, particularly for small payloads.
Set the content type explicitly.

Thanks Alex Guerrieri for the report.