### PR TITLE
Move to FSNotify for file system watching

### DIFF
--- a/cli/cmd/encore/daemon/daemon.go
+++ b/cli/cmd/encore/daemon/daemon.go
@@ -108,6 +108,7 @@ func (d *Daemon) init() {
 	d.EncoreDB = d.openDB()
 
 	d.Apps = apps.NewManager(d.EncoreDB)
+	d.close = append(d.close, d.Apps)
 
 	// If ENCORE_SQLDB_HOST is set, use the external cluster instead of
 	// creating our own docker container cluster.

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/rjeczalik/notify"
 	"github.com/rs/zerolog/log"
 	"go4.org/syncutil"
 
 	"encr.dev/cli/daemon/internal/manifest"
 	"encr.dev/cli/internal/appfile"
 	"encr.dev/internal/experiments"
+	"encr.dev/pkg/watcher"
 )
 
 var ErrNotFound = errors.New("app not found")
@@ -165,7 +165,7 @@ func (mgr *Manager) RegisterAppListener(fn func(*Instance)) {
 }
 
 // WatchFunc is the signature of functions registered as app watchers.
-type WatchFunc func(*Instance, notify.EventInfo)
+type WatchFunc func(*Instance, []watcher.Event)
 
 // WatchAll watches all apps for changes.
 func (mgr *Manager) WatchAll(fn WatchFunc) error {
@@ -184,7 +184,7 @@ func (mgr *Manager) WatchAll(fn WatchFunc) error {
 	return nil
 }
 
-func (mgr *Manager) onWatchEvent(i *Instance, ev notify.EventInfo) {
+func (mgr *Manager) onWatchEvent(i *Instance, ev []watcher.Event) {
 	mgr.watchMu.Lock()
 	watchers := mgr.watchers
 	mgr.watchMu.Unlock()
@@ -240,6 +240,20 @@ func (mgr *Manager) resolve(appRoot string) (*Instance, error) {
 	return i, nil
 }
 
+func (mgr *Manager) Close() error {
+	mgr.instanceMu.Lock()
+	defer mgr.instanceMu.Unlock()
+
+	for _, inst := range mgr.instances {
+		if err := inst.Close(); err != nil {
+			log.Err(err).Str("id", inst.PlatformOrLocalID()).Msg("unable to close app instance")
+			// do not return an error here as we want to close all instances
+		}
+	}
+
+	return nil
+}
+
 // Instance describes an app instance known by the Encore daemon.
 type Instance struct {
 	root       string
@@ -248,15 +262,17 @@ type Instance struct {
 
 	// mgr is a reference to the manager that created it.
 	// It may be nil if an instance was created without a manager.
-	mgr *Manager
+	mgr     *Manager
+	watcher *watcher.Watcher
 
-	setupWatch syncutil.Once
-	watchMu    sync.Mutex
-	watchers   []WatchFunc
+	setupWatch  syncutil.Once
+	watchMu     sync.Mutex
+	nextWatchID WatchSubscriptionID
+	watchers    map[WatchSubscriptionID]*watchSubscription
 }
 
 func NewInstance(root, localID, platformID string) *Instance {
-	return &Instance{root: root, localID: localID, platformID: platformID}
+	return &Instance{root: root, localID: localID, platformID: platformID, watchers: make(map[WatchSubscriptionID]*watchSubscription)}
 }
 
 // Root returns the filesystem path for the app root.
@@ -311,40 +327,69 @@ func (i *Instance) GlobalCORS() (appfile.CORS, error) {
 
 }
 
-func (i *Instance) Watch(fn WatchFunc) error {
+func (i *Instance) Watch(fn WatchFunc) (WatchSubscriptionID, error) {
 	if err := i.beginWatch(); err != nil {
-		return err
+		return 0, err
 	}
 
 	i.watchMu.Lock()
-	i.watchers = append(i.watchers, fn)
+	i.nextWatchID++
+	id := i.nextWatchID
+	i.watchers[id] = &watchSubscription{id, fn}
 	i.watchMu.Unlock()
-	return nil
+	return id, nil
+}
+
+func (i *Instance) Unwatch(id WatchSubscriptionID) {
+	i.watchMu.Lock()
+	delete(i.watchers, id)
+	i.watchMu.Unlock()
 }
 
 func (i *Instance) beginWatch() error {
 	return i.setupWatch.Do(func() error {
-		evs := make(chan notify.EventInfo, 100)
-		err := notify.Watch(filepath.Join(i.root, "..."), evs, notify.All)
+		watch, err := watcher.New(i.PlatformOrLocalID())
 		if err != nil {
-			return errors.Wrap(err, "watch")
+			return errors.Wrap(err, "unable to create watcher")
+		}
+		i.watcher = watch
+
+		if err := i.watcher.RecursivelyWatch(i.root); err != nil {
+			return errors.Wrap(err, "unable to watch app")
 		}
 
 		go func() {
-			for ev := range evs {
+			for range i.watcher.EventsReady {
+				batch := i.watcher.GetEventsBatch()
+				events := batch.Events()
+
 				if i.mgr != nil {
-					i.mgr.onWatchEvent(i, ev)
+					i.mgr.onWatchEvent(i, events)
 				}
 
 				i.watchMu.Lock()
 				watchers := i.watchers
 				i.watchMu.Unlock()
-				for _, fn := range watchers {
-					fn(i, ev)
+				for _, sub := range watchers {
+					sub.f(i, events)
 				}
 			}
 		}()
 
 		return nil
 	})
+}
+
+func (i *Instance) Close() error {
+	if i.watcher != nil {
+		return i.watcher.Close()
+	}
+	return nil
+}
+
+type WatchSubscriptionID int64
+
+type watchSubscription struct {
+	id WatchSubscriptionID
+	f  WatchFunc
 }

--- a/cli/daemon/watch.go
+++ b/cli/daemon/watch.go
@@ -6,16 +6,16 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/bep/debounce"
 	"github.com/cockroachdb/errors"
-	"github.com/rjeczalik/notify"
 	"github.com/rs/zerolog/log"
 
 	"encr.dev/cli/daemon/apps"
+	"encr.dev/cli/daemon/run"
 	"encr.dev/compiler"
+	"encr.dev/pkg/watcher"
 )
 
 func (s *Server) watchApps() {
@@ -32,19 +32,8 @@ func (s *Server) watchApps() {
 	}
 }
 
-func (s *Server) onWatchEvent(i *apps.Instance, ev notify.EventInfo) {
-	path := ev.Path()
-	ext := filepath.Ext(path)
-	filename := filepath.Base(path)
-	switch ext {
-	case ".go", ".mod", ".sum", ".work":
-		// Our code may have changed; regenerate
-	default:
-		return
-	}
-
-	if strings.HasPrefix(strings.ToLower(filename), "encore.gen.") {
-		// Ignore generated code
+func (s *Server) onWatchEvent(i *apps.Instance, events []watcher.Event) {
+	if run.IgnoreEvents(events) {
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/fatih/structtag v1.2.0
 	github.com/frankban/quicktest v1.14.3
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gofrs/uuid v4.3.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/golang/protobuf v1.5.2
@@ -33,7 +34,6 @@ require (
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/nsqio/nsq v1.2.1
 	github.com/pkg/errors v0.9.1
-	github.com/rjeczalik/notify v0.9.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rogpeppe/go-internal v1.9.0
 	github.com/rs/xid v1.4.0
@@ -47,7 +47,7 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 	golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7
-	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8
+	golang.org/x/sys v0.2.0
 	golang.org/x/text v0.3.8-0.20211105212822-18b340fc7af2
 	golang.org/x/tools v0.1.12
 	google.golang.org/genproto v0.0.0-20220923205249-dd2d53f1fffc
@@ -105,7 +105,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc1 // indirect
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc // indirect
-	github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,9 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/gabriel-vasile/mimetype v1.3.1/go.mod h1:fA8fi6KUiG7MgQQ+mEWotXoEOvmxRtOJlERCzSmRvr8=
@@ -1190,8 +1191,6 @@ github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc h1:gSVONB
 github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc/go.mod h1:KbKfKPy2I6ecOIGA9apfheFv14+P3RSmmQvshofQyMY=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
-github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1203,8 +1202,6 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d h1:gNEXs+4IbftZmT6WnAJbBWgbPrjDjqaMfuNeKODqBhc=
-github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -1616,7 +1613,6 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1740,8 +1736,9 @@ golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
-golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/watcher/event.go
+++ b/pkg/watcher/event.go
@@ -1,0 +1,44 @@
+package watcher
+
+import "os"
+
+type EventType = string
+
+const (
+	CREATED  EventType = "Created"
+	MODIFIED EventType = "Modified"
+	DELETED  EventType = "Deleted"
+)
+
+type Event struct {
+	EventType EventType
+	Path      string
+	Info      os.FileInfo
+}
+
+type Events struct {
+	latestEvents map[string]Event // Latest event per file
+}
+
+func newEventBatch() *Events {
+	return &Events{
+		latestEvents: make(map[string]Event),
+	}
+}
+
+func (e *Events) addEvent(path string, event EventType, info os.FileInfo) {
+	e.latestEvents[path] = Event{
+		EventType: event,
+		Path:      path,
+		Info:      info,
+	}
+}
+
+func (e *Events) Events() []Event {
+	events := make([]Event, 0, len(e.latestEvents))
+	for _, event := range e.latestEvents {
+		events = append(events, event)
+	}
+
+	return events
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -61,6 +61,19 @@ func New(appID string) (*Watcher, error) {
 func (w *Watcher) RecursivelyWatch(folder string) error {
 	folder = filepath.Clean(folder)
 
+	// We don't want to watch certain folders as they'll never impact
+	// an Encore app, and they cause an extreme amount of noise.
+	folderName := filepath.Base(folder)
+	if folderName == "node_modules" {
+		return nil
+	}
+
+	// Don't watch hidden folders like `.git` or `.idea` as
+	// they also don't impact an Encore app.
+	if len(folderName) > 1 && folderName[0] == '.' {
+		return nil
+	}
+
 	w.mutex.Lock()
 
 	// Track the fact we're watching this directory

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,170 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/bep/debounce"
+	"github.com/fsnotify/fsnotify"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+type Watcher struct {
+	mutex sync.Mutex
+
+	log     *zerolog.Logger
+	appRoot string
+
+	watcher     *fsnotify.Watcher
+	directories map[string]struct{}
+	stop        chan struct{}
+
+	EventsReady chan struct{}
+
+	events         *Events
+	notifyListener func()
+}
+
+func New(appID string) (*Watcher, error) {
+	fswatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	logger := log.With().Str("component", "watcher").Str("app", appID).Logger()
+	logger.Debug().Msg("File system watcher created")
+	w := &Watcher{
+		watcher:     fswatcher,
+		log:         &logger,
+		directories: make(map[string]struct{}),
+		stop:        make(chan struct{}),
+		events:      nil,
+		EventsReady: make(chan struct{}),
+	}
+
+	// We debounce this to give the system time to process mass file updates
+	d := debounce.New(50 * time.Millisecond)
+	w.notifyListener = func() {
+		d(func() {
+			w.EventsReady <- struct{}{}
+		})
+	}
+
+	go w.listenForChangeEvents()
+
+	return w, nil
+}
+
+func (w *Watcher) RecursivelyWatch(folder string) error {
+	folder = filepath.Clean(folder)
+
+	w.mutex.Lock()
+
+	// Track the fact we're watching this directory
+	if _, found := w.directories[folder]; found {
+		w.mutex.Unlock()
+		return nil
+	}
+	w.directories[folder] = struct{}{}
+	w.mutex.Unlock() // unlock here to prevent reentrant locks during recursion
+
+	if err := w.watcher.Add(folder); err != nil {
+		return err
+	}
+
+	return filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return w.RecursivelyWatch(path)
+		}
+
+		return nil
+	})
+}
+
+func (w *Watcher) listenForChangeEvents() {
+	for {
+		select {
+		case <-w.stop:
+			_ = w.watcher.Close()
+			return
+
+		case event := <-w.watcher.Events:
+			switch {
+			case event.Op&fsnotify.Create == fsnotify.Create:
+				w.handleCreateEvent(event.Name)
+			case event.Op&fsnotify.Write == fsnotify.Write:
+				w.handleWriteEvent(event.Name)
+			case event.Op&fsnotify.Remove == fsnotify.Remove:
+				w.handleDeleteEvent(event.Name)
+			}
+
+		case err := <-w.watcher.Errors:
+			w.log.Err(err).Msg("Watcher error")
+		}
+	}
+}
+
+func (w *Watcher) handleCreateEvent(path string) {
+	if info, err := os.Stat(path); err != nil {
+		w.log.Err(err).Str("path", path).Msg("Unable to stat file")
+	} else if info.IsDir() {
+		if err := w.RecursivelyWatch(path); err != nil {
+			w.log.Err(err).Str("path", path).Msg("Unable to start watching new directory")
+		}
+	} else {
+		w.recordEventInBatch(path, CREATED, info)
+	}
+}
+
+func (w *Watcher) handleDeleteEvent(path string) {
+	// If it's a directory we're watching, stop watching it
+	w.mutex.Lock()
+	delete(w.directories, path)
+	w.mutex.Unlock()
+
+	w.recordEventInBatch(path, DELETED, nil)
+}
+
+func (w *Watcher) handleWriteEvent(path string) {
+	if info, err := os.Stat(path); err != nil {
+		w.log.Err(err).Str("path", path).Msg("Unable to stat file")
+	} else if !info.IsDir() {
+		w.recordEventInBatch(path, MODIFIED, info)
+	}
+}
+
+func (w *Watcher) recordEventInBatch(path string, event EventType, info os.FileInfo) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if w.events == nil {
+		w.events = newEventBatch()
+		w.notifyListener()
+	}
+
+	w.events.addEvent(path, event, info)
+}
+
+func (w *Watcher) GetEventsBatch() *Events {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	events := w.events
+	w.events = nil
+
+	return events
+}
+
+func (w *Watcher) Close() error {
+	w.stop <- struct{}{}
+	close(w.EventsReady)
+	close(w.stop)
+	return nil
+}


### PR DESCRIPTION
The existing library we where using had not been updated in a couple of years and uses a deprecated API on MacOS. This commit moves Encore over to using [fsnotify](https://github.com/fsnotify/fsnotify) as the core of the file system watching component.