### PR TITLE
pkg/scrub: handle quoted strings properly

### DIFF
--- a/pkg/scrub/scanner.go
+++ b/pkg/scrub/scanner.go
@@ -119,18 +119,18 @@ func (s *scanner) scanString() scanItem {
 	// Use s.pos-1 since scan already consumed the first byte.
 	it := scanItem{from: s.pos - 1, tok: literal}
 
-	var wasBackslash bool
 	for {
 		b := s.readByte()
+
+		if b == '\\' {
+			b = s.readByte()
+			// Escaped symbols never signal the end of the string,
+			// so it's safe to just continue here regardless of value.
+			continue
+		}
+
 		switch b {
-		case '\\':
-			wasBackslash = true
-		default:
-			wasBackslash = false
 		case '"':
-			if wasBackslash {
-				continue // escaped double-quote
-			}
 			it.to = s.pos
 			return it
 		case '\n', '\r':

--- a/pkg/scrub/scanner_test.go
+++ b/pkg/scrub/scanner_test.go
@@ -23,6 +23,27 @@ var tests = []scannerTest{
 		},
 	},
 	{
+		name: "escaped_string",
+		src:  `"foo\"bar"`,
+		want: []tokDesc{
+			str("foo\"bar"),
+		},
+	},
+	{
+		name: "escaped_string_at_end",
+		src:  `"foo\""`,
+		want: []tokDesc{
+			str("foo\""),
+		},
+	},
+	{
+		name: "escaped_quoted_string",
+		src:  `["\"one\""]`,
+		want: []tokDesc{
+			arrStart, str("\"one\""), arrEnd,
+		},
+	},
+	{
 		name: "newline_reset_key",
 		src:  "{0: true, 1:\n2: true}",
 		want: []tokDesc{

--- a/pkg/scrub/scrub_test.go
+++ b/pkg/scrub/scrub_test.go
@@ -230,6 +230,16 @@ func TestJSON(t *testing.T) {
 			},
 			wantOutput: "{0:\n \"[sensitive]\"}",
 		},
+		{
+			name:  "test",
+			input: `{"One":["\"one\""]}}`,
+			paths: []Path{
+				[]PathEntry{
+					{Kind: ObjectField, FieldName: `"x"`, CaseSensitive: false},
+				},
+			},
+			wantOutput: `{"One":["\"one\""]}}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The scanner mishandled double-quoted strings.