### PR TITLE
.github: use ubuntu-20.04 builder

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - builder: ubuntu-latest
+          - builder: ubuntu-20.04
             goos: linux
             goarch: amd64
             release_key: linux_x86-64
-          - builder: ubuntu-latest
+          - builder: ubuntu-20.04
             goos: linux
             goarch: arm64
             release_key: linux_arm64
@@ -89,7 +89,7 @@ jobs:
         path: encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
   notify_release_success:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Webhook
       uses: distributhor/workflow-webhook@v3


### PR DESCRIPTION
We've gotten reports that ubuntu-latest causes issues with glibc versioning
on older operating systems (including ubuntu 20.04).

Fix this by reverting to using an ubuntu-20.04 builder instead.