### PR TITLE
runtime: fix payload tracing

### DIFF
--- a/cli/daemon/engine/trace/trace.go
+++ b/cli/daemon/engine/trace/trace.go
@@ -371,6 +371,10 @@ func (tp *traceParser) requestStart(ts uint64) error {
 		req.MessageId = tp.String()
 		req.Attempt = tp.Uint32()
 		req.PublishTime = uint64(tp.Time().UnixMilli())
+
+		if tp.version >= 10 {
+			req.RequestPayload = tp.ByteString()
+		}
 	}
 
 	tp.reqs = append(tp.reqs, req)
@@ -432,10 +436,6 @@ func (tp *traceParser) requestEnd(ts uint64) error {
 		if len(errMsg) > 0 {
 			req.Err = errMsg
 
-			// Version 9 has a spurious duplicated error message.
-			// Ignore it.
-			_ = tp.String()
-			
 			req.ErrStack = tp.stack(filterNone)
 		}
 

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -138,7 +138,7 @@ func (d *Desc[Req, Resp]) begin(c IncomingContext) (reqData Req, beginErr error)
 	if decodeErr == nil {
 		payload = d.ReqUserPayload(reqData)
 		if !d.Raw {
-			nonRawPayload = marshalParams(c.server.json, reqData)
+			nonRawPayload = marshalParams(c.server.json, payload)
 		}
 	}
 
@@ -372,9 +372,10 @@ func (d *Desc[Req, Resp]) Call(c CallContext, req Req) (respData Resp, respErr e
 			httpMethod = d.Methods[0]
 		}
 
+		userPayload := d.ReqUserPayload(req)
 		var nonRawPayload []byte
 		if !d.Raw {
-			nonRawPayload = marshalParams(c.server.json, req)
+			nonRawPayload = marshalParams(c.server.json, userPayload)
 		}
 
 		reqObj, beginErr := c.server.beginRequest(c.ctx, &beginRequestParams{
@@ -385,7 +386,7 @@ func (d *Desc[Req, Resp]) Call(c CallContext, req Req) (respData Resp, respErr e
 				HTTPMethod:    httpMethod,
 				Path:          path,
 				PathParams:    d.toNamedParams(params),
-				TypedPayload:  d.ReqUserPayload(req),
+				TypedPayload:  userPayload,
 				Desc:          d.rpcDesc(),
 				NonRawPayload: nonRawPayload,
 

--- a/runtime/appruntime/app/app.go
+++ b/runtime/appruntime/app/app.go
@@ -92,7 +92,7 @@ func New(p *NewParams) *App {
 	auth := auth.NewManager(rt)
 	rlog := rlog.NewManager(rt)
 	sqldb := sqldb.NewManager(cfg, rt)
-	pubsub := pubsub.NewManager(cfg, rt, ts, apiSrv, rootLogger)
+	pubsub := pubsub.NewManager(cfg, rt, ts, apiSrv, rootLogger, json)
 	cache := cache.NewManager(cfg, rt, ts, json)
 	appCfg := appCfg.NewManager(rt, json)
 	etMgr := et.NewManager(cfg, rt)

--- a/runtime/appruntime/model/request.go
+++ b/runtime/appruntime/model/request.go
@@ -112,6 +112,8 @@ type PubSubMsgData struct {
 	Published      time.Time
 	Attempt        int
 	DecodedPayload any
+	// Payload is the JSON-encoded payload.
+	Payload []byte
 }
 
 type TestData struct {

--- a/runtime/appruntime/trace/events.go
+++ b/runtime/appruntime/trace/events.go
@@ -140,6 +140,7 @@ func (l *Log) BeginRequest(req *model.Request, goid uint32) {
 		tb.String(data.MessageID)
 		tb.Uint32(uint32(data.Attempt))
 		tb.Time(data.Published)
+		tb.ByteString(data.Payload)
 	}
 
 	l.Add(RequestStart, tb.Buf())
@@ -152,7 +153,6 @@ func (l *Log) FinishRequest(req *model.Request, resp *model.Response) {
 
 	tb.Err(resp.Err)
 	if resp.Err != nil {
-		tb.String(resp.Err.Error())
 		tb.Stack(errs.Stack(resp.Err))
 	}
 

--- a/runtime/appruntime/trace/trace.go
+++ b/runtime/appruntime/trace/trace.go
@@ -7,7 +7,7 @@ import (
 type Version int
 
 // CurrentVersion is the trace protocol version this package produces traces in.
-const CurrentVersion Version = 9
+const CurrentVersion Version = 10
 
 // Enabled reports whether tracing is enabled.
 // It is always enabled except for running tests and for ejected applications.

--- a/runtime/pubsub/manager_internal.go
+++ b/runtime/pubsub/manager_internal.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/rs/zerolog"
 
 	"encore.dev/appruntime/api"
@@ -22,13 +23,14 @@ type Manager struct {
 	apiSrv     *api.Server
 	ts         *testsupport.Manager
 	rootLogger zerolog.Logger
+	json       jsoniter.API
 	providers  []provider
 
 	publishCounter uint64
 	outstanding    *outstandingMessageTracker
 }
 
-func NewManager(cfg *config.Config, rt *reqtrack.RequestTracker, ts *testsupport.Manager, server *api.Server, rootLogger zerolog.Logger) *Manager {
+func NewManager(cfg *config.Config, rt *reqtrack.RequestTracker, ts *testsupport.Manager, server *api.Server, rootLogger zerolog.Logger, json jsoniter.API) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
 	mgr := &Manager{
 		ctx:         ctx,
@@ -38,6 +40,7 @@ func NewManager(cfg *config.Config, rt *reqtrack.RequestTracker, ts *testsupport
 		apiSrv:      server,
 		ts:          ts,
 		rootLogger:  rootLogger,
+		json:        json,
 		outstanding: newOutstandingMessageTracker(),
 	}
 

--- a/runtime/pubsub/subscription.go
+++ b/runtime/pubsub/subscription.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"encore.dev/appruntime/config"
 	"encore.dev/appruntime/model"
 	"encore.dev/appruntime/trace"
@@ -133,6 +135,7 @@ func NewSubscription[T any](topic *Topic[T], name string, subscriptionCfg Subscr
 				Attempt:        deliveryAttempt,
 				Published:      publishTime,
 				DecodedPayload: msg,
+				Payload:        marshalParams(mgr.json, msg),
 			},
 			DefLoc: staticCfg.TraceIdx,
 			Traced: tracingEnabled,
@@ -197,4 +200,9 @@ func (t *Topic[T]) getSubscriptionConfig(name string) (*config.PubsubSubscriptio
 	}
 
 	return subscription, staticCfg
+}
+
+func marshalParams[Resp any](json jsoniter.API, resp Resp) []byte {
+	data, _ := json.Marshal(resp)
+	return data
 }


### PR DESCRIPTION
This fixes some minor bugs related to how payloads
were represented in traces. PubSub message payloads,
in particular, were not being passed to the request
object which meant they were not being rendered.