### PR TITLE
Implement Encore Cloud metrics exporter

### DIFF
--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -279,14 +279,18 @@ type RedisDatabase struct {
 }
 
 type Metrics struct {
-	CollectionInterval time.Duration                  `json:"collection_interval,omitempty"`
+	CollectionInterval time.Duration `json:"collection_interval,omitempty"`
+	EncoreCloud        *EncoreCloudProvider
 	CloudMonitoring    *GCPCloudMonitoringProvider    `json:"gcp_cloud_monitoring,omitempty"`
 	CloudWatch         *AWSCloudWatchMetricsProvider  `json:"aws_cloud_watch,omitempty"`
 	LogsBased          *LogsBasedMetricsProvider      `json:"logs_based,omitempty"`
 	Prometheus         *PrometheusRemoteWriteProvider `json:"prometheus,omitempty"`
 }
 
-type LogsBasedMetricsProvider struct{}
+type EncoreCloudProvider struct {
+	GCPCloudMonitoringProvider
+	MetricNames map[string]string
+}
 
 type GCPCloudMonitoringProvider struct {
 	// ProjectID is the GCP project id to send metrics to.
@@ -310,3 +314,5 @@ type PrometheusRemoteWriteProvider struct {
 	// The URL of the endpoint to send samples to.
 	RemoteWriteURL string
 }
+
+type LogsBasedMetricsProvider struct{}

--- a/runtime/appruntime/metrics/encore_cloud_exporter.go
+++ b/runtime/appruntime/metrics/encore_cloud_exporter.go
@@ -9,13 +9,13 @@ import (
 
 func init() {
 	registerProvider(providerDesc{
-		name: "gcp_cloud_monitoring",
+		name: "encore_cloud",
 		matches: func(cfg *config.Metrics) bool {
-			return cfg.CloudMonitoring != nil
+			return cfg.EncoreCloud != nil
 		},
 		newExporter: func(mgr *Manager) exporter {
 			metricsCfg := mgr.cfg.Runtime.Metrics
-			return gcp.New(mgr.cfg.Static.BundledServices, metricsCfg.CloudMonitoring, mgr.rootLogger)
+			return gcp.NewEncoreCloudExporter(mgr.cfg.Static.BundledServices, metricsCfg.CloudMonitoring, mgr.rootLogger, metricsCfg.EncoreCloud.MetricNames)
 		},
 	})
 }

--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -121,6 +121,7 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 		svcNum := m.Info.SvcNum()
 		encoreCloudMetricName, ok := x.encoreCloudMetricNames[m.Info.Name()]
 		if !ok {
+			x.rootLogger.Error().Msgf("encore: internal error: metric %s not found in config", m.Info.Name())
 			continue
 		}
 		metricType := "custom.googleapis.com/" + encoreCloudMetricName

--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -119,12 +119,15 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 		}
 
 		svcNum := m.Info.SvcNum()
-		encoreCloudMetricName, ok := x.encoreCloudMetricNames[m.Info.Name()]
-		if !ok {
-			x.rootLogger.Error().Msgf("encore: internal error: metric %s not found in config", m.Info.Name())
-			continue
+		metricType := "custom.googleapis.com/" + m.Info.Name()
+		if x.exportsToEncoreCloud {
+			encoreCloudMetricName, ok := x.encoreCloudMetricNames[m.Info.Name()]
+			if !ok {
+				x.rootLogger.Error().Msgf("encore: internal error: metric %s not found in config", m.Info.Name())
+				continue
+			}
+			metricType = "custom.googleapis.com/" + encoreCloudMetricName
 		}
-		metricType := "custom.googleapis.com/" + encoreCloudMetricName
 
 		doAdd := func(val *monitoringpb.TypedValue, svcIdx uint16) {
 			labels := make(map[string]string, len(baseLabels)+1)

--- a/runtime/appruntime/metrics/gcp_cloud_monitoring_exporter.go
+++ b/runtime/appruntime/metrics/gcp_cloud_monitoring_exporter.go
@@ -11,10 +11,14 @@ func init() {
 	registerProvider(providerDesc{
 		name: "gcp_cloud_monitoring",
 		matches: func(cfg *config.Metrics) bool {
-			return cfg.CloudMonitoring != nil
+			return cfg.CloudMonitoring != nil || cfg.EncoreCloud != nil
 		},
 		newExporter: func(mgr *Manager) exporter {
-			return gcp.New(mgr.cfg.Static.BundledServices, mgr.cfg.Runtime.Metrics.CloudMonitoring, mgr.rootLogger)
+			metricsCfg := mgr.cfg.Runtime.Metrics
+			if metricsCfg.EncoreCloud != nil {
+				return gcp.NewEncoreCloudExporter(mgr.cfg.Static.BundledServices, metricsCfg.CloudMonitoring, mgr.rootLogger, metricsCfg.EncoreCloud.MetricNames)
+			}
+			return gcp.New(mgr.cfg.Static.BundledServices, metricsCfg.CloudMonitoring, mgr.rootLogger)
 		},
 	})
 }


### PR DESCRIPTION
The platform prefixes an Encore app metrics with their resource ID. To be able to export metrics to Encore Cloud, the runtime needs to know what the metric names in Encore Cloud are: these are injected into the runtime config by the platform, so that the runtime can use them to export metrics to Encore Cloud.