### PR TITLE
Fix missing time series error

### DIFF
--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -69,6 +69,10 @@ func (x *Exporter) Export(ctx context.Context, collected []metrics.CollectedMetr
 	endTime := time.Now()
 
 	data := x.getMetricData(newCounterStart, endTime, collected)
+	if len(data) == 0 {
+		return nil
+	}
+
 	err := x.getClient().CreateTimeSeries(ctx, &monitoringpb.CreateTimeSeriesRequest{
 		Name:       "projects/" + x.cfg.ProjectID,
 		TimeSeries: data,


### PR DESCRIPTION
If no metrics have been collected, we shouldn't make any request to GCP. If we do, we get an error saying that the time series field can't be empty.