### PR TITLE
compiler: fix exec script from other dir

### DIFF
--- a/cli/daemon/run/exec_script.go
+++ b/cli/daemon/run/exec_script.go
@@ -111,11 +111,15 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 			EncoreGoRoot:          env.EncoreGoRoot(),
 			BuildTags:             []string{"encore_local", "encore_no_gcp", "encore_no_aws", "encore_no_azure"},
 			Experiments:           expSet,
+			OpTracker:             tracker,
 			Meta: &cueutil.Meta{
 				APIBaseURL: apiBaseURL,
 				EnvName:    "local",
 				EnvType:    cueutil.EnvType_Development,
 				CloudType:  cueutil.CloudType_Local,
+			},
+			ExecScript: &compiler.ExecScriptConfig{
+				ScriptMainPkg: p.ScriptRelPath,
 			},
 		}
 		build, err = compiler.ExecScript(p.App.Root(), cfg)

--- a/compiler/build.go
+++ b/compiler/build.go
@@ -77,6 +77,9 @@ type Config struct {
 	// Test is the specific settings for running tests.
 	Test *TestConfig
 
+	// ExecScript is the specific settings for executing scripts.
+	ExecScript *ExecScriptConfig
+
 	// The meta config we pass to CUE when computing the runtime configuration for the services within this
 	// application
 	Meta *cueutil.Meta


### PR DESCRIPTION
We were incorrectly using the working dir where
we should be using the script rel path.

Also propagate the op tracker for better visibility
into what the command is doing during compilation.