### PR TITLE
Fix time series start time

### DIFF
--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -65,7 +65,7 @@ func (x *Exporter) Shutdown(force context.Context) {
 func (x *Exporter) Export(ctx context.Context, collected []metrics.CollectedMetric) error {
 	// Call time.Now twice so we don't get identical timestamps,
 	// which is not allowed for cumulative metrics.
-	newCounterStart := time.Now()
+	newCounterStart := time.Now().Add(-time.Microsecond)
 	endTime := time.Now()
 
 	data := x.getMetricData(newCounterStart, endTime, collected)


### PR DESCRIPTION
GCP Cloud Monitoring returns an error if the time series start time is equal or after the time series end time. Even if the code already takes that into account, we still get this error when the app exports metrics for the time after being deployed.

This probably happens because timestamps in GCP Cloud Monitoring have microsecond precision, which means that the timestamps we initially send look identical on their side.