### PR TITLE
Define default metric e_requests_total as custom metric

### DIFF
--- a/runtime/appruntime/api/handler_test.go
+++ b/runtime/appruntime/api/handler_test.go
@@ -21,13 +21,13 @@ import (
 	encore "encore.dev"
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/config"
-	"encore.dev/appruntime/metrics"
 	"encore.dev/appruntime/metrics/metricstest"
 	"encore.dev/appruntime/model"
 	"encore.dev/appruntime/reqtrack"
 	"encore.dev/appruntime/trace"
 	"encore.dev/appruntime/trace/mock_trace"
 	"encore.dev/beta/errs"
+	usermetrics "encore.dev/metrics"
 )
 
 type mockReq struct {
@@ -362,11 +362,11 @@ func testServer(t *testing.T, klock clock.Clock, mockTraces bool) (*api.Server, 
 
 	logger := zerolog.New(os.Stdout)
 	testMetricsExporter := metricstest.NewTestMetricsExporter(logger)
-	metrics := metrics.NewManager(nil, cfg, logger)
 	rt := reqtrack.New(logger, nil, tf)
+	metricsRegistry := usermetrics.NewRegistry(rt, uint16(len(cfg.Static.BundledServices)))
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	encoreMgr := encore.NewManager(cfg, rt)
-	server := api.NewServer(cfg, rt, nil, encoreMgr, logger, metrics, json, true, klock)
+	server := api.NewServer(cfg, rt, nil, encoreMgr, logger, metricsRegistry, json, true, klock)
 	return server, traceMock, testMetricsExporter
 }
 

--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -190,12 +190,11 @@ func (s *Server) finishRequest(resp *model.Response) {
 		curr.Trace.FinishRequest(req, resp)
 	}
 
-	s.rt.FinishRequest()
-	s.requestsTotal.With(RequestsTotalLabels{
-		Service:  req.RPCData.Desc.Service,
-		Endpoint: req.RPCData.Desc.Endpoint,
-		Code:     code(resp.Err, resp.HTTPStatus),
+	s.requestsTotal.With(requestsTotalLabels{
+		endpoint: req.RPCData.Desc.Endpoint,
+		code:     code(resp.Err, resp.HTTPStatus),
 	}).Increment()
+	s.rt.FinishRequest()
 }
 
 type CallOptions struct {

--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -191,7 +191,11 @@ func (s *Server) finishRequest(resp *model.Response) {
 	}
 
 	s.rt.FinishRequest()
-	s.metrics.ReqEnd(req.RPCData.Desc.Service, req.RPCData.Desc.Endpoint, resp.Err, resp.HTTPStatus, dur.Seconds())
+	s.requestsTotal.With(RequestsTotalLabels{
+		Service:  req.RPCData.Desc.Service,
+		Endpoint: req.RPCData.Desc.Endpoint,
+		Code:     code(resp.Err, resp.HTTPStatus),
+	}).Increment()
 }
 
 type CallOptions struct {

--- a/runtime/appruntime/api/server.go
+++ b/runtime/appruntime/api/server.go
@@ -59,10 +59,9 @@ type Handler interface {
 	Handle(c IncomingContext)
 }
 
-type RequestsTotalLabels struct {
-	Service  string // Service name.
-	Endpoint string // Endpoint name.
-	Code     string // Human-readable HTTP status code.
+type requestsTotalLabels struct {
+	endpoint string // Endpoint name.
+	code     string // Human-readable HTTP status code.
 }
 
 type Server struct {
@@ -70,7 +69,7 @@ type Server struct {
 	rt             *reqtrack.RequestTracker
 	pc             *platform.Client // if nil, requests are not authenticated against platform
 	encoreMgr      *encore.Manager
-	requestsTotal  *metrics.CounterGroup[RequestsTotalLabels, uint64]
+	requestsTotal  *metrics.CounterGroup[requestsTotalLabels, uint64]
 	clock          clock.Clock
 	rootLogger     zerolog.Logger
 	json           jsoniter.API
@@ -99,12 +98,11 @@ func NewServer(
 	tracingEnabled bool,
 	clock clock.Clock,
 ) *Server {
-	requestsTotal := metrics.NewCounterGroupInternal[RequestsTotalLabels, uint64](reg, "e_requests_total", metrics.CounterConfig{
-		EncoreInternal_LabelMapper: func(labels RequestsTotalLabels) []metrics.KeyValue {
+	requestsTotal := metrics.NewCounterGroupInternal[requestsTotalLabels, uint64](reg, "e_requests_total", metrics.CounterConfig{
+		EncoreInternal_LabelMapper: func(labels requestsTotalLabels) []metrics.KeyValue {
 			return []metrics.KeyValue{
-				{Key: "service", Value: labels.Service},
-				{Key: "endpoint", Value: labels.Endpoint},
-				{Key: "code", Value: labels.Code},
+				{Key: "endpoint", Value: labels.endpoint},
+				{Key: "code", Value: labels.code},
 			}
 		},
 	})

--- a/runtime/appruntime/api/server.go
+++ b/runtime/appruntime/api/server.go
@@ -99,6 +99,8 @@ func NewServer(
 	tracingEnabled bool,
 	clock clock.Clock,
 ) *Server {
+	requestsTotal := metrics.NewCounterGroupInternal[RequestsTotalLabels, uint64](reg, "e_requests_total", metrics.CounterConfig{})
+
 	public := httprouter.New()
 	public.HandleOPTIONS = false
 	public.RedirectFixedPath = false
@@ -119,7 +121,7 @@ func NewServer(
 		pc:             pc,
 		rt:             rt,
 		encoreMgr:      encoreMgr,
-		requestsTotal:  metrics.NewCounterGroupInternal[RequestsTotalLabels, uint64]("e_requests_total", metrics.CounterConfig{}, reg),
+		requestsTotal:  requestsTotal,
 		clock:          clock,
 		rootLogger:     rootLogger,
 		json:           json,

--- a/runtime/appruntime/api/server.go
+++ b/runtime/appruntime/api/server.go
@@ -99,7 +99,15 @@ func NewServer(
 	tracingEnabled bool,
 	clock clock.Clock,
 ) *Server {
-	requestsTotal := metrics.NewCounterGroupInternal[RequestsTotalLabels, uint64](reg, "e_requests_total", metrics.CounterConfig{})
+	requestsTotal := metrics.NewCounterGroupInternal[RequestsTotalLabels, uint64](reg, "e_requests_total", metrics.CounterConfig{
+		EncoreInternal_LabelMapper: func(labels RequestsTotalLabels) []metrics.KeyValue {
+			return []metrics.KeyValue{
+				{Key: "service", Value: labels.Service},
+				{Key: "endpoint", Value: labels.Endpoint},
+				{Key: "code", Value: labels.Code},
+			}
+		},
+	})
 
 	public := httprouter.New()
 	public.HandleOPTIONS = false

--- a/runtime/appruntime/api/util.go
+++ b/runtime/appruntime/api/util.go
@@ -1,8 +1,30 @@
 package api
 
+import (
+	"strconv"
+
+	"encore.dev/beta/errs"
+)
+
 func clampTo64Chars(str string) string {
 	if len(str) > 64 {
 		return str[:64]
 	}
 	return str
+}
+
+func code(err error, httpStatus int) string {
+	if err != nil {
+		e := errs.Convert(err).(*errs.Error)
+		return e.Code.String()
+	}
+
+	if httpStatus == 0 {
+		return errs.OK.String()
+	}
+
+	if code := errs.HTTPStatusToCode(httpStatus); code != errs.Unknown {
+		return code.String()
+	}
+	return "http_" + strconv.Itoa(httpStatus)
 }

--- a/runtime/appruntime/app/app.go
+++ b/runtime/appruntime/app/app.go
@@ -89,7 +89,7 @@ func New(p *NewParams) *App {
 	metrics := rtmetrics.NewManager(metricsRegistry, cfg, rootLogger)
 
 	klock := clock.New()
-	apiSrv := api.NewServer(cfg, rt, pc, encore, rootLogger, metrics, json, tracingEnabled, klock)
+	apiSrv := api.NewServer(cfg, rt, pc, encore, rootLogger, metricsRegistry, json, tracingEnabled, klock)
 	apiSrv.Register(p.APIHandlers)
 	apiSrv.SetAuthHandler(p.AuthHandler)
 	service := service.NewManager(rt)

--- a/runtime/appruntime/metrics/metrics.go
+++ b/runtime/appruntime/metrics/metrics.go
@@ -2,13 +2,11 @@ package metrics
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/rs/zerolog"
 
 	"encore.dev/appruntime/config"
-	"encore.dev/beta/errs"
 	"encore.dev/metrics"
 )
 
@@ -100,42 +98,6 @@ func (mgr *Manager) collectNow(ctx context.Context) {
 	} else {
 		mgr.rootLogger.Trace().Int("num_metrics", len(m)).Msg("successfully emitted metrics")
 	}
-}
-
-func (m *Manager) ReqEnd(service, endpoint string, err error, httpStatus int, durSecs float64) {
-	if m.logsEmitter == nil {
-		return
-	}
-	code := code(err, httpStatus)
-	m.logsEmitter.IncCounter(
-		"e_requests_total",
-		"service", service,
-		"endpoint", endpoint,
-		"code", code,
-	)
-	m.logsEmitter.Observe(
-		"e_request_duration_seconds",
-		"duration", durSecs,
-		"service", service,
-		"endpoint", endpoint,
-		"code", code,
-	)
-}
-
-func code(err error, httpStatus int) string {
-	if err != nil {
-		e := errs.Convert(err).(*errs.Error)
-		return e.Code.String()
-	}
-
-	if httpStatus == 0 {
-		return errs.OK.String()
-	}
-
-	if code := errs.HTTPStatusToCode(httpStatus); code != errs.Unknown {
-		return code.String()
-	}
-	return "http_" + strconv.Itoa(httpStatus)
 }
 
 type exporter interface {

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -65,7 +65,7 @@ func NewCounterGroup[L Labels, V Value](name string, cfg CounterConfig) *Counter
 }
 
 //publicapigen:drop
-func NewCounterGroupInternal[L Labels, V Value](name string, cfg CounterConfig, reg *Registry) *CounterGroup[L, V] {
+func NewCounterGroupInternal[L Labels, V Value](reg *Registry, name string, cfg CounterConfig) *CounterGroup[L, V] {
 	return newCounterGroup[L, V](reg, name, cfg)
 }
 

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -64,6 +64,11 @@ func NewCounterGroup[L Labels, V Value](name string, cfg CounterConfig) *Counter
 	return newCounterGroup[L, V](Singleton, name, cfg)
 }
 
+//publicapigen:drop
+func NewCounterGroupInternal[L Labels, V Value](name string, cfg CounterConfig, reg *Registry) *CounterGroup[L, V] {
+	return newCounterGroup[L, V](reg, name, cfg)
+}
+
 func newCounterGroup[L Labels, V Value](mgr *Registry, name string, cfg CounterConfig) *CounterGroup[L, V] {
 	labelMapper := cfg.EncoreInternal_LabelMapper.(func(L) []KeyValue)
 	m := newMetricInfo[V](mgr, name, CounterType, cfg.EncoreInternal_SvcNum)

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -9,7 +9,7 @@ import (
 	"encore.dev/internal/nativehist"
 )
 
-var Singleton *Registry // TODO
+var Singleton *Registry
 
 type Registry struct {
 	rt       *reqtrack.RequestTracker


### PR DESCRIPTION
We defined `e_requests_total` as a logs-based metric, but considered the quota limitations of logs-based metrics, we've decided to treat default metrics like `e_requests_total` as custom metrics.

Custom metrics, as opposed to logs-based metrics, have higher quotas in GCP. This makes it easier to use them in Encore Cloud.