### PR TITLE
Add Cloud Run instance ID to node_id

### DIFF
--- a/runtime/appruntime/metrics/encore_cloud_exporter.go
+++ b/runtime/appruntime/metrics/encore_cloud_exporter.go
@@ -3,6 +3,8 @@
 package metrics
 
 import (
+	"cloud.google.com/go/compute/metadata"
+
 	"encore.dev/appruntime/config"
 	"encore.dev/appruntime/metrics/gcp"
 )
@@ -14,7 +16,14 @@ func init() {
 			return cfg.EncoreCloud != nil
 		},
 		newExporter: func(mgr *Manager) exporter {
+			cloudRunInstanceID, err := metadata.InstanceID()
+			if err != nil {
+				mgr.rootLogger.Err(err).Msg("unable to initialize metrics exporter")
+				return nil
+			}
+
 			metricsCfg := mgr.cfg.Runtime.Metrics
+			metricsCfg.EncoreCloud.MonitoredResourceLabels["node_id"] += "-" + cloudRunInstanceID
 			return gcp.New(mgr.cfg.Static.BundledServices, metricsCfg.EncoreCloud, mgr.rootLogger)
 		},
 	})

--- a/runtime/appruntime/metrics/encore_cloud_exporter.go
+++ b/runtime/appruntime/metrics/encore_cloud_exporter.go
@@ -18,12 +18,21 @@ func init() {
 		newExporter: func(mgr *Manager) exporter {
 			cloudRunInstanceID, err := metadata.InstanceID()
 			if err != nil {
-				mgr.rootLogger.Err(err).Msg("unable to initialize metrics exporter")
+				mgr.rootLogger.Err(err).Msg(
+					"unable to initialize metrics exporter: error getting Cloud Run instance ID",
+				)
 				return nil
 			}
 
 			metricsCfg := mgr.cfg.Runtime.Metrics
-			metricsCfg.EncoreCloud.MonitoredResourceLabels["node_id"] += "-" + cloudRunInstanceID
+			nodeID, ok := metricsCfg.EncoreCloud.MonitoredResourceLabels["node_id"]
+			if !ok {
+				mgr.rootLogger.Err(err).Msg(
+					"unable to initialize metrics exporter: missing node_id",
+				)
+				return nil
+			}
+			metricsCfg.EncoreCloud.MonitoredResourceLabels["node_id"] = nodeID + "-" + cloudRunInstanceID
 			return gcp.New(mgr.cfg.Static.BundledServices, metricsCfg.EncoreCloud, mgr.rootLogger)
 		},
 	})

--- a/runtime/appruntime/metrics/gcp_cloud_monitoring_exporter.go
+++ b/runtime/appruntime/metrics/gcp_cloud_monitoring_exporter.go
@@ -23,7 +23,7 @@ func init() {
 			}
 
 			metricsCfg := mgr.cfg.Runtime.Metrics
-			metricsCfg.EncoreCloud.MonitoredResourceLabels["node_id"] += "-" + cloudRunInstanceID
+			metricsCfg.CloudMonitoring.MonitoredResourceLabels["node_id"] += "-" + cloudRunInstanceID
 			return gcp.New(mgr.cfg.Static.BundledServices, metricsCfg.CloudMonitoring, mgr.rootLogger)
 		},
 	})

--- a/runtime/appruntime/metrics/gcp_cloud_monitoring_exporter.go
+++ b/runtime/appruntime/metrics/gcp_cloud_monitoring_exporter.go
@@ -3,6 +3,8 @@
 package metrics
 
 import (
+	"cloud.google.com/go/compute/metadata"
+
 	"encore.dev/appruntime/config"
 	"encore.dev/appruntime/metrics/gcp"
 )
@@ -14,7 +16,14 @@ func init() {
 			return cfg.CloudMonitoring != nil
 		},
 		newExporter: func(mgr *Manager) exporter {
+			cloudRunInstanceID, err := metadata.InstanceID()
+			if err != nil {
+				mgr.rootLogger.Err(err).Msg("unable to initialize metrics exporter")
+				return nil
+			}
+
 			metricsCfg := mgr.cfg.Runtime.Metrics
+			metricsCfg.EncoreCloud.MonitoredResourceLabels["node_id"] += "-" + cloudRunInstanceID
 			return gcp.New(mgr.cfg.Static.BundledServices, metricsCfg.CloudMonitoring, mgr.rootLogger)
 		},
 	})


### PR DESCRIPTION
This PR fixes a bug where multiple Cloud Run instances write to the same cumulative metric with different start times. By adding the Cloud Run instance ID to `node_id`, we avoid writing to the same time series which should fix the bug.