### PR TITLE
Remove per-service time series slice

### DIFF
--- a/runtime/appruntime/api/handler_test.go
+++ b/runtime/appruntime/api/handler_test.go
@@ -363,7 +363,7 @@ func testServer(t *testing.T, klock clock.Clock, mockTraces bool) (*api.Server, 
 	logger := zerolog.New(os.Stdout)
 	testMetricsExporter := metricstest.NewTestMetricsExporter(logger)
 	rt := reqtrack.New(logger, nil, tf)
-	metricsRegistry := usermetrics.NewRegistry(rt, uint16(len(cfg.Static.BundledServices)))
+	metricsRegistry := usermetrics.NewRegistry()
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	encoreMgr := encore.NewManager(cfg, rt)
 	server := api.NewServer(cfg, rt, nil, encoreMgr, logger, metricsRegistry, json, true, klock)

--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -189,6 +189,7 @@ func (s *Server) finishRequest(resp *model.Response) {
 	}
 
 	s.requestsTotal.With(requestsTotalLabels{
+		service:  req.RPCData.Desc.Service,
 		endpoint: req.RPCData.Desc.Endpoint,
 		code:     code(resp.Err, resp.HTTPStatus),
 	}).Increment()

--- a/runtime/appruntime/api/server.go
+++ b/runtime/appruntime/api/server.go
@@ -60,6 +60,7 @@ type Handler interface {
 }
 
 type requestsTotalLabels struct {
+	service  string // Service name.
 	endpoint string // Endpoint name.
 	code     string // Human-readable HTTP status code.
 }
@@ -101,6 +102,7 @@ func NewServer(
 	requestsTotal := metrics.NewCounterGroupInternal[requestsTotalLabels, uint64](reg, "e_requests_total", metrics.CounterConfig{
 		EncoreInternal_LabelMapper: func(labels requestsTotalLabels) []metrics.KeyValue {
 			return []metrics.KeyValue{
+				{Key: "service", Value: labels.service},
 				{Key: "endpoint", Value: labels.endpoint},
 				{Key: "code", Value: labels.code},
 			}

--- a/runtime/appruntime/app/app.go
+++ b/runtime/appruntime/app/app.go
@@ -85,7 +85,7 @@ func New(p *NewParams) *App {
 	shutdown := newShutdownTracker()
 	encore := encore.NewManager(cfg, rt)
 
-	metricsRegistry := usermetrics.NewRegistry(rt, uint16(len(cfg.Static.BundledServices)))
+	metricsRegistry := usermetrics.NewRegistry()
 	metrics := rtmetrics.NewManager(metricsRegistry, cfg, rootLogger)
 
 	klock := clock.New()

--- a/runtime/appruntime/metrics/gcp/cloud_monitoring_test.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring_test.go
@@ -36,6 +36,11 @@ func TestGetMetricData(t *testing.T) {
 		ProjectID:               "test-project",
 		MonitoredResourceType:   "resource-type",
 		MonitoredResourceLabels: map[string]string{"key": "value"},
+		MetricNames: map[string]string{
+			"test_counter": "test_counter",
+			"test_gauge":   "test_gauge",
+			"test_labels":  "test_labels",
+		},
 	}
 	monitoredRes := &monitoredres.MonitoredResource{
 		Type:   "resource-type",
@@ -54,7 +59,7 @@ func TestGetMetricData(t *testing.T) {
 			name: "counter",
 			metric: metrics.CollectedMetric{
 				Info: metricInfo{"test_counter", metrics.CounterType, 1},
-				Val:  []int64{10},
+				Val:  int64(10),
 			},
 			data: []*monitoringpb.TimeSeries{{
 				Metric: &metricpb.Metric{
@@ -73,7 +78,7 @@ func TestGetMetricData(t *testing.T) {
 			name: "gauge",
 			metric: metrics.CollectedMetric{
 				Info: metricInfo{"test_gauge", metrics.GaugeType, 2},
-				Val:  []float64{0.5},
+				Val:  float64(0.5),
 			},
 			data: []*monitoringpb.TimeSeries{{
 				Metric: &metricpb.Metric{
@@ -93,7 +98,7 @@ func TestGetMetricData(t *testing.T) {
 			metric: metrics.CollectedMetric{
 				Info:   metricInfo{"test_labels", metrics.GaugeType, 1},
 				Labels: []metrics.KeyValue{{"key", "value"}},
-				Val:    []uint64{2},
+				Val:    uint64(2),
 			},
 			data: []*monitoringpb.TimeSeries{{
 				Metric: &metricpb.Metric{
@@ -113,31 +118,19 @@ func TestGetMetricData(t *testing.T) {
 			metric: metrics.CollectedMetric{
 				Info:   metricInfo{"test_labels", metrics.GaugeType, 0},
 				Labels: []metrics.KeyValue{{"key", "value"}},
-				Val:    []time.Duration{2 * time.Second, 4 * time.Second},
+				Val:    2 * time.Second,
 			},
 			data: []*monitoringpb.TimeSeries{
 				{
 					Metric: &metricpb.Metric{
 						Type:   "custom.googleapis.com/test_labels",
-						Labels: map[string]string{"service": "foo", "key": "value"},
+						Labels: map[string]string{"key": "value"},
 					},
 					Resource:   monitoredRes,
 					MetricKind: metricpb.MetricDescriptor_GAUGE,
 					Points: []*monitoringpb.Point{{
 						Interval: &monitoringpb.TimeInterval{EndTime: pbEnd},
 						Value:    floatVal(2),
-					}},
-				},
-				{
-					Metric: &metricpb.Metric{
-						Type:   "custom.googleapis.com/test_labels",
-						Labels: map[string]string{"service": "bar", "key": "value"},
-					},
-					Resource:   monitoredRes,
-					MetricKind: metricpb.MetricDescriptor_GAUGE,
-					Points: []*monitoringpb.Point{{
-						Interval: &monitoringpb.TimeInterval{EndTime: pbEnd},
-						Value:    floatVal(4),
 					}},
 				},
 			},

--- a/runtime/metrics/histogram_internal.go
+++ b/runtime/metrics/histogram_internal.go
@@ -27,14 +27,7 @@ func newHistogramInternal[V Value](m *metricInfo[V]) *Histogram[V] {
 
 	// Initialize the values if they haven't yet been set up.
 	if !setup {
-		n := m.reg.numSvcs
-		if m.svcNum > 0 {
-			n = 1
-		}
-		ts.value = make([]*nativehist.Histogram, n)
-		for i := range ts.value {
-			ts.value[i] = nativehist.New(bucketFactor)
-		}
+		ts.value = nativehist.New(bucketFactor)
 	}
 
 	return &Histogram[V]{
@@ -55,9 +48,7 @@ func (h *Histogram[V]) Observe(val V) {
 	if math.IsNaN(f) {
 		return
 	}
-	if idx, ok := h.svcIdx(); ok {
-		h.ts.value[idx].Observe(f)
-	}
+	h.ts.value.Observe(f)
 }
 
 // NewHistogramGroup creates a new histogram group with a set of labels,
@@ -98,14 +89,7 @@ func (c *HistogramGroup[L, V]) get(labels L) *timeseries[*nativehist.Histogram] 
 	ts, setup := getTS[*nativehist.Histogram](c.reg, c.name, labels, c.metricInfo)
 
 	if !setup {
-		n := c.reg.numSvcs
-		if c.svcNum > 0 {
-			n = 1
-		}
-		ts.value = make([]*nativehist.Histogram, n)
-		for i := range ts.value {
-			ts.value[i] = nativehist.New(bucketFactor)
-		}
+		ts.value = nativehist.New(bucketFactor)
 	}
 
 	return ts

--- a/runtime/metrics/metrics_test.go
+++ b/runtime/metrics/metrics_test.go
@@ -5,15 +5,10 @@ import (
 	"strconv"
 	"sync"
 	"testing"
-
-	"github.com/rs/zerolog"
-
-	"encore.dev/appruntime/reqtrack"
 )
 
 func TestCounter(t *testing.T) {
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	m := newMetricInfo[int64](mgr, "foo", CounterType, 1)
 	c := newCounterInternal(m)
 
@@ -41,8 +36,7 @@ func TestCounter(t *testing.T) {
 }
 
 func TestCounter_Global(t *testing.T) {
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 2)
+	mgr := NewRegistry()
 	m := newMetricInfo[int64](mgr, "foo", CounterType, 0)
 	c := newCounterInternal(m)
 
@@ -64,8 +58,7 @@ func TestCounter_Global(t *testing.T) {
 }
 
 func TestGauge(t *testing.T) {
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	m := newMetricInfo[float64](mgr, "foo", GaugeType, 1)
 	c := newGauge(m)
 
@@ -97,8 +90,7 @@ func TestCounterGroup(t *testing.T) {
 		key string
 	}
 
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	c := newCounterGroup[myLabels, int64](mgr, "foo", CounterConfig{
 		EncoreInternal_SvcNum: 1,
 		EncoreInternal_LabelMapper: func(labels myLabels) []KeyValue {
@@ -134,8 +126,7 @@ func TestGaugeGroup(t *testing.T) {
 	type myLabels struct {
 		key string
 	}
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	c := newGaugeGroup[myLabels, float64](mgr, "foo", GaugeConfig{
 		EncoreInternal_SvcNum: 1,
 		EncoreInternal_LabelMapper: func(labels myLabels) []KeyValue {
@@ -168,8 +159,7 @@ func TestGaugeGroup(t *testing.T) {
 
 func BenchmarkCounter_Inc(b *testing.B) {
 	b.ReportAllocs()
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	m := newMetricInfo[int64](mgr, "foo", CounterType, 1)
 	c := newCounterInternal(m)
 
@@ -184,8 +174,7 @@ func BenchmarkCounter_NewLabel(b *testing.B) {
 	type myLabels struct {
 		key string
 	}
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	c := newCounterGroup[myLabels, int64](mgr, "foo", CounterConfig{
 		EncoreInternal_SvcNum: 1,
 		EncoreInternal_LabelMapper: func(labels myLabels) []KeyValue {
@@ -209,8 +198,7 @@ func BenchmarkCounter_NewLabelSometimes(b *testing.B) {
 	type myLabels struct {
 		key string
 	}
-	rt := reqtrack.New(zerolog.Logger{}, nil, nil)
-	mgr := NewRegistry(rt, 1)
+	mgr := NewRegistry()
 	c := newCounterGroup[myLabels, int64](mgr, "foo", CounterConfig{
 		EncoreInternal_SvcNum: 1,
 		EncoreInternal_LabelMapper: func(labels myLabels) []KeyValue {

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -93,7 +93,7 @@ type timeseries[T any] struct {
 	id     uint64
 	init   initGate
 	labels []KeyValue
-	value  []T
+	value  T
 }
 
 func (ts *timeseries[V]) setup(labels []KeyValue) {

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -77,7 +77,7 @@ type CollectedMetric struct {
 	Info         MetricInfo
 	TimeSeriesID uint64
 	Labels       []KeyValue
-	Val          any // []T where T is any of Value
+	Val          any // T where T is any of Value
 }
 
 type registryKey struct {

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -5,21 +5,18 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"encore.dev/appruntime/reqtrack"
 	"encore.dev/internal/nativehist"
 )
 
 var Singleton *Registry
 
 type Registry struct {
-	rt       *reqtrack.RequestTracker
-	numSvcs  uint16
 	tsid     uint64
 	registry sync.Map // map[registryKey]*timeseries
 }
 
-func NewRegistry(rt *reqtrack.RequestTracker, numServicesInBinary uint16) *Registry {
-	return &Registry{rt: rt, numSvcs: numServicesInBinary}
+func NewRegistry() *Registry {
+	return &Registry{}
 }
 
 func (r *Registry) Collect() []CollectedMetric {


### PR DESCRIPTION
Currently, we store time series values in a slice where the value at position `i` is for service `i`. This PR simplifies how we store time series by only storing the latest value for a metric (instead of the latest value per service).

If a custom metric is declared within a service, we keep track of that so that it's easy to automatically add a `service` label to a time series when exporting metrics.