### PR TITLE
pkg/pgproxy: fix ssl negotiation

### DIFF
--- a/pkg/pgproxy/pgproxy.go
+++ b/pkg/pgproxy/pgproxy.go
@@ -373,6 +373,8 @@ func clientTLSNegotiate(client net.Conn, tlsConfig *tls.Config) (*pgproto3.Backe
 	log.Trace().Msg("negotiating TLS with client")
 	backend := pgproto3.NewBackend(pgproto3.NewChunkReader(client), client)
 	hasTLS := false
+
+StartupMessageLoop:
 	for {
 		startup, err := backend.ReceiveStartupMessage()
 		if err != nil {
@@ -387,6 +389,7 @@ func clientTLSNegotiate(client net.Conn, tlsConfig *tls.Config) (*pgproto3.Backe
 				if _, err := client.Write([]byte{'N'}); err != nil {
 					return nil, nil, err
 				}
+				continue StartupMessageLoop
 			}
 
 			if _, err := client.Write([]byte{'S'}); err != nil {


### PR DESCRIPTION
If the client requested SSL but the server does not support
SSL we reject the SSL request. However, instead of reading
a new startup message we would incorrectly proceed to
actually doing the SSL handshake.

Thanks Cilla for the report.