### PR TITLE
storage/sqldb: add sqldb.Error

### DIFF
--- a/runtime/storage/sqldb/errors.go
+++ b/runtime/storage/sqldb/errors.go
@@ -1,0 +1,116 @@
+package sqldb
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+
+	"encore.dev/beta/errs"
+	"encore.dev/storage/sqldb/sqlerr"
+)
+
+// ErrCode reports the error code for a given error.
+// If the error is nil or is not of type *Error it reports sqlerr.Other.
+func ErrCode(err error) sqlerr.Code {
+	var pgerr *Error
+	if errors.As(err, &pgerr) {
+		return pgerr.Code
+	}
+	return sqlerr.Other
+}
+
+// Error represents an error reported by the database server.
+// It's not guaranteed all errors reported by sqldb functions will be of this type;
+// it is only returned when the database reports an error.
+//
+// Note that the fields for schema name, table name, column name, data type name,
+// and constraint name are supplied only for a limited number of error types;
+// see https://www.postgresql.org/docs/current/errcodes-appendix.html.
+//
+// You should not assume that the presence of any of these fields guarantees
+// the presence of another field.
+type Error struct {
+	// Code defines the general class of the error.
+	// See [sqlerr.Code] for a list of possible values.
+	Code sqlerr.Code
+
+	// Severity is the severity of the error.
+	Severity sqlerr.Severity
+
+	// DatabaseCode is the database server-specific error code.
+	// It is specific to the underlying database server.
+	DatabaseCode string
+
+	// Message: the primary human-readable error message. This should be accurate
+	// but terse (typically one line). Always present.
+	Message string
+
+	// SchemaName: if the error was associated with a specific database object,
+	// the name of the schema containing that object, if any.
+	SchemaName string
+
+	// TableName: if the error was associated with a specific table, the name of the table.
+	// (Refer to the schema name field for the name of the table's schema.)
+	TableName string
+
+	// ColumnName: if the error was associated with a specific table column,
+	// the name of the column. (Refer to the schema and table name fields to identify the table.)
+	ColumnName string
+
+	// Data type name: if the error was associated with a specific data type,
+	// the name of the data type. (Refer to the schema name field for the name of the data type's schema.)
+	DataTypeName string
+
+	// Constraint name: if the error was associated with a specific constraint,
+	// the name of the constraint. Refer to fields listed above for the associated
+	// table or domain. (For this purpose, indexes are treated as constraints,
+	// even if they weren't created with constraint syntax.)
+	ConstraintName string
+
+	// driverErr is the underlying error from the driver.
+	// It's used to support errors.As and errors.Is to preserve
+	// backwards compatibility.
+	driverErr error
+}
+
+func (pe *Error) Error() string {
+	return string(pe.Severity) + ": " + pe.Message + " (Code " + string(pe.Code) + ": SQLSTATE " + pe.DatabaseCode + ")"
+}
+
+func (pe *Error) Unwrap() error {
+	return pe.driverErr
+}
+
+func convertErr(err error) error {
+	var pgerr *pgconn.PgError
+	if errors.As(err, &pgerr) {
+		err = convertPgError(pgerr)
+	}
+
+	switch err {
+	case pgx.ErrNoRows, sql.ErrNoRows:
+		err = errs.WrapCode(sql.ErrNoRows, errs.NotFound, "")
+	case pgx.ErrTxClosed, pgx.ErrInvalidLogLevel, pgx.ErrTxCommitRollback, sql.ErrTxDone, sql.ErrConnDone:
+		err = errs.WrapCode(err, errs.Internal, "")
+	default:
+		err = errs.WrapCode(err, errs.Unavailable, "")
+	}
+	return errs.DropStackFrame(err)
+}
+
+func convertPgError(src *pgconn.PgError) error {
+	return &Error{
+		Code:           sqlerr.MapCode(src.Code),
+		Severity:       sqlerr.MapSeverity(src.Severity),
+		DatabaseCode:   src.Code,
+		Message:        src.Message,
+		SchemaName:     src.SchemaName,
+		TableName:      src.TableName,
+		ColumnName:     src.ColumnName,
+		DataTypeName:   src.DataTypeName,
+		ConstraintName: src.ConstraintName,
+		driverErr:      src,
+	}
+}

--- a/runtime/storage/sqldb/errors_test.go
+++ b/runtime/storage/sqldb/errors_test.go
@@ -1,0 +1,28 @@
+package sqldb
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"encore.dev/storage/sqldb/sqlerr"
+)
+
+func TestErrCode(t *testing.T) {
+	tests := []struct {
+		err  error
+		want sqlerr.Code
+	}{
+		{err: nil, want: sqlerr.Other},
+		{err: io.EOF, want: sqlerr.Other},
+		{err: errors.New("some error"), want: sqlerr.Other},
+		{err: &Error{Code: sqlerr.UniqueViolation}, want: sqlerr.UniqueViolation},
+		{err: fmt.Errorf("wrapped: %w", &Error{Code: sqlerr.UniqueViolation}), want: sqlerr.UniqueViolation},
+	}
+	for _, tt := range tests {
+		if got := ErrCode(tt.err); got != tt.want {
+			t.Errorf("ErrCode(%v) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}

--- a/runtime/storage/sqldb/sqldb.go
+++ b/runtime/storage/sqldb/sqldb.go
@@ -237,18 +237,6 @@ func (r *Row) Err() error {
 	return convertErr(r.rows.Err())
 }
 
-func convertErr(err error) error {
-	switch err {
-	case pgx.ErrNoRows, sql.ErrNoRows:
-		err = errs.WrapCode(sql.ErrNoRows, errs.NotFound, "")
-	case pgx.ErrTxClosed, pgx.ErrInvalidLogLevel, pgx.ErrTxCommitRollback, sql.ErrTxDone, sql.ErrConnDone:
-		err = errs.WrapCode(err, errs.Internal, "")
-	default:
-		err = errs.WrapCode(err, errs.Unavailable, "")
-	}
-	return errs.DropStackFrame(err)
-}
-
 type interceptor struct {
 	mgr *Manager
 }

--- a/runtime/storage/sqldb/sqlerr/sqlerr.go
+++ b/runtime/storage/sqldb/sqlerr/sqlerr.go
@@ -1,0 +1,120 @@
+// Package sqlerr provides a set of common error codes for SQL datbaases.
+//
+// Not all error codes are supported by all databases, and multiple
+// underlying database errors may map to the same error code if the
+// meaning overlaps.
+//
+// In future releases additional error codes may be added to this
+// package, and the mapping of underlying database errors to these
+// error codes may change.
+package sqlerr
+
+// Code describes a specific type of database error.
+// The value Other is reported when an error does not map to any of the defined codes.
+//
+// Not all error codes are supported by all databases, and multiple
+// underlying database errors may map to the same error code if the
+// meaning overlaps.
+type Code string
+
+const (
+	// Other is reported when an error does not map to any of the defined codes.
+	// Consult the underlying database error for more information.
+	Other Code = "other"
+
+	// NotNullViolation is reported when a not null constraint would be violated.
+	NotNullViolation Code = "not_null_violation"
+
+	// ForeignKeyViolation is reported when a foreign key constraint would be violated.
+	ForeignKeyViolation Code = "foreign_key_violation"
+
+	// UniqueViolation is reported when a unique constraint would be violated.
+	UniqueViolation Code = "unique_violation"
+
+	// CheckViolation is reported when a check constraint would be violated.
+	CheckViolation Code = "check_violation"
+
+	// ExcludeViolation is reported when an exclusion constraint would be violated.
+	ExcludeViolation Code = "exclude_violation"
+
+	// TransactionFailed is reported when running a command in a failed transaction,
+	// due to some previous command failure.
+	TransactionFailed Code = "transaction_failed"
+
+	// DeadlockDetected is reported when a deadlock is detected.
+	// Deadlock detection is done on a best-effort basis and not all deadlocks
+	// can be detected.
+	DeadlockDetected Code = "deadlock_detected"
+
+	// TooManyConnections is reported when the database rejects a connection request
+	// due to reaching the maximum number of connections.
+	// This is different from blocking waiting on a connection pool.
+	TooManyConnections Code = "too_many_connections"
+)
+
+// MapCode maps an underlying database error to an Code.
+//
+//publicapigen:drop
+func MapCode(code string) Code {
+	switch code {
+	case "23502":
+		return NotNullViolation
+	case "23503":
+		return ForeignKeyViolation
+	case "23505":
+		return UniqueViolation
+	case "23514":
+		return CheckViolation
+	case "23P01":
+		return ExcludeViolation
+	case "25P02":
+		return TransactionFailed
+	case "40P01":
+		return DeadlockDetected
+	case "53300":
+		return TooManyConnections
+	default:
+		return Other
+	}
+}
+
+// Severity defines the severity of a database error.
+type Severity string
+
+const (
+	SeverityError   Severity = "ERROR"
+	SeverityFatal   Severity = "FATAL"
+	SeverityPanic   Severity = "PANIC"
+	SeverityWarning Severity = "WARNING"
+	SeverityNotice  Severity = "NOTICE"
+	SeverityDebug   Severity = "DEBUG"
+	SeverityInfo    Severity = "INFO"
+	SeverityLog     Severity = "LOG"
+)
+
+// MapSeverity maps the severity string from the underlying database
+// to a Severity.
+//
+//publicapigen:drop
+func MapSeverity(severity string) Severity {
+	switch severity {
+	case "ERROR":
+		return SeverityError
+	case "FATAL":
+		return SeverityFatal
+	case "PANIC":
+		return SeverityPanic
+	case "WARNING":
+		return SeverityWarning
+	case "NOTICE":
+		return SeverityNotice
+	case "DEBUG":
+		return SeverityDebug
+	case "INFO":
+		return SeverityInfo
+	case "LOG":
+		return SeverityLog
+	default:
+		return SeverityError
+	}
+}


### PR DESCRIPTION
This adds a `*sqldb.Error` type which exposes information about the underlying database error. It also adds the new `encore.dev/storage/sqldb/sqlerr` package with common error codes that can be tested against in a database-agnostic way.

The error also contains the `DatabaseCode` field that provides a non-portable way of getting the precise error from the underlying database server.