### PR TITLE
rlog: trace log fields from `With`

### DIFF
--- a/runtime/rlog/pkgfn.go
+++ b/runtime/rlog/pkgfn.go
@@ -7,30 +7,30 @@ var Singleton *Manager
 
 // Debug logs a debug-level message.
 // The variadic key-value pairs are treated as they are in With.
-func Debug(msg string, keysAndValues ...interface{}) {
+func Debug(msg string, keysAndValues ...any) {
 	Singleton.Debug(msg, keysAndValues...)
 }
 
 // Info logs an info-level message.
 // The variadic key-value pairs are treated as they are in With.
-func Info(msg string, keysAndValues ...interface{}) {
+func Info(msg string, keysAndValues ...any) {
 	Singleton.Info(msg, keysAndValues...)
 }
 
 // Warn logs a warn-level message.
 // The variadic key-value pairs are treated as they are in With.
-func Warn(msg string, keysAndValues ...interface{}) {
+func Warn(msg string, keysAndValues ...any) {
 	Singleton.Warn(msg, keysAndValues...)
 }
 
 // Error logs an error-level message.
 // The variadic key-value pairs are treated as they are in With.
-func Error(msg string, keysAndValues ...interface{}) {
+func Error(msg string, keysAndValues ...any) {
 	Singleton.Error(msg, keysAndValues...)
 }
 
 // With adds a variadic number of fields to the logging context.
 // The keysAndValues must be pairs of string keys and arbitrary data.
-func With(keysAndValues ...interface{}) Ctx {
+func With(keysAndValues ...any) Ctx {
 	return Singleton.With(keysAndValues...)
 }

--- a/runtime/rlog/rlog.go
+++ b/runtime/rlog/rlog.go
@@ -48,104 +48,126 @@ func NewManager(rt *reqtrack.RequestTracker) *Manager {
 // Ctx holds additional logging context for use with the Infoc and family
 // of logging functions.
 type Ctx struct {
-	ctx zerolog.Context
-	mgr *Manager
+	ctx    zerolog.Context
+	mgr    *Manager
+	fields []any
 }
 
-func (l *Manager) Debug(msg string, keysAndValues ...interface{}) {
-	l.doLog(levelDebug, l.rt.Logger().Debug(), msg, keysAndValues...)
+func (l *Manager) Debug(msg string, keysAndValues ...any) {
+	fields := pairs(keysAndValues)
+	l.doLog(levelDebug, l.rt.Logger().Debug(), msg, nil, fields)
 }
 
-func (l *Manager) Info(msg string, keysAndValues ...interface{}) {
-	l.doLog(levelInfo, l.rt.Logger().Info(), msg, keysAndValues...)
+func (l *Manager) Info(msg string, keysAndValues ...any) {
+	fields := pairs(keysAndValues)
+	l.doLog(levelInfo, l.rt.Logger().Info(), msg, nil, fields)
 }
 
-func (l *Manager) Warn(msg string, keysAndValues ...interface{}) {
-	l.doLog(levelWarn, l.rt.Logger().Warn(), msg, keysAndValues...)
+func (l *Manager) Warn(msg string, keysAndValues ...any) {
+	fields := pairs(keysAndValues)
+	l.doLog(levelWarn, l.rt.Logger().Warn(), msg, nil, fields)
 }
 
-func (l *Manager) Error(msg string, keysAndValues ...interface{}) {
-	l.doLog(levelError, l.rt.Logger().Error(), msg, keysAndValues...)
+func (l *Manager) Error(msg string, keysAndValues ...any) {
+	fields := pairs(keysAndValues)
+	l.doLog(levelError, l.rt.Logger().Error(), msg, nil, fields)
 }
 
-func (l *Manager) With(keysAndValues ...interface{}) Ctx {
+func (l *Manager) With(keysAndValues ...any) Ctx {
 	ctx := l.rt.Logger().With()
-	for i := 0; i < len(keysAndValues); i += 2 {
-		key := keysAndValues[i].(string)
-		val := keysAndValues[i+1]
+	fields := pairs(keysAndValues)
+	for i := 0; i < len(fields); i += 2 {
+		key := fields[i].(string)
+		val := fields[i+1]
 		ctx = addContext(ctx, key, val)
 	}
-	return Ctx{ctx: ctx, mgr: l}
+	return Ctx{ctx: ctx, mgr: l, fields: fields}
 }
 
 // Debug logs a debug-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Debug(msg string, keysAndValues ...interface{}) {
+func (ctx Ctx) Debug(msg string, keysAndValues ...any) {
 	l := ctx.ctx.Logger()
-	ctx.mgr.doLog(levelDebug, l.Debug(), msg, keysAndValues...)
+	fields := pairs(keysAndValues)
+	ctx.mgr.doLog(levelDebug, l.Debug(), msg, ctx.fields, fields)
 }
 
 // Info logs an info-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Info(msg string, keysAndValues ...interface{}) {
+func (ctx Ctx) Info(msg string, keysAndValues ...any) {
 	l := ctx.ctx.Logger()
-	ctx.mgr.doLog(levelInfo, l.Info(), msg, keysAndValues...)
+	fields := pairs(keysAndValues)
+	ctx.mgr.doLog(levelInfo, l.Info(), msg, ctx.fields, fields)
 }
 
 // Warn logs a warn-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Warn(msg string, keysAndValues ...interface{}) {
+func (ctx Ctx) Warn(msg string, keysAndValues ...any) {
 	l := ctx.ctx.Logger()
-	ctx.mgr.doLog(levelWarn, l.Warn(), msg, keysAndValues...)
+	fields := pairs(keysAndValues)
+	ctx.mgr.doLog(levelWarn, l.Warn(), msg, ctx.fields, fields)
 }
 
 // Error logs an error-level message, merging the context from ctx
 // with the additional context provided as key-value pairs.
 // The variadic key-value pairs are treated as they are in With.
-func (ctx Ctx) Error(msg string, keysAndValues ...interface{}) {
+func (ctx Ctx) Error(msg string, keysAndValues ...any) {
 	l := ctx.ctx.Logger()
-	ctx.mgr.doLog(levelError, l.Error(), msg, keysAndValues...)
+	fields := pairs(keysAndValues)
+	ctx.mgr.doLog(levelError, l.Error(), msg, ctx.fields, fields)
 }
 
 // With creates a new logging context that inherits the context
 // from the original ctx and adds additional context on top.
 // The original ctx is not affected.
-func (ctx Ctx) With(keysAndValues ...interface{}) Ctx {
+func (ctx Ctx) With(keysAndValues ...any) Ctx {
 	c := ctx.ctx
-	for i := 0; i < len(keysAndValues); i += 2 {
-		key := keysAndValues[i].(string)
-		val := keysAndValues[i+1]
+	fields := pairs(keysAndValues)
+	for i := 0; i < len(fields); i += 2 {
+		key := fields[i].(string)
+		val := fields[i+1]
 		c = addContext(c, key, val)
 	}
 	return Ctx{ctx: c, mgr: ctx.mgr}
 }
 
-func (l *Manager) doLog(level logLevel, ev *zerolog.Event, msg string, keysAndValues ...interface{}) {
+func (l *Manager) doLog(level logLevel, ev *zerolog.Event, msg string, ctxFields, logFields []any) {
 	var tb *trace.Buffer
 	curr := l.rt.Current()
-	fields := len(keysAndValues) / 2
+	numFields := len(ctxFields)/2 + len(logFields)/2
 
 	if curr.Req != nil && curr.Trace != nil {
-		t := trace.NewBuffer(16 + 8 + len(msg) + 4 + fields*50)
+		t := trace.NewBuffer(16 + 8 + len(msg) + 4 + numFields*50)
 		tb = &t
 		tb.Bytes(curr.Req.SpanID[:])
 		tb.UVarint(uint64(curr.Goctr))
 		tb.Byte(byte(level))
 		tb.String(msg)
-		tb.UVarint(uint64(fields))
+		tb.UVarint(uint64(numFields))
 	}
 
-	for i := 0; i < fields; i++ {
-		key := keysAndValues[2*i].(string)
-		val := keysAndValues[2*i+1]
+	// Add context fields to the trace only, not to the zerolog event,
+	// as they're already part of the zerolog event.
+	if tb != nil {
+		for i := 0; i < len(ctxFields); i += 2 {
+			key := ctxFields[i].(string)
+			val := ctxFields[i+1]
+			addTraceBufEntry(tb, key, val)
+		}
+	}
+
+	for i := 0; i < len(logFields); i += 2 {
+		key := logFields[i].(string)
+		val := logFields[i+1]
 		addEventEntry(ev, key, val)
 		if tb != nil {
 			addTraceBufEntry(tb, key, val)
 		}
 	}
+
 	ev.Msg(msg)
 
 	if curr.Trace != nil {
@@ -154,7 +176,7 @@ func (l *Manager) doLog(level logLevel, ev *zerolog.Event, msg string, keysAndVa
 	}
 }
 
-func addEventEntry(ev *zerolog.Event, key string, val interface{}) {
+func addEventEntry(ev *zerolog.Event, key string, val any) {
 	if reserved(key) {
 		key = "x_" + key
 	}
@@ -206,7 +228,7 @@ func addEventEntry(ev *zerolog.Event, key string, val interface{}) {
 	}
 }
 
-func addContext(ctx zerolog.Context, key string, val interface{}) zerolog.Context {
+func addContext(ctx zerolog.Context, key string, val any) zerolog.Context {
 	if reserved(key) {
 		key = "x_" + key
 	}
@@ -276,7 +298,7 @@ const (
 	float64Type byte = 11
 )
 
-func addTraceBufEntry(tb *trace.Buffer, key string, val interface{}) {
+func addTraceBufEntry(tb *trace.Buffer, key string, val any) {
 	switch val := val.(type) {
 	case error:
 		tb.Byte(errType)
@@ -367,4 +389,17 @@ func addTraceBufEntry(tb *trace.Buffer, key string, val interface{}) {
 		tb.String(key)
 		tb.Float64(val)
 	}
+}
+
+// pairs ensures the key-values are in pairs.
+// It drops the last entry if there's an odd number of entries.
+func pairs(keysAndValues []any) []any {
+	fields := keysAndValues
+	num := len(fields)
+	if num%2 == 1 {
+		// Odd number of key-values, drop the last one
+		num--
+		fields = fields[:num]
+	}
+	return fields
 }


### PR DESCRIPTION
We were only adding those fields to the zerolog.Event,
not to the trace.