### PR TITLE
Rewrite placeholders when creating app

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/FlowDiagram/FlowDiagram.tsx
+++ b/cli/daemon/dash/dashapp/src/components/FlowDiagram/FlowDiagram.tsx
@@ -132,7 +132,7 @@ export const FlowDiagram: FC<Props> = ({ metaData }) => {
             const scaleX = parent.width / graphLayoutData.width!;
             const scaleY = parent.height / graphLayoutData.height!;
             let scale = scaleY > scaleX ? scaleX : scaleY;
-            scale = Math.min(scale, 2);
+            scale = Math.min(scale, 1.5) * 0.8;
 
             return (
               <Zoom<SVGSVGElement>


### PR DESCRIPTION
This adds support for defining examples with
placeholder values that are replaced on app
creation.