### PR TITLE
Keep track of which services have emitted metrics

### DIFF
--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -152,7 +152,7 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(floatVal(vals[0]), svcNum-1)
 			} else {
 				for i, val := range vals {
-					if m.Valid[i] {
+					if m.Valid[i].Load() {
 						doAdd(floatVal(val), uint16(i))
 					}
 				}
@@ -163,7 +163,7 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(int64Val(vals[0]), svcNum-1)
 			} else {
 				for i, val := range vals {
-					if m.Valid[i] {
+					if m.Valid[i].Load() {
 						doAdd(int64Val(val), uint16(i))
 					}
 				}
@@ -174,7 +174,7 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(uint64Val(vals[0]), svcNum-1)
 			} else {
 				for i, val := range vals {
-					if m.Valid[i] {
+					if m.Valid[i].Load() {
 						doAdd(uint64Val(val), uint16(i))
 					}
 				}
@@ -185,7 +185,7 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(floatVal(float64(vals[0]/time.Second)), svcNum-1)
 			} else {
 				for i, val := range vals {
-					if m.Valid[i] {
+					if m.Valid[i].Load() {
 						doAdd(floatVal(float64(val/time.Second)), uint16(i))
 					}
 				}

--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -152,7 +152,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(floatVal(vals[0]), svcNum-1)
 			} else {
 				for i, val := range vals {
-					doAdd(floatVal(val), uint16(i))
+					if m.Valid[i] {
+						doAdd(floatVal(val), uint16(i))
+					}
 				}
 			}
 
@@ -161,7 +163,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(int64Val(vals[0]), svcNum-1)
 			} else {
 				for i, val := range vals {
-					doAdd(int64Val(val), uint16(i))
+					if m.Valid[i] {
+						doAdd(int64Val(val), uint16(i))
+					}
 				}
 			}
 
@@ -170,7 +174,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(uint64Val(vals[0]), svcNum-1)
 			} else {
 				for i, val := range vals {
-					doAdd(uint64Val(val), uint16(i))
+					if m.Valid[i] {
+						doAdd(uint64Val(val), uint16(i))
+					}
 				}
 			}
 
@@ -179,7 +185,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 				doAdd(floatVal(float64(vals[0]/time.Second)), svcNum-1)
 			} else {
 				for i, val := range vals {
-					doAdd(floatVal(float64(val/time.Second)), uint16(i))
+					if m.Valid[i] {
+						doAdd(floatVal(float64(val/time.Second)), uint16(i))
+					}
 				}
 			}
 

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -42,9 +42,7 @@ type Counter[V Value] struct {
 func (c *Counter[V]) Increment() {
 	if idx, ok := c.svcIdx(); ok {
 		c.inc(&c.ts.value[idx])
-		if !c.ts.valid[idx].Load() {
-			c.ts.valid[idx].Store(true)
-		}
+		c.ts.valid[idx].Store(true)
 	}
 }
 
@@ -56,9 +54,7 @@ func (c *Counter[V]) Add(delta V) {
 	}
 	if idx, ok := c.svcIdx(); ok {
 		c.add(&c.ts.value[idx], delta)
-		if !c.ts.valid[idx].Load() {
-			c.ts.valid[idx].Store(true)
-		}
+		c.ts.valid[idx].Store(true)
 	}
 }
 
@@ -133,18 +129,14 @@ type Gauge[V Value] struct {
 func (g *Gauge[V]) Set(val V) {
 	if idx, ok := g.svcIdx(); ok {
 		g.set(&g.ts.value[idx], val)
-		if !g.ts.valid[idx].Load() {
-			g.ts.valid[idx].Store(true)
-		}
+		g.ts.valid[idx].Store(true)
 	}
 }
 
 func (g *Gauge[V]) Add(val V) {
 	if idx, ok := g.svcIdx(); ok {
 		g.add(&g.ts.value[idx], val)
-		if !g.ts.valid[idx].Load() {
-			g.ts.valid[idx].Store(true)
-		}
+		g.ts.valid[idx].Store(true)
 	}
 }
 

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -41,6 +41,9 @@ type Counter[V Value] struct {
 func (c *Counter[V]) Increment() {
 	if idx, ok := c.svcIdx(); ok {
 		c.inc(&c.ts.value[idx])
+		if idx != 0 {
+			c.ts.valid[idx] = true
+		}
 	}
 }
 
@@ -52,6 +55,9 @@ func (c *Counter[V]) Add(delta V) {
 	}
 	if idx, ok := c.svcIdx(); ok {
 		c.add(&c.ts.value[idx], delta)
+		if idx != 0 {
+			c.ts.valid[idx] = true
+		}
 	}
 }
 
@@ -126,12 +132,18 @@ type Gauge[V Value] struct {
 func (g *Gauge[V]) Set(val V) {
 	if idx, ok := g.svcIdx(); ok {
 		g.set(&g.ts.value[idx], val)
+		if idx != 0 {
+			g.ts.valid[idx] = true
+		}
 	}
 }
 
 func (g *Gauge[V]) Add(val V) {
 	if idx, ok := g.svcIdx(); ok {
 		g.add(&g.ts.value[idx], val)
+		if idx != 0 {
+			g.ts.valid[idx] = true
+		}
 	}
 }
 
@@ -210,11 +222,14 @@ func (m *metricInfo[V]) getTS(labels any) (ts *timeseries[V], setup bool) {
 
 	// Initialize the values if they haven't yet been set up.
 	if !setup {
-		n := m.reg.numSvcs
 		if m.svcNum > 0 {
-			n = 1
+			ts.value = make([]V, 1)
+			ts.valid = []bool{true}
+		} else {
+			n := m.reg.numSvcs
+			ts.value = make([]V, n)
+			ts.valid = make([]bool, n)
 		}
-		ts.value = make([]V, n)
 	}
 
 	return ts, setup

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -32,6 +32,7 @@ func (r *Registry) Collect() []CollectedMetric {
 				TimeSeriesID: val.id,
 				Labels:       val.labels,
 				Val:          val.value,
+				Valid:        val.valid,
 			})
 		case *timeseries[uint64]:
 			metrics = append(metrics, CollectedMetric{
@@ -39,6 +40,7 @@ func (r *Registry) Collect() []CollectedMetric {
 				TimeSeriesID: val.id,
 				Labels:       val.labels,
 				Val:          val.value,
+				Valid:        val.valid,
 			})
 		case *timeseries[float64]:
 			metrics = append(metrics, CollectedMetric{
@@ -46,6 +48,7 @@ func (r *Registry) Collect() []CollectedMetric {
 				TimeSeriesID: val.id,
 				Labels:       val.labels,
 				Val:          val.value,
+				Valid:        val.valid,
 			})
 		case *timeseries[*nativehist.Histogram]:
 			metrics = append(metrics, CollectedMetric{
@@ -53,6 +56,7 @@ func (r *Registry) Collect() []CollectedMetric {
 				TimeSeriesID: val.id,
 				Labels:       val.labels,
 				Val:          val.value,
+				Valid:        val.valid,
 			})
 		default:
 			panic(fmt.Sprintf("unhandled timeseries type %T", val))
@@ -81,6 +85,7 @@ type CollectedMetric struct {
 	TimeSeriesID uint64
 	Labels       []KeyValue
 	Val          any // []T where T is any of Value
+	Valid        []bool
 }
 
 type registryKey struct {
@@ -94,6 +99,7 @@ type timeseries[T any] struct {
 	init   initGate
 	labels []KeyValue
 	value  []T
+	valid  []bool
 }
 
 func (ts *timeseries[V]) setup(labels []KeyValue) {

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -85,7 +85,7 @@ type CollectedMetric struct {
 	TimeSeriesID uint64
 	Labels       []KeyValue
 	Val          any // []T where T is any of Value
-	Valid        []bool
+	Valid        []atomic.Bool
 }
 
 type registryKey struct {
@@ -99,7 +99,7 @@ type timeseries[T any] struct {
 	init   initGate
 	labels []KeyValue
 	value  []T
-	valid  []bool
+	valid  []atomic.Bool
 }
 
 func (ts *timeseries[V]) setup(labels []KeyValue) {


### PR DESCRIPTION
We currently don't keep track of which services have emitted metrics for metrics defined outside services.

This PR adds a `valid` slice to time series to keep track of which services have emitted metrics.