### PR TITLE
[ENC-1069] Support Private Network Access in CORS

### DIFF
--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -294,6 +294,23 @@ func (i *Instance) Experiments(environ []string) (*experiments.Set, error) {
 	return experiments.NewSet(exp, environ)
 }
 
+// GlobalCORS returns the CORS configuration for the app which
+// will be applied against all API gateways into the app
+func (i *Instance) GlobalCORS() (appfile.CORS, error) {
+	cors, err := appfile.GlobalCORS(i.root)
+	if err != nil {
+		return appfile.CORS{}, err
+	}
+
+	// If there are no Global CORS return the default
+	if cors == nil {
+		return appfile.CORS{}, nil
+	}
+
+	return *cors, nil
+
+}
+
 func (i *Instance) Watch(fn WatchFunc) error {
 	if err := i.beginWatch(); err != nil {
 		return err

--- a/cli/daemon/run/exec_script.go
+++ b/cli/daemon/run/exec_script.go
@@ -138,7 +138,7 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 		return err
 	}
 
-	runtimeCfg := mgr.generateConfig(generateConfigParams{
+	runtimeCfg, err := mgr.generateConfig(generateConfigParams{
 		App:         p.App,
 		RS:          rs,
 		Meta:        parse.Meta,
@@ -148,6 +148,9 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 		ConfigAppID: GenID(),
 		ConfigEnvID: GenID(),
 	})
+	if err != nil {
+		return err
+	}
 	runtimeJSON, _ := json.Marshal(runtimeCfg)
 
 	env := append(os.Environ(), p.Environ...)

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -415,7 +415,7 @@ func (r *Run) StartProc(params *StartProcParams) (p *Proc, err error) {
 	}
 	go p.parseSymTable(params.BinPath)
 
-	runtimeCfg := r.Mgr.generateConfig(generateConfigParams{
+	runtimeCfg, err := r.Mgr.generateConfig(generateConfigParams{
 		App:         r.App,
 		RS:          r.ResourceServers,
 		Meta:        params.Meta,
@@ -425,6 +425,9 @@ func (r *Run) StartProc(params *StartProcParams) (p *Proc, err error) {
 		ConfigAppID: r.ID,
 		ConfigEnvID: p.ID,
 	})
+	if err != nil {
+		return nil, err
+	}
 	runtimeJSON, _ := json.Marshal(runtimeCfg)
 
 	cmd := exec.Command(params.BinPath)

--- a/cli/internal/appfile/appfile.go
+++ b/cli/internal/appfile/appfile.go
@@ -31,6 +31,19 @@ type File struct {
 	//
 	// Do not use these features in production without consulting the Encore team.
 	Experiments []experiments.Name `json:"experiments,omitempty"`
+
+	// Configure global CORS settings for the application which
+	// will be applied to all API gateways into the application.
+	GlobalCORS *CORS `json:"global_cors,omitempty"`
+}
+
+type CORS struct {
+	// Debug is a flag to enable debug logging for CORS
+	Debug bool `json:"debug,omitempty"`
+
+	// AllowHeaders allows an app to specify additional headers that should be
+	// accepted by the app
+	AllowHeaders []string `json:"allow_headers"`
 }
 
 // Parse parses the app file data into a File.
@@ -75,4 +88,13 @@ func Experiments(appRoot string) ([]experiments.Name, error) {
 		return nil, err
 	}
 	return f.Experiments, nil
+}
+
+// GlobalCORS returns the global CORS settings for the app located
+func GlobalCORS(appRoot string) (*CORS, error) {
+	f, err := ParseFile(filepath.Join(appRoot, Name))
+	if err != nil {
+		return nil, err
+	}
+	return f.GlobalCORS, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc1 // indirect
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc // indirect
+	github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1203,6 +1203,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d h1:gNEXs+4IbftZmT6WnAJbBWgbPrjDjqaMfuNeKODqBhc=
+github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -62,6 +62,9 @@ type Runtime struct {
 const UnsafeAllOriginWithCredentials = "UNSAFE_ALL_ORIGINS_WITH_CREDENTIALS"
 
 type CORS struct {
+	// Debug enables debug logging of all requests passing through the CORS system
+	Debug bool `json:"debug"`
+
 	// DisableCredentials, if true, causes Encore to respond to OPTIONS requests
 	// without setting Access-Control-Allow-Credentials: true.
 	DisableCredentials bool `json:"disable_credentials,omitempty"`
@@ -81,6 +84,12 @@ type CORS struct {
 	// the default set of {"Origin", "Authorization", "Content-Type"}.
 	// As a special case, if the list contains "*" all headers are allowed.
 	ExtraAllowedHeaders []string `json:"raw_allowed_headers,omitempty"`
+
+	// AllowAccessWhenOnPrivateNetwork, if true, allows requests to Encore apps running
+	// on private networks from websites.
+	//
+	// See: https://wicg.github.io/private-network-access/
+	AllowAccessWhenOnPrivateNetwork bool `json:"allow_private_network_access,omitempty"`
 }
 
 type CommitInfo struct {

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nsqio/go-nsq v1.1.0
-	github.com/rs/cors v1.8.2
+	github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d
 	github.com/rs/zerolog v1.28.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870
 	google.golang.org/api v0.97.0

--- a/runtime/go.sum
+++ b/runtime/go.sum
@@ -374,6 +374,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d h1:gNEXs+4IbftZmT6WnAJbBWgbPrjDjqaMfuNeKODqBhc=
+github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=


### PR DESCRIPTION
As of Chrome 107, a new CORS header is present if the requested resource is on a private network: `Access-Control-Allow-Private-Network: true` The response _must_ include this header as well for the preflight to pass.

This commit adds support for this only on applications running locally (i.e. run through `encore run`).

This commit also adds support for `encore.app` files to declare a list of allowed headers which should be permitted on the application. Previously this was configuration within the Encore platform but did not affect local development.

By adding the following to `encore.app`, an app can opt into allowing the header `X-Test-Header`:

```json
{
    "global_cors": {
        "allow_headers": [
            "X-Test-Header",
        ],
    },
}
```