### PR TITLE
Export metrics only if set

### DIFF
--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -149,7 +149,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 		switch vals := m.Val.(type) {
 		case []float64:
 			if svcNum > 0 {
-				doAdd(floatVal(vals[0]), svcNum-1)
+				if m.Valid[0].Load() {
+					doAdd(floatVal(vals[0]), svcNum-1)
+				}
 			} else {
 				for i, val := range vals {
 					if m.Valid[i].Load() {
@@ -160,7 +162,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 
 		case []int64:
 			if svcNum > 0 {
-				doAdd(int64Val(vals[0]), svcNum-1)
+				if m.Valid[0].Load() {
+					doAdd(int64Val(vals[0]), svcNum-1)
+				}
 			} else {
 				for i, val := range vals {
 					if m.Valid[i].Load() {
@@ -171,7 +175,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 
 		case []uint64:
 			if svcNum > 0 {
-				doAdd(uint64Val(vals[0]), svcNum-1)
+				if m.Valid[0].Load() {
+					doAdd(uint64Val(vals[0]), svcNum-1)
+				}
 			} else {
 				for i, val := range vals {
 					if m.Valid[i].Load() {
@@ -182,7 +188,9 @@ func (x *Exporter) getMetricData(newCounterStart, endTime time.Time, collected [
 
 		case []time.Duration:
 			if svcNum > 0 {
-				doAdd(floatVal(float64(vals[0]/time.Second)), svcNum-1)
+				if m.Valid[0].Load() {
+					doAdd(floatVal(float64(vals[0]/time.Second)), svcNum-1)
+				}
 			} else {
 				for i, val := range vals {
 					if m.Valid[i].Load() {

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -218,7 +218,6 @@ func (m *metricInfo[V]) getTS(labels any) (ts *timeseries[V], setup bool) {
 		if m.svcNum > 0 {
 			ts.value = make([]V, 1)
 			ts.valid = make([]atomic.Bool, 1)
-			ts.valid[0].Store(true)
 		} else {
 			n := m.reg.numSvcs
 			ts.value = make([]V, n)


### PR DESCRIPTION
Currently, metrics defined within a service are exported even if they haven't been set by application code. This behavior leads to potentially confusing graphs when visualizing gauges.