### PR TITLE
runtime: fix log format in GCP

### DIFF
--- a/runtime/appruntime/app/app.go
+++ b/runtime/appruntime/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"io"
 	"os"
+	"time"
 
 	"github.com/benbjohnson/clock"
 	jsoniter "github.com/json-iterator/go"
@@ -20,6 +21,7 @@ import (
 	"encore.dev/beta/auth"
 	appCfg "encore.dev/config"
 	"encore.dev/et"
+	"encore.dev/internal/cloud"
 	"encore.dev/pubsub"
 	"encore.dev/rlog"
 	"encore.dev/storage/cache"
@@ -164,5 +166,17 @@ func metricsExporter(cfg *runtimeCfg.Config, logger zerolog.Logger) metrics.Expo
 		return metrics.NewLogsBasedExporter(logger)
 	default:
 		panic("unexpected metrics exporter")
+	}
+}
+
+// ReconfigureZerologFormat reconfigures the zerolog Logger's output format
+// based on the cloud provider.
+func (app *App) ReconfigureZerologFormat() {
+	switch app.cfg.Runtime.EnvCloud {
+	case cloud.GCP:
+		zerolog.LevelFieldName = "severity"
+		zerolog.TimestampFieldName = "timestamp"
+		zerolog.TimeFieldFormat = time.RFC3339Nano
+	default:
 	}
 }

--- a/runtime/appruntime/app/appinit/appinit.go
+++ b/runtime/appruntime/app/appinit/appinit.go
@@ -14,6 +14,7 @@ import (
 
 // AppMain is the entrypoint to the Encore Application.
 func AppMain() {
+	singleton.ReconfigureZerologFormat()
 	if err := singleton.Run(); err != nil && err != io.EOF {
 		singleton.RootLogger().Fatal().Err(err).Msg("could not run")
 	}

--- a/runtime/appruntime/app/setup_cloud.go
+++ b/runtime/appruntime/app/setup_cloud.go
@@ -6,9 +6,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"time"
-
-	"github.com/rs/zerolog"
 )
 
 var devMode = false
@@ -19,13 +16,4 @@ func Listen() (net.Listener, error) {
 		port = 8080
 	}
 	return net.Listen("tcp", ":"+strconv.Itoa(port))
-}
-
-// ConfigureZerologOutput configures the zerolog Logger's output format.
-func ConfigureZerologOutput() {
-	// Settings to match what Cloud Logging expects.
-	// TODO(andre): change this to vary by cloud provider?
-	zerolog.LevelFieldName = "severity"
-	zerolog.TimestampFieldName = "timestamp"
-	zerolog.TimeFieldFormat = time.RFC3339Nano
 }

--- a/runtime/appruntime/app/setup_local.go
+++ b/runtime/appruntime/app/setup_local.go
@@ -46,8 +46,3 @@ func Listen() (net.Listener, error) {
 
 	return yamux.Server(rwc, yamux.DefaultConfig())
 }
-
-// ConfigureZerologOutput configures the zerolog Logger's output format.
-func ConfigureZerologOutput() {
-	// Use default settings for local development.
-}


### PR DESCRIPTION
GCP's Cloud Logging expects a different format
for level and timestamp field names. Handle this
by reconfiguring zerolog based on the runtime config.

Thanks Patryk Siemiński for the report!