### PR TITLE
Support example.json to set initial secrets

### DIFF
--- a/cli/cmd/encore/app/create.go
+++ b/cli/cmd/encore/app/create.go
@@ -573,5 +573,5 @@ func parseExampleConfig(repoPath string) (cfg exampleConfig, exists bool) {
 }
 
 func exampleJSONPath(repoPath string) string {
-	return filepath.Join(repoPath, "example.json")
+	return filepath.Join(repoPath, "example-initial-setup.json")
 }

--- a/cli/daemon/secret/secret.go
+++ b/cli/daemon/secret/secret.go
@@ -74,16 +74,16 @@ func (mgr *Manager) Load(app *apps.Instance) *LoadResult {
 // For subsequent calls to Get (such as during live reload), it returns any
 // more recent data that has been subsequently cached.
 func (lr *LoadResult) Get(ctx context.Context, expSet *experiments.Set) (data *Data, err error) {
-	if lr.app.PlatformID() == "" {
-		return &Data{}, nil
-	}
-
 	defer func() {
 		if err == nil && experiments.LocalSecretsOverride.Enabled(expSet) {
 			// Return a new data object so we don't write the overrides to the cache.
 			data, err = applyLocalOverrides(lr.app, data)
 		}
 	}()
+
+	if lr == nil || lr.app.PlatformID() == "" {
+		return &Data{}, nil
+	}
 
 	// Fetch the initial result the first time.
 	err = lr.once.Do(func() error {

--- a/cli/internal/platform/api.go
+++ b/cli/internal/platform/api.go
@@ -16,7 +16,8 @@ import (
 )
 
 type CreateAppParams struct {
-	Name string `json:"name"`
+	Name           string `json:"name"`
+	InitialSecrets map[string]string
 }
 
 type App struct {


### PR DESCRIPTION
To improve the onboarding experience when
creating a new example app, support parsing
an `example.json` file in the newly created app
if it exists. Use that to set initial secrets on the
platform.