### PR TITLE
Secret handling tweaks

### DIFF
--- a/cli/daemon/exec_script.go
+++ b/cli/daemon/exec_script.go
@@ -7,7 +7,6 @@ import (
 
 	"encr.dev/cli/daemon/run"
 	"encr.dev/internal/optracker"
-	"encr.dev/pkg/appfile"
 	daemonpb "encr.dev/proto/encore/daemon"
 )
 
@@ -18,11 +17,6 @@ func (s *Server) ExecScript(req *daemonpb.ExecScriptRequest, stream daemonpb.Dae
 	sendErr := func(err error) {
 		slog.Stderr(false).Write([]byte(err.Error() + "\n"))
 		streamExit(stream, 1)
-	}
-
-	// Prefetch secrets if the app is linked.
-	if appSlug, err := appfile.Slug(req.AppRoot); err == nil && appSlug != "" {
-		s.sm.Prefetch(appSlug)
 	}
 
 	app, err := s.apps.Track(req.AppRoot)

--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -12,7 +12,6 @@ import (
 	"encr.dev/cli/daemon/run"
 	"encr.dev/internal/optracker"
 	"encr.dev/internal/version"
-	"encr.dev/pkg/appfile"
 	daemonpb "encr.dev/proto/encore/daemon"
 )
 
@@ -28,11 +27,6 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 				Code: code,
 			}},
 		})
-	}
-
-	// Prefetch secrets if the app is linked.
-	if appSlug, err := appfile.Slug(req.AppRoot); err == nil && appSlug != "" {
-		s.sm.Prefetch(appSlug)
 	}
 
 	// ListenAddr should always be passed but guard against old clients.

--- a/cli/daemon/run/exec_script.go
+++ b/cli/daemon/run/exec_script.go
@@ -84,10 +84,7 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 	var secrets map[string]string
 	if usesSecrets(parse.Meta) {
 		jobs.Go("Fetching application secrets", true, 150*time.Millisecond, func(ctx context.Context) error {
-			if p.App.PlatformID() == "" {
-				return fmt.Errorf("the app defines secrets, but is not yet linked to encore.dev; link it with `encore app link` to use secrets")
-			}
-			data, err := mgr.Secret.Get(ctx, p.App, expSet)
+			data, err := mgr.Secret.Load(p.App).Get(ctx, expSet)
 			if err != nil {
 				return err
 			}

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -304,7 +304,9 @@ func (r *Run) buildAndStart(ctx context.Context, tracker *optracker.OpTracker) e
 	if usesSecrets(parse.Meta) {
 		jobs.Go("Fetching application secrets", true, 150*time.Millisecond, func(ctx context.Context) error {
 			if r.App.PlatformID() == "" {
-				return fmt.Errorf("the app defines secrets, but is not yet linked to encore.dev; link it with `encore app link` to use secrets")
+				// Not linked to the Encore Platform; do nothing.
+				// We'll log an error for missing secrets later.
+				return nil
 			}
 			data, err := r.Mgr.Secret.Get(ctx, r.App, expSet)
 			if err != nil {

--- a/cli/daemon/run/tests.go
+++ b/cli/daemon/run/tests.go
@@ -14,6 +14,7 @@ import (
 	encore "encore.dev"
 	"encore.dev/appruntime/config"
 	"encr.dev/cli/daemon/apps"
+	"encr.dev/cli/daemon/secret"
 	"encr.dev/cli/daemon/sqldb"
 	"encr.dev/compiler"
 	"encr.dev/internal/env"
@@ -38,6 +39,9 @@ type TestParams struct {
 	// It must be set.
 	Parse *parser.Result
 
+	// Secrets are the secrets to use.
+	Secrets *secret.LoadResult
+
 	// Args are the arguments to pass to "go test".
 	Args []string
 
@@ -56,7 +60,7 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 		return err
 	}
 
-	secretData, err := mgr.Secret.Get(ctx, params.App, expSet)
+	secretData, err := params.Secrets.Get(ctx, expSet)
 	if err != nil {
 		return err
 	}

--- a/cli/daemon/sqldb/db.go
+++ b/cli/daemon/sqldb/db.go
@@ -157,17 +157,16 @@ func (db *DB) EnsureRoles(ctx context.Context, roles ...Role) error {
 
 		// We've observed race conditions in Postgres to grant access. Retry a few times.
 		{
-			var lastErr error
+			var err error
 			for i := 0; i < 5; i++ {
-				_, err := adm.Exec(ctx, stmt)
+				_, err = adm.Exec(ctx, stmt)
 				if err == nil {
 					break
 				}
-				lastErr = err
 				db.log.Debug().Str("role", role.Username).Str("db", db.Name).Err(err).Msg("error granting role, retrying")
 				time.Sleep(250 * time.Millisecond)
 			}
-			if lastErr != nil {
+			if err != nil {
 				return fmt.Errorf("grant %s role %s: %v", role.Type, role.Username, err)
 			}
 		}

--- a/e2e-tests/app_test.go
+++ b/e2e-tests/app_test.go
@@ -81,7 +81,7 @@ func RunApp(c testing.TB, appRoot string, logger RunLogger, env []string) *RunAp
 	assertNil(err)
 
 	secrets := secret.New()
-	secretData, err := secrets.Get(ctx, app, expSet)
+	secretData, err := secrets.Load(app).Get(ctx, expSet)
 	assertNil(err)
 
 	p, err := run.StartProc(&StartProcParams{

--- a/runtime/appruntime/app/appinit/appinit.go
+++ b/runtime/appruntime/app/appinit/appinit.go
@@ -3,9 +3,7 @@
 package appinit
 
 import (
-	"fmt"
 	"io"
-	"os"
 
 	"encore.dev/appruntime/api"
 	"encore.dev/appruntime/app"
@@ -52,11 +50,7 @@ func init() {
 // LoadSecret loads the secret with the given key.
 // If it is not defined it logs a fatal error and exits the process.
 func LoadSecret(key string) string {
-	if val, ok := singleton.GetSecret(key); ok {
-		return val
-	}
-
-	fmt.Fprintln(os.Stderr, "encore: could not find secret", key)
-	os.Exit(2)
-	panic("unreachable")
+	return singleton.GetSecret(key)
 }
+
+var missingSecrets []string


### PR DESCRIPTION
This improves the user experience of using secrets in a few ways:

* Downgrades missing secrets in local dev to a warning instead of a fatal error
* Fixes the secret caching when setting a secret and immediately restarting `encore run`

It also fixes a small miscellaneous bug with sqldb role granting.