### PR TITLE
[ENC-1073] Automatically add headers used in types to CORS config

### DIFF
--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -130,8 +130,8 @@ func (b *Builder) computeCORSHeaders() (Code, error) {
 
 	// Walk all the structures looking for headers
 	decls := b.res.Meta.Decls
-	for _, decl := range decls {
-		err := schema.Walk(decls, decl, func(node any) error {
+	for _, param := range b.res.App.ParamTypes() {
+		err := schema.Walk(decls, param, func(node any) error {
 			switch n := node.(type) {
 			case *schema.Struct:
 				for _, field := range n.Fields {

--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -2,14 +2,18 @@ package codegen
 
 import (
 	"fmt"
+	"net/http"
 	"path"
+	"sort"
 
 	. "github.com/dave/jennifer/jen"
 
 	"encr.dev/internal/gocodegen"
 	"encr.dev/parser"
 	"encr.dev/parser/est"
+	"encr.dev/pkg/eerror"
 	"encr.dev/pkg/errlist"
+	schema "encr.dev/proto/encore/parser/schema/v1"
 )
 
 const JsonPkg = "github.com/json-iterator/go"
@@ -46,6 +50,11 @@ func (b *Builder) Main(compilerVersion string, mainPkgPath, mainFuncName string)
 
 	mwNames, mwCode := b.RenderMiddlewares(mainPkgPath)
 
+	corsHeaders, err := b.computeCORSHeaders()
+	if err != nil {
+		b.error(eerror.Wrap(err, "codegen", "failed to compute CORS headers", nil))
+	}
+
 	f.Anon("unsafe") // for go:linkname
 	f.Comment("loadApp loads the Encore app runtime.")
 	f.Comment("//go:linkname loadApp encore.dev/appruntime/app/appinit.load")
@@ -57,6 +66,7 @@ func (b *Builder) Main(compilerVersion string, mainPkgPath, mainFuncName string)
 				Id("Revision"):    Lit(b.res.Meta.AppRevision),
 				Id("Uncommitted"): Lit(b.res.Meta.UncommittedChanges),
 			}),
+			Id("CORSHeaders"):  corsHeaders,
 			Id("PubsubTopics"): b.computeStaticPubsubConfig(),
 			Id("Testing"):      False(),
 			Id("TestService"):  Lit(""),
@@ -111,6 +121,49 @@ func (b *Builder) computeStaticPubsubConfig() Code {
 		})
 	}
 	return Map(String()).Op("*").Qual("encore.dev/appruntime/config", "StaticPubsubTopic").Values(pubsubTopicDict)
+}
+
+func (b *Builder) computeCORSHeaders() (Code, error) {
+	// Find all used headers
+	usedHeaderSet := map[string]struct{}{}
+	usedHeaders := []string{}
+
+	// Walk all the structures looking for headers
+	decls := b.res.Meta.Decls
+	for _, decl := range decls {
+		err := schema.Walk(decls, decl, func(node any) error {
+			switch n := node.(type) {
+			case *schema.Struct:
+				for _, field := range n.Fields {
+					for _, tag := range field.Tags {
+						if tag.Key == "header" {
+							name := http.CanonicalHeaderKey(tag.Name)
+							if _, found := usedHeaderSet[name]; !found {
+								usedHeaderSet[name] = struct{}{}
+								usedHeaders = append(usedHeaders, name)
+							}
+						}
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(usedHeaders) == 0 {
+		return Nil(), nil
+	}
+
+	// Generate the code list of used static headers
+	sort.Strings(usedHeaders)
+	usedHeadersCode := make([]Code, len(usedHeaders))
+	for _, header := range usedHeaders {
+		usedHeadersCode = append(usedHeadersCode, Lit(header))
+	}
+	return Index().String().Values(usedHeadersCode...), nil
 }
 
 func (b *Builder) computeHandlerRegistrationConfig(mwNames map[*est.Middleware]*Statement) *Statement {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__empty.golden
@@ -18,6 +18,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       nil,
+		CORSHeaders:    nil,
 		EncoreCompiler: "test",
 		PubsubTopics:   map[string]*__config.StaticPubsubTopic{},
 		TestService:    "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -20,7 +20,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
-		CORSHeaders:    []string{"Header1", "Header2"},
+		CORSHeaders:    nil,
 		EncoreCompiler: "test",
 		PubsubTopics:   map[string]*__config.StaticPubsubTopic{},
 		TestService:    "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -20,6 +20,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
+		CORSHeaders:    []string{"Header1", "Header2"},
 		EncoreCompiler: "test",
 		PubsubTopics:   map[string]*__config.StaticPubsubTopic{},
 		TestService:    "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -20,7 +20,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
-		CORSHeaders:    nil,
+		CORSHeaders:    []string{"Header1", "Header2"},
 		EncoreCompiler: "test",
 		PubsubTopics:   map[string]*__config.StaticPubsubTopic{},
 		TestService:    "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -20,6 +20,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
+		CORSHeaders:    nil,
 		EncoreCompiler: "test",
 		PubsubTopics:   map[string]*__config.StaticPubsubTopic{},
 		TestService:    "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -20,6 +20,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
+		CORSHeaders:    nil,
 		EncoreCompiler: "test",
 		PubsubTopics:   map[string]*__config.StaticPubsubTopic{},
 		TestService:    "",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -23,7 +23,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
-		CORSHeaders:    nil,
+		CORSHeaders:    []string{"One", "Three", "Two"},
 		EncoreCompiler: "test",
 		PubsubTopics: map[string]*__config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*__config.StaticPubsubSubscription{"subscription-name": {
 			Service:  "otherservice",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -23,6 +23,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
+		CORSHeaders:    []string{"One", "Three", "Two", "X-Header"},
 		EncoreCompiler: "test",
 		PubsubTopics: map[string]*__config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*__config.StaticPubsubSubscription{"subscription-name": {
 			Service:  "otherservice",

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -23,7 +23,7 @@ func loadApp() *__appinit.LoadData {
 			Uncommitted: false,
 		},
 		AuthData:       reflect.TypeOf((*svc.AuthData)(nil)),
-		CORSHeaders:    []string{"One", "Three", "Two", "X-Header"},
+		CORSHeaders:    nil,
 		EncoreCompiler: "test",
 		PubsubTopics: map[string]*__config.StaticPubsubTopic{"test-topic": {Subscriptions: map[string]*__config.StaticPubsubSubscription{"subscription-name": {
 			Service:  "otherservice",

--- a/parser/est/est.go
+++ b/parser/est/est.go
@@ -27,6 +27,31 @@ type Application struct {
 	Middleware    []*Middleware
 }
 
+// ParamTypes returns all used parameter types used for input to an Encore application
+func (a *Application) ParamTypes() (rtn []*schema.Type) {
+	used := make(map[*schema.Type]struct{})
+
+	// Check the auth handler
+	if a.AuthHandler != nil && a.AuthHandler.Params != nil {
+		rtn = append(rtn, a.AuthHandler.Params)
+		used[a.AuthHandler.Params] = struct{}{}
+	}
+
+	// Check all the RPC's
+	for _, s := range a.Services {
+		for _, rpc := range s.RPCs {
+			if rpc.Request != nil {
+				if _, found := used[rpc.Request.Type]; !found {
+					rtn = append(rtn, rpc.Request.Type)
+					used[rpc.Request.Type] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return
+}
+
 type File struct {
 	Name       string          // file name ("foo.go")
 	Pkg        *Package        // package it belongs to

--- a/runtime/appruntime/api/server.go
+++ b/runtime/appruntime/api/server.go
@@ -131,7 +131,7 @@ func NewServer(
 	if cfg.Runtime.CORS != nil {
 		corsCfg = cfg.Runtime.CORS
 	}
-	handler := cors.Wrap(corsCfg, http.HandlerFunc(s.handler))
+	handler := cors.Wrap(corsCfg, cfg.Static.CORSHeaders, http.HandlerFunc(s.handler))
 	s.httpsrv = &http.Server{
 		Handler: handler,
 	}

--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -21,6 +21,7 @@ type Static struct {
 	EncoreCompiler string
 	AppCommit      CommitInfo // The commit which this service was built from
 
+	CORSHeaders  []string // Headers required to be allowed by cors, pulled from the static analysis
 	PubsubTopics map[string]*StaticPubsubTopic
 
 	Testing              bool

--- a/runtime/appruntime/cors/cors.go
+++ b/runtime/appruntime/cors/cors.go
@@ -10,8 +10,8 @@ import (
 	"encore.dev/appruntime/config"
 )
 
-func Wrap(cfg *config.CORS, handler http.Handler) http.Handler {
-	c := cors.New(Options(cfg))
+func Wrap(cfg *config.CORS, staticHeaders []string, handler http.Handler) http.Handler {
+	c := cors.New(Options(cfg, staticHeaders))
 	if cfg.Debug {
 		logger := log.With().Str("subsystem", "cors").Logger()
 		logger.Debug().Msg("CORS system running in debug mode. All requests will be logged.")
@@ -20,7 +20,7 @@ func Wrap(cfg *config.CORS, handler http.Handler) http.Handler {
 	return c.Handler(handler)
 }
 
-func Options(cfg *config.CORS) cors.Options {
+func Options(cfg *config.CORS, staticHeaders []string) cors.Options {
 	// Sort origins to allow for binary search
 	originsCreds := sortedSliceCopy(cfg.AllowOriginsWithCredentials)
 	originsWithoutCreds := sortedSliceCopy(cfg.AllowOriginsWithoutCredentials)
@@ -36,6 +36,7 @@ func Options(cfg *config.CORS) cors.Options {
 		"X-Request-ID",
 	}
 	allowedHeaders = append(allowedHeaders, cfg.ExtraAllowedHeaders...)
+	allowedHeaders = append(allowedHeaders, staticHeaders...)
 
 	return cors.Options{
 		Debug:               cfg.Debug,

--- a/runtime/appruntime/cors/cors_test.go
+++ b/runtime/appruntime/cors/cors_test.go
@@ -97,6 +97,11 @@ func TestOptions(t *testing.T) {
 			},
 			goodHeaders: []string{"Authorization", "Content-Type", "Origin", "X-Forwarded-For", "X-Real-Ip", "X-Requested-With", "X-Evil-Header"},
 		},
+		{
+			name:        "static_headers",
+			cfg:         config.CORS{},
+			goodHeaders: []string{"Authorization", "Content-Type", "Origin", "X-Static-Test"},
+		},
 	}
 
 	checkOrigins := func(t *testing.T, c *cors.Cors, creds, good bool, origins []string) {
@@ -148,7 +153,7 @@ func TestOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Options(&tt.cfg)
+			got := Options(&tt.cfg, []string{"X-Static-Test"})
 			got.Debug = true
 			c := cors.New(got)
 			c.Log = log.New(os.Stdout, "cors: ", 0)


### PR DESCRIPTION
This commit automatically adds any headers used within data types used within the Encore application to be added to the list of accepted headers used by the CORS middleware within the Encore runtime.