### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cli/cmd/encore/app.go
+++ b/cli/cmd/encore/app.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -201,11 +200,11 @@ func createApp(ctx context.Context, name, template string) (err error) {
 		gray.Printf("Downloaded template %s.\n", ex.Name)
 	} else {
 		// Set up files that we need when we don't have an example
-		if err := ioutil.WriteFile(filepath.Join(name, ".gitignore"), []byte("/.encore\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(name, ".gitignore"), []byte("/.encore\n"), 0644); err != nil {
 			fatal(err)
 		}
 		encoreModData := []byte("module encore.app\n")
-		if err := ioutil.WriteFile(filepath.Join(name, "go.mod"), encoreModData, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(name, "go.mod"), encoreModData, 0644); err != nil {
 			fatal(err)
 		}
 	}
@@ -241,7 +240,7 @@ func createApp(ctx context.Context, name, template string) (err error) {
 }
 `)
 	}
-	if err := ioutil.WriteFile(filepath.Join(name, "encore.app"), encoreAppData, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(name, "encore.app"), encoreAppData, 0644); err != nil {
 		return err
 	}
 
@@ -505,7 +504,7 @@ func slurpJSON(req *http.Request, respData interface{}) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("got non-200 response: %s: %s", resp.Status, body)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(respData); err != nil {
@@ -589,7 +588,7 @@ func addEncoreRemote(root, appID string) {
 func linkApp(appID string, force bool) {
 	root, _ := determineAppRoot()
 	filePath := filepath.Join(root, "encore.app")
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		fatal(err)
 		os.Exit(1)
@@ -652,7 +651,7 @@ func linkApp(appID string, force bool) {
 	}
 
 	val.Format()
-	if err := ioutil.WriteFile(filePath, val.Pack(), 0644); err != nil {
+	if err := os.WriteFile(filePath, val.Pack(), 0644); err != nil {
 		fatal(err)
 		os.Exit(1)
 	}

--- a/cli/cmd/encore/gen.go
+++ b/cli/cmd/encore/gen.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -78,7 +77,7 @@ Supported language codes are:
 			if output == "" {
 				os.Stdout.Write(resp.Code)
 			} else {
-				if err := ioutil.WriteFile(output, resp.Code, 0755); err != nil {
+				if err := os.WriteFile(output, resp.Code, 0755); err != nil {
 					fatal(err)
 				}
 			}

--- a/cli/cmd/encore/secret.go
+++ b/cli/cmd/encore/secret.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"syscall"
 	"time"
@@ -64,7 +64,7 @@ Note that this strips trailing newlines from the secret value.`,
 			value = string(data)
 			fmt.Fprintln(os.Stderr)
 		} else {
-			data, err := ioutil.ReadAll(os.Stdin)
+			data, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				fatal(err)
 			}

--- a/cli/daemon/common.go
+++ b/cli/daemon/common.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -68,7 +67,7 @@ func (s *Server) OnError(r *run.Run, err *errlist.List) {
 // parseApp parses the app.
 func (s *Server) parseApp(appRoot, workingDir string, parseTests bool) (*parser.Result, error) {
 	modPath := filepath.Join(appRoot, "go.mod")
-	modData, err := ioutil.ReadFile(modPath)
+	modData, err := os.ReadFile(modPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -179,7 +178,7 @@ func (h *handler) apiCall(ctx context.Context, reply jsonrpc2.Replier, p *apiCal
 		log.Error().Err(err).Msg("dash: api call failed")
 		return reply(ctx, nil, err)
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
 	// Encode the body back into a Go style struct

--- a/cli/daemon/engine/runtime.go
+++ b/cli/daemon/engine/runtime.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -52,7 +52,7 @@ func (s *server) RecordTrace(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/cli/daemon/internal/manifest/manifest.go
+++ b/cli/daemon/internal/manifest/manifest.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -68,7 +67,7 @@ func ReadOrCreate(appRoot string) (mf *Manifest, err error) {
 	out, _ := json.Marshal(&man)
 	if err := os.MkdirAll(filepath.Dir(cfgPath), 0755); err != nil {
 		return nil, err
-	} else if err := ioutil.WriteFile(cfgPath, out, 0644); err != nil {
+	} else if err := os.WriteFile(cfgPath, out, 0644); err != nil {
 		return nil, err
 	}
 	return &man, nil

--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -2,7 +2,7 @@ package run
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -137,7 +137,7 @@ type parseAppParams struct {
 // parseApp parses the app and returns the parse result.
 func (mgr *Manager) parseApp(p parseAppParams) (*parser.Result, error) {
 	modPath := filepath.Join(p.App.Root(), "go.mod")
-	modData, err := ioutil.ReadFile(modPath)
+	modData, err := os.ReadFile(modPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mathrand "math/rand"
 	"net"
 	"net/http"
@@ -483,7 +482,7 @@ func (r *Run) StartProc(params *StartProcParams) (p *Proc, err error) {
 		io.ReadCloser
 		io.Writer
 	}{
-		ReadCloser: ioutil.NopCloser(respRd),
+		ReadCloser: io.NopCloser(respRd),
 		Writer:     reqWr,
 	}
 	p.Client, err = yamux.Client(rwc, yamux.DefaultConfig())

--- a/cli/daemon/sqldb/migrate.go
+++ b/cli/daemon/sqldb/migrate.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -61,7 +60,7 @@ func (src *src) ReadUp(version uint) (r io.ReadCloser, identifier string, err er
 	if err != nil {
 		return nil, "", err
 	}
-	return ioutil.NopCloser(bytes.NewReader(data)), m.Description, nil
+	return io.NopCloser(bytes.NewReader(data)), m.Description, nil
 }
 
 func (src *src) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {

--- a/cli/internal/update/update.go
+++ b/cli/internal/update/update.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -70,7 +69,7 @@ func Check(ctx context.Context) (latestVersion *LatestVersion, err error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("GET %s: responded with %s: %s", releaseAPI, resp.Status, body)
 	}
 

--- a/compiler/build.go
+++ b/compiler/build.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -185,7 +184,7 @@ func (b *builder) Build() (res *Result, err error) {
 		}
 	}()
 
-	b.workdir, err = ioutil.TempDir("", "encore-build")
+	b.workdir, err = os.MkdirTemp("", "encore-build")
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +253,7 @@ func (b *builder) endCodeGenTracker() error {
 func (b *builder) parseApp() error {
 	defer b.trace("parse app")()
 	modPath := filepath.Join(b.appRoot, "go.mod")
-	modData, err := ioutil.ReadFile(modPath)
+	modData, err := os.ReadFile(modPath)
 	if err != nil {
 		return err
 	}
@@ -362,16 +361,16 @@ func (b *builder) writeModFile() error {
 
 	modBytes := modfile.Format(b.modfile.Syntax)
 	dstGomod := filepath.Join(b.workdir, "go.mod")
-	return ioutil.WriteFile(dstGomod, modBytes, 0644)
+	return os.WriteFile(dstGomod, modBytes, 0644)
 }
 
 func (b *builder) writeSumFile() error {
 	defer b.trace("write sum file")()
-	appSum, err := ioutil.ReadFile(filepath.Join(b.appRoot, "go.sum"))
+	appSum, err := os.ReadFile(filepath.Join(b.appRoot, "go.sum"))
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	runtimeSum, err := ioutil.ReadFile(filepath.Join(b.cfg.EncoreRuntimePath, "go.sum"))
+	runtimeSum, err := os.ReadFile(filepath.Join(b.cfg.EncoreRuntimePath, "go.sum"))
 	if err != nil {
 		return err
 	}
@@ -380,7 +379,7 @@ func (b *builder) writeSumFile() error {
 	}
 	data := append(appSum, runtimeSum...)
 	dstGosum := filepath.Join(b.workdir, "go.sum")
-	return ioutil.WriteFile(dstGosum, data, 0644)
+	return os.WriteFile(dstGosum, data, 0644)
 }
 
 func (b *builder) writePackages() error {
@@ -415,7 +414,7 @@ func (b *builder) buildMain() error {
 
 	overlayData, _ := json.Marshal(map[string]interface{}{"Replace": b.overlay})
 	overlayPath := filepath.Join(b.workdir, "overlay.json")
-	if err := ioutil.WriteFile(overlayPath, overlayData, 0644); err != nil {
+	if err := os.WriteFile(overlayPath, overlayData, 0644); err != nil {
 		return err
 	}
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -1,7 +1,6 @@
 package compiler_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ func TestCompile(t *testing.T) {
 			e.Setenv("HOME", home)
 			e.Setenv("GOFLAGS", "-modcacherw")
 			gomod := []byte("module test\n\nrequire encore.dev v0.17.0")
-			return ioutil.WriteFile(filepath.Join(e.WorkDir, "go.mod"), gomod, 0755)
+			return os.WriteFile(filepath.Join(e.WorkDir, "go.mod"), gomod, 0755)
 		},
 	})
 }

--- a/compiler/exec_script.go
+++ b/compiler/exec_script.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,7 +60,7 @@ func (b *builder) ExecScript() (res *Result, err error) {
 		}
 	}()
 
-	b.workdir, err = ioutil.TempDir("", "encore-exec")
+	b.workdir, err = os.MkdirTemp("", "encore-exec")
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +168,7 @@ FileLoop:
 
 	name := filepath.Base(mainFile.Path)
 	dst := filepath.Join(dir, name)
-	if err := ioutil.WriteFile(dst, mainFile.Contents, 0644); err != nil {
+	if err := os.WriteFile(dst, mainFile.Contents, 0644); err != nil {
 		return err
 	}
 	b.addOverlay(mainFile.Path, dst)
@@ -183,7 +182,7 @@ func (b *builder) buildExecScript() error {
 
 	overlayData, _ := json.Marshal(map[string]interface{}{"Replace": b.overlay})
 	overlayPath := filepath.Join(b.workdir, "overlay.json")
-	if err := ioutil.WriteFile(overlayPath, overlayData, 0644); err != nil {
+	if err := os.WriteFile(overlayPath, overlayData, 0644); err != nil {
 		return err
 	}
 

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -241,7 +241,6 @@ import (
 	"fmt"
 	jsoniter "github.com/json-iterator/go"
 	"io"
-	"io/ioutil"
 	"strconv"
 )
 
@@ -282,7 +281,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -241,7 +241,6 @@ import (
 	"fmt"
 	jsoniter "github.com/json-iterator/go"
 	"io"
-	"io/ioutil"
 	"strconv"
 )
 
@@ -282,7 +281,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -237,7 +237,6 @@ import (
 	"fmt"
 	jsoniter "github.com/json-iterator/go"
 	"io"
-	"io/ioutil"
 )
 
 // Marshaller is used to serialize request data into strings and deserialize response data from strings
@@ -267,7 +266,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -1612,7 +1612,6 @@ import (
 	"fmt"
 	jsoniter "github.com/json-iterator/go"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"time"
 )
@@ -1762,7 +1761,7 @@ func (e *Marshaller) setErr(msg, field string, err error) {
 }
 
 func (d *Marshaller) Body(body io.Reader) (payload []byte) {
-	payload, err := ioutil.ReadAll(body)
+	payload, err := io.ReadAll(body)
 	if err == nil && len(payload) == 0 {
 		d.setErr("missing request body", "request_body", fmt.Errorf("missing request body"))
 	} else if err != nil {

--- a/compiler/rewrite.go
+++ b/compiler/rewrite.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"go/ast"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -140,7 +140,7 @@ func (b *builder) rewritePkg(pkg *est.Package, targetDir string) error {
 		// Write out the file
 		name := filepath.Base(file.Path)
 		dst := filepath.Join(targetDir, name)
-		if err := ioutil.WriteFile(dst, rw.Data(), 0644); err != nil {
+		if err := os.WriteFile(dst, rw.Data(), 0644); err != nil {
 			return err
 		}
 		b.addOverlay(file.Path, dst)

--- a/compiler/test.go
+++ b/compiler/test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func (b *builder) Test(ctx context.Context) (err error) {
 		}
 	}()
 
-	b.workdir, err = ioutil.TempDir("", "encore-test")
+	b.workdir, err = os.MkdirTemp("", "encore-test")
 	if err != nil {
 		return err
 	}
@@ -124,7 +123,7 @@ func (b *builder) runTests(ctx context.Context) error {
 	defer b.trace("run tests")()
 	overlayData, _ := json.Marshal(map[string]interface{}{"Replace": b.overlay})
 	overlayPath := filepath.Join(b.workdir, "overlay.json")
-	if err := ioutil.WriteFile(overlayPath, overlayData, 0644); err != nil {
+	if err := os.WriteFile(overlayPath, overlayData, 0644); err != nil {
 		return err
 	}
 

--- a/e2e-tests/testdata/echo/test/endpoints.go
+++ b/e2e-tests/testdata/echo/test/endpoints.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -162,7 +162,7 @@ type response struct {
 func RawEndpoint(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 
-	bytes, err := ioutil.ReadAll(req.Body)
+	bytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e-tests/testdata/echo_client/client/client.go
+++ b/e2e-tests/testdata/echo_client/client/client.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -1209,7 +1208,7 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, heade
 	}()
 	if rawResponse.StatusCode >= 400 {
 		// Read the full body sent back
-		body, err := ioutil.ReadAll(rawResponse.Body)
+		body, err := io.ReadAll(rawResponse.Body)
 		if err != nil {
 			return nil, &APIError{
 				Code:    ErrUnknown,

--- a/internal/clientgen/client_test.go
+++ b/internal/clientgen/client_test.go
@@ -4,7 +4,7 @@
 package clientgen
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -46,7 +46,7 @@ func TestClientCodeGeneration(t *testing.T) {
 			})
 			c.Assert(err, qt.IsNil)
 
-			files, err := ioutil.ReadDir("./testdata")
+			files, err := os.ReadDir("./testdata")
 			c.Assert(err, qt.IsNil)
 
 			expectedPrefix := "expected" + strings.TrimPrefix(strings.TrimSuffix(filepath.Base(path), ".go"), "input") + "_"

--- a/internal/clientgen/golang.go
+++ b/internal/clientgen/golang.go
@@ -1112,7 +1112,7 @@ func (g *golang) generateBaseClient(file *File) (err error) {
 			).Call(),
 			If(Id("rawResponse").Dot("StatusCode").Op(">=").Lit(400)).Block(
 				Comment("Read the full body sent back"),
-				List(Id("body"), Err()).Op(":=").Qual("io/ioutil", "ReadAll").Call(Id("rawResponse").Dot("Body")),
+				List(Id("body"), Err()).Op(":=").Qual("io", "ReadAll").Call(Id("rawResponse").Dot("Body")),
 				If(Err().Op("!=").Nil()).Block(
 					Return(
 						Nil(),

--- a/internal/clientgen/testdata/expected_golang.go
+++ b/internal/clientgen/testdata/expected_golang.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -517,7 +516,7 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, heade
 	}()
 	if rawResponse.StatusCode >= 400 {
 		// Read the full body sent back
-		body, err := ioutil.ReadAll(rawResponse.Body)
+		body, err := io.ReadAll(rawResponse.Body)
 		if err != nil {
 			return nil, &APIError{
 				Code:    ErrUnknown,

--- a/internal/clientgen/testdata/expected_noauth_golang.go
+++ b/internal/clientgen/testdata/expected_noauth_golang.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -152,7 +151,7 @@ func callAPI(ctx context.Context, client *baseClient, method, path string, heade
 	}()
 	if rawResponse.StatusCode >= 400 {
 		// Read the full body sent back
-		body, err := ioutil.ReadAll(rawResponse.Body)
+		body, err := io.ReadAll(rawResponse.Body)
 		if err != nil {
 			return nil, &APIError{
 				Code:    ErrUnknown,

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -81,7 +80,7 @@ func Write(cfg *Config) (err error) {
 		return err
 	} else if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
-	} else if err := ioutil.WriteFile(path, data, 0600); err != nil {
+	} else if err := os.WriteFile(path, data, 0600); err != nil {
 		return err
 	}
 	return nil
@@ -132,7 +131,7 @@ func OriginalUser(configDir string) (cfg *Config, err error) {
 
 func readConf(configDir string) (*Config, error) {
 	path := filepath.Join(configDir, ".auth_token")
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gocodegen/marshalling.go
+++ b/internal/gocodegen/marshalling.go
@@ -151,7 +151,7 @@ func (g *MarshallingCodeGenerator) WriteToFile(f *File) {
 
 	if g.usedBody {
 		f.Func().Params(Id("d").Op("*").Id(g.structName)).Id("Body").Params(Id("body").Qual("io", "Reader")).Params(Id("payload").Index().Byte()).Block(
-			List(Id("payload"), Err()).Op(":=").Qual("io/ioutil", "ReadAll").Call(Id("body")),
+			List(Id("payload"), Err()).Op(":=").Qual("io", "ReadAll").Call(Id("body")),
 			If(Err().Op("==").Nil().Op("&&").Len(Id("payload")).Op("==").Lit(0)).Block(
 				Id("d").Dot("setErr").Call(Lit("missing request body"), Lit("request_body"), Qual("fmt", "Errorf").Call(Lit("missing request body"))),
 			).Else().If(Err().Op("!=").Nil()).Block(

--- a/parser/dirs.go
+++ b/parser/dirs.go
@@ -8,7 +8,6 @@ import (
 	"go/scanner"
 	"go/token"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -81,7 +80,7 @@ func parseDir(buildContext build.Context, fset *token.FileSet, dir string, list 
 	for _, d := range list {
 		if strings.HasSuffix(d.Name(), ".go") && (filter == nil || filter(d)) {
 			filename := filepath.Join(dir, d.Name())
-			contents, err := ioutil.ReadFile(filename)
+			contents, err := os.ReadFile(filename)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/parser/meta.go
+++ b/parser/meta.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -291,7 +290,7 @@ func parseMigrations(appRoot, relPath string) ([]*meta.DBMigration, error) {
 		return nil, fmt.Errorf("%s is not a directory", relPath)
 	}
 
-	files, err := ioutil.ReadDir(absPath)
+	files, err := os.ReadDir(absPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read migrations: %v", err)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -6,7 +6,6 @@ import (
 	goparser "go/parser"
 	"go/scanner"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,7 +106,7 @@ func TestCompile(t *testing.T) {
 			e.Values["wd"] = e.WorkDir
 			e.Values["output"] = &bytes.Buffer{}
 			e.Values["errs"] = &bytes.Buffer{}
-			return ioutil.WriteFile(filepath.Join(e.WorkDir, "go.mod"), gomod, 0755)
+			return os.WriteFile(filepath.Join(e.WorkDir, "go.mod"), gomod, 0755)
 		},
 		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
 			"parse": func(ts *testscript.TestScript, neg bool, args []string) {
@@ -120,7 +119,7 @@ func TestCompile(t *testing.T) {
 
 				wd := ts.Value("wd").(string)
 				modPath := filepath.Join(wd, "go.mod")
-				modData, err := ioutil.ReadFile(modPath)
+				modData, err := os.ReadFile(modPath)
 				if err != nil {
 					ts.Fatalf("cannot read go.mod: %v", err)
 				}

--- a/pkg/cueutil/build.go
+++ b/pkg/cueutil/build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -212,13 +211,13 @@ func reader(f *build.File) (io.ReadCloser, error) {
 	case nil:
 		// Use the file name.
 	case string:
-		return ioutil.NopCloser(strings.NewReader(s)), nil
+		return io.NopCloser(strings.NewReader(s)), nil
 	case []byte:
-		return ioutil.NopCloser(bytes.NewReader(s)), nil
+		return io.NopCloser(bytes.NewReader(s)), nil
 	case *bytes.Buffer:
 		// is io.Reader, but it needs to be readable repeatedly
 		if s != nil {
-			return ioutil.NopCloser(bytes.NewReader(s.Bytes())), nil
+			return io.NopCloser(bytes.NewReader(s.Bytes())), nil
 		}
 	default:
 		return nil, fmt.Errorf("invalid source type %T", f.Source)

--- a/runtime/types/uuid/codec_test.go
+++ b/runtime/types/uuid/codec_test.go
@@ -25,7 +25,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -286,7 +285,7 @@ func TestSeedFuzzCorpus(t *testing.T) {
 	corpusDir := filepath.Join(".", "testdata", "corpus")
 	writeSeedFile := func(name, data string) error {
 		path := filepath.Join(corpusDir, name)
-		return ioutil.WriteFile(path, []byte(data), os.ModePerm)
+		return os.WriteFile(path, []byte(data), os.ModePerm)
 	}
 	for _, fst := range fromStringTests {
 		name := "seed_valid_" + fst.variant

--- a/tools/publicapigen/main.go
+++ b/tools/publicapigen/main.go
@@ -7,7 +7,6 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -203,7 +202,7 @@ func registerTypesToDrop(fAST *ast.File) {
 }
 
 // readAST parses the AST of all non-test Go files in a directory and stores it in the files map
-func readAST(path, rel string, file []os.FileInfo) error {
+func readAST(path, rel string, file []os.DirEntry) error {
 	for _, f := range file {
 		if !strings.HasSuffix(f.Name(), ".go") {
 			// ignore non-go files
@@ -554,20 +553,20 @@ func writePendingComments(originalFile *ast.File, formattedFile *ast.File) {
 }
 
 // walkDir recursively descends path, calling walkFn for directory
-func walkDir(dir, rel string, f func(path, rel string, files []os.FileInfo) error) error {
+func walkDir(dir, rel string, f func(path, rel string, files []os.DirEntry) error) error {
 	if rel == "types/uuid" {
 		// we don't want to rewrite this package
 		return nil
 	}
 
 	log.Debug().Str("rel", rel).Msg("walking directory")
-	entries, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
 
 	// Split the files and dirs
-	var dirs, files []os.FileInfo
+	var dirs, files []os.DirEntry
 	for _, entry := range entries {
 		if entry.IsDir() {
 			dirs = append(dirs, entry)


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (`os.ReadDir` returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo` and it is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir