### PR TITLE
fix: use info for logging failed requests

### DIFF
--- a/runtime/appruntime/api/reqtrack.go
+++ b/runtime/appruntime/api/reqtrack.go
@@ -143,7 +143,7 @@ func (s *Server) finishRequest(resp *model.Response) {
 			req.Logger.Error().Err(resp.Err).Msg("auth handler failed")
 		default:
 			e := errs.Convert(resp.Err).(*errs.Error)
-			ev := req.Logger.Error()
+			ev := req.Logger.Info()
 			for k, v := range e.Meta {
 				ev = ev.Interface(k, v)
 			}


### PR DESCRIPTION
As we have tried to utilise logging more in our project, we have noticed that all failed request automatically are logged as errors by encore.

However, we find this a bit annoying as many failed requests are not really errors. Especially the `4XX` range are user errors, and logging them clutters the logs. We think it would make sense to give more logging control to the developers.

Example from our logs:

<img width="383" alt="image" src="https://user-images.githubusercontent.com/10176195/215135596-f105e507-8b47-4d4d-81d7-c5221b0772e0.png">


You might have better ideas or other opinions or there are more things that need changing in the codebase. So please feel free to do what you wish with this PR!