### PR TITLE
ENC-1259: Make Runtime.DeployID overridable by ENV var

### DIFF
--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -40,7 +40,7 @@ type Runtime struct {
 	EnvName       string          `json:"env_name"`
 	EnvType       string          `json:"env_type"`
 	EnvCloud      string          `json:"env_cloud"`
-	DeployID      string          `json:"deploy_id"`
+	DeployID      string          `json:"deploy_id"` // Overridden by ENCORE_DEPLOY_ID env var if set
 	DeployedAt    time.Time       `json:"deploy_time"`
 	TraceEndpoint string          `json:"trace_endpoint,omitempty"`
 	AuthKeys      []EncoreAuthKey `json:"auth_keys,omitempty"`

--- a/runtime/appruntime/config/parse.go
+++ b/runtime/appruntime/config/parse.go
@@ -37,6 +37,10 @@ func ParseRuntime(s string) *Runtime {
 		log.Fatalln("encore runtime: fatal error: could not parse api base url from encore runtime config:", err)
 	}
 
+	if deployID := os.Getenv("ENCORE_DEPLOY_ID"); deployID != "" {
+		cfg.DeployID = deployID
+	}
+
 	return &cfg
 }
 


### PR DESCRIPTION
The runtime configuration on GCP is kept in a GCP secret manager secret to protect runtime secrets. We can avoid updating this secret unnecessarily by extracting the deploy_id as an env variable. 