### PR TITLE
Add service number to API handler descriptor

### DIFF
--- a/compiler/internal/codegen/api_handlers.go
+++ b/compiler/internal/codegen/api_handlers.go
@@ -127,6 +127,7 @@ func (b *rpcBuilder) Write(f *File) {
 		Multi:     true,
 	},
 		Id("Service").Op(":").Lit(b.svc.Name),
+		Id("SvcNum").Op(":").Lit(b.getSvcNum(b.svc)),
 		Id("Endpoint").Op(":").Lit(rpc.Name),
 		Id("Methods").Op(":").Add(methods),
 		Id("Raw").Op(":").Lit(rpc.Raw),

--- a/compiler/internal/codegen/auth_handler.go
+++ b/compiler/internal/codegen/auth_handler.go
@@ -49,6 +49,7 @@ func (b *authHandlerBuilder) Write() {
 		Multi:     true,
 	},
 		Id("Service").Op(":").Lit(b.svc.Name),
+		Id("SvcNum").Op(":").Lit(b.getSvcNum(b.svc)),
 		Id("Endpoint").Op(":").Lit(b.ah.Name),
 		Id("DefLoc").Op(":").Lit(defLoc),
 		Id("HasAuthData").Op(":").Lit(b.ah.AuthData != nil),

--- a/compiler/internal/codegen/codegen_main.go
+++ b/compiler/internal/codegen/codegen_main.go
@@ -72,10 +72,10 @@ func (b *Builder) Main(compilerVersion string, mainPkgPath, mainFuncName string)
 				Id("Revision"):    Lit(b.res.Meta.AppRevision),
 				Id("Uncommitted"): Lit(b.res.Meta.UncommittedChanges),
 			}),
-			Id("CORSHeaders"):  corsHeaders,
-			Id("PubsubTopics"): b.computeStaticPubsubConfig(),
-			Id("Testing"):      False(),
-			Id("TestService"):  Lit(""),
+			Id("CORSHeaders"):     corsHeaders,
+			Id("PubsubTopics"):    b.computeStaticPubsubConfig(),
+			Id("Testing"):         False(),
+			Id("TestService"):     Lit(""),
 			Id("BundledServices"): b.computeBundledServices(),
 		})
 		g.Id("handlers").Op(":=").Add(b.computeHandlerRegistrationConfig(mwNames))
@@ -256,6 +256,22 @@ func (b *Builder) computeBundledServices() Code {
 			g.Lit(name)
 		}
 	})
+}
+
+func (b *Builder) getSvcNum(svc *est.Service) int {
+	sortedNames := make([]string, 0, len(b.res.App.Services))
+	for _, svc := range b.res.App.Services {
+		sortedNames = append(sortedNames, svc.Name)
+	}
+	sort.Strings(sortedNames)
+
+	for i, name := range sortedNames {
+		if name == svc.Name {
+			return i + 1
+		}
+	}
+	b.errorf("cannot find service %s", svc.Name)
+	return 0
 }
 
 func (b *Builder) error(err error) {

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -200,6 +200,7 @@ type EncoreInternal_AuthHandlerAuthParams = AuthHeaders
 
 var EncoreInternal_AuthHandlerAuthHandler = &__api.AuthHandlerDesc[*EncoreInternal_AuthHandlerAuthParams]{
 	Service:     "svc",
+	SvcNum:      1,
 	Endpoint:    "AuthHandler",
 	DefLoc:      3,
 	HasAuthData: true,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_header_auth.golden
@@ -72,6 +72,7 @@ type EncoreInternal_EightResp = Response
 
 var EncoreInternal_EightHandler = &__api.Desc[*EncoreInternal_EightReq, *EncoreInternal_EightResp]{
 	Service:        "svc",
+	SvcNum:         1,
 	Endpoint:       "Eight",
 	Methods:        []string{"POST"},
 	Raw:            false,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -72,6 +72,7 @@ type EncoreInternal_EightResp = Response
 
 var EncoreInternal_EightHandler = &__api.Desc[*EncoreInternal_EightReq, *EncoreInternal_EightResp]{
 	Service:        "svc",
+	SvcNum:         1,
 	Endpoint:       "Eight",
 	Methods:        []string{"POST"},
 	Raw:            false,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__only_query_auth.golden
@@ -200,6 +200,7 @@ type EncoreInternal_AuthHandlerAuthParams = AuthQuery
 
 var EncoreInternal_AuthHandlerAuthHandler = &__api.AuthHandlerDesc[*EncoreInternal_AuthHandlerAuthParams]{
 	Service:     "svc",
+	SvcNum:      1,
 	Endpoint:    "AuthHandler",
 	DefLoc:      3,
 	HasAuthData: true,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -72,6 +72,7 @@ type EncoreInternal_EightResp = Response
 
 var EncoreInternal_EightHandler = &__api.Desc[*EncoreInternal_EightReq, *EncoreInternal_EightResp]{
 	Service:        "svc",
+	SvcNum:         1,
 	Endpoint:       "Eight",
 	Methods:        []string{"POST"},
 	Raw:            false,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__token_auth.golden
@@ -200,6 +200,7 @@ type EncoreInternal_AuthHandlerAuthParams = string
 
 var EncoreInternal_AuthHandlerAuthHandler = &__api.AuthHandlerDesc[string]{
 	Service:     "svc",
+	SvcNum:      1,
 	Endpoint:    "AuthHandler",
 	DefLoc:      3,
 	HasAuthData: true,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -1386,6 +1386,7 @@ type EncoreInternal_AuthHandlerAuthParams = AuthParams
 
 var EncoreInternal_AuthHandlerAuthHandler = &__api.AuthHandlerDesc[*EncoreInternal_AuthHandlerAuthParams]{
 	Service:     "svc",
+	SvcNum:      2,
 	Endpoint:    "AuthHandler",
 	DefLoc:      39,
 	HasAuthData: true,

--- a/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
+++ b/compiler/internal/codegen/testdata/TestCodeGenMain__variants.golden
@@ -170,6 +170,7 @@ type EncoreInternal_CronOneResp = __api.Void
 
 var EncoreInternal_CronOneHandler = &__api.Desc[*EncoreInternal_CronOneReq, EncoreInternal_CronOneResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "CronOne",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -225,6 +226,7 @@ type EncoreInternal_DIResp = __api.Void
 
 var EncoreInternal_DIHandler = &__api.Desc[*EncoreInternal_DIReq, EncoreInternal_DIResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "DI",
 	Methods:        []string{"GET"},
 	Raw:            false,
@@ -284,6 +286,7 @@ type EncoreInternal_DIRawResp = __api.Void
 
 var EncoreInternal_DIRawHandler = &__api.Desc[*EncoreInternal_DIRawReq, EncoreInternal_DIRawResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "DIRaw",
 	Methods:        []string{"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"},
 	Raw:            true,
@@ -333,6 +336,7 @@ type EncoreInternal_EightResp = Response
 
 var EncoreInternal_EightHandler = &__api.Desc[*EncoreInternal_EightReq, *EncoreInternal_EightResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Eight",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -441,6 +445,7 @@ type EncoreInternal_FiveResp = __api.Void
 
 var EncoreInternal_FiveHandler = &__api.Desc[*EncoreInternal_FiveReq, EncoreInternal_FiveResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Five",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -549,6 +554,7 @@ type EncoreInternal_FourResp = __api.Void
 
 var EncoreInternal_FourHandler = &__api.Desc[*EncoreInternal_FourReq, EncoreInternal_FourResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Four",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -630,6 +636,7 @@ type EncoreInternal_NineResp = ComplexResponse
 
 var EncoreInternal_NineHandler = &__api.Desc[*EncoreInternal_NineReq, *EncoreInternal_NineResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Nine",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -748,6 +755,7 @@ type EncoreInternal_OneResp = __api.Void
 
 var EncoreInternal_OneHandler = &__api.Desc[*EncoreInternal_OneReq, EncoreInternal_OneResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "One",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -805,6 +813,7 @@ type EncoreInternal_QueryResp = QueryParams
 
 var EncoreInternal_QueryHandler = &__api.Desc[*EncoreInternal_QueryReq, *EncoreInternal_QueryResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Query",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -944,6 +953,7 @@ type EncoreInternal_SevenResp = __api.Void
 
 var EncoreInternal_SevenHandler = &__api.Desc[*EncoreInternal_SevenReq, EncoreInternal_SevenResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Seven",
 	Methods:        []string{"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"},
 	Raw:            true,
@@ -1007,6 +1017,7 @@ type EncoreInternal_SixResp = __api.Void
 
 var EncoreInternal_SixHandler = &__api.Desc[*EncoreInternal_SixReq, EncoreInternal_SixResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Six",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -1121,6 +1132,7 @@ type EncoreInternal_TenResp = HeaderResponse
 
 var EncoreInternal_TenHandler = &__api.Desc[*EncoreInternal_TenReq, *EncoreInternal_TenResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Ten",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -1208,6 +1220,7 @@ type EncoreInternal_ThreeResp = __api.Void
 
 var EncoreInternal_ThreeHandler = &__api.Desc[*EncoreInternal_ThreeReq, EncoreInternal_ThreeResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Three",
 	Methods:        []string{"GET", "POST"},
 	Raw:            false,
@@ -1284,6 +1297,7 @@ type EncoreInternal_TwoResp = __api.Void
 
 var EncoreInternal_TwoHandler = &__api.Desc[*EncoreInternal_TwoReq, EncoreInternal_TwoResp]{
 	Service:        "svc",
+	SvcNum:         2,
 	Endpoint:       "Two",
 	Methods:        []string{"POST"},
 	Raw:            false,

--- a/runtime/appruntime/api/auth.go
+++ b/runtime/appruntime/api/auth.go
@@ -15,6 +15,7 @@ import (
 type AuthHandlerDesc[Params any] struct {
 	// Service and Endpoint name the auth handler this description is for.
 	Service     string
+	SvcNum      uint16
 	Endpoint    string
 	DefLoc      int32
 	HasAuthData bool // whether the handler returns custom auth data
@@ -128,6 +129,7 @@ func (d *AuthHandlerDesc[Params]) rpcDesc() *model.RPCDesc {
 	d.rpcDescOnce.Do(func() {
 		desc := &model.RPCDesc{
 			Service:     d.Service,
+			SvcNum:      d.SvcNum,
 			Endpoint:    d.Endpoint,
 			AuthHandler: true,
 			Raw:         false,

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -471,6 +471,7 @@ func (d *Desc[Req, Resp]) rpcDesc() *model.RPCDesc {
 		var reqTyp Req
 		desc := &model.RPCDesc{
 			Service:     d.Service,
+			SvcNum:      d.SvcNum,
 			Endpoint:    d.Endpoint,
 			Raw:         d.Raw,
 			RequestType: reflect.TypeOf(reqTyp),

--- a/runtime/appruntime/api/handler.go
+++ b/runtime/appruntime/api/handler.go
@@ -45,6 +45,7 @@ func isVoid[T any]() bool {
 type Desc[Req, Resp any] struct {
 	// Service and Endpoint name the API this description is for.
 	Service  string
+	SvcNum   uint16
 	Endpoint string
 	Methods  []string
 	Path     string

--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -37,8 +37,6 @@ type beginRequestParams struct {
 	// It is copied from the parent request if it is empty.
 	ParentTraceID model.TraceID
 
-	SvcNum uint16
-
 	// ExtRequestID specifies the externally-provided request id, if any.
 	// If not empty, it will be recorded as part of the "starting request" log message
 	// to facilitate request correlation.
@@ -67,7 +65,7 @@ func (s *Server) beginRequest(ctx context.Context, p *beginRequestParams) (*mode
 		ParentTraceID:    p.ParentTraceID,
 		ExtCorrelationID: p.ExtCorrelationID,
 		DefLoc:           p.DefLoc,
-		SvcNum:           p.SvcNum,
+		SvcNum:           p.Data.Desc.SvcNum,
 		Start:            s.clock.Now(),
 		Traced:           s.tracingEnabled,
 		RPCData:          p.Data,

--- a/runtime/appruntime/model/request.go
+++ b/runtime/appruntime/model/request.go
@@ -22,6 +22,7 @@ const (
 
 type RPCDesc struct {
 	Service      string
+	SvcNum       uint16
 	Endpoint     string
 	AuthHandler  bool // true if this is an auth handler
 	Raw          bool


### PR DESCRIPTION
The metrics code reads service numbers from the request tracker, which in turn reads them from API handler descriptors.

This PR modifies the code generator to add service numbers to API handler descriptors.