### PR TITLE
dashapp: fix 'copy as curl' without auth handler

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -697,10 +697,10 @@ export const copyAsCurlToClipboard = (options: {
     hasBody = !!bodyParams.length;
     processStruct(params, reqBody);
   }
-  const { authorization } = apiEncoding;
-  if (authorization.query_parameters?.length || authorization.header_parameters?.length) {
-    const queryParams = authorization.query_parameters ?? [];
-    const headerParams = authorization.header_parameters ?? [];
+  const { authorization: auth } = apiEncoding;
+  if (auth !== null && (auth.query_parameters?.length || auth.header_parameters?.length)) {
+    const queryParams = auth.query_parameters ?? [];
+    const headerParams = auth.header_parameters ?? [];
     processStruct([...queryParams, ...headerParams], authBody);
   }
 

--- a/cli/daemon/dash/dashapp/src/components/api/api.ts
+++ b/cli/daemon/dash/dashapp/src/components/api/api.ts
@@ -59,6 +59,6 @@ export interface ServiceEncoding {
 }
 
 export interface APIEncoding {
-  authorization: AuthEncoding;
+  authorization: AuthEncoding | null;
   services: ServiceEncoding[];
 }

--- a/cli/daemon/dash/dashapp/src/components/snippets/snippetData.tsx
+++ b/cli/daemon/dash/dashapp/src/components/snippets/snippetData.tsx
@@ -344,7 +344,7 @@ const pubSubSection: SnippetSection = {
   heading: "Pub/Sub",
   description: (
     <>
-      PubSub lets you build systems that communicate by broadcasting events asynchronously.
+      PubSub lets you build systems that communicate by broadcasting events asynchronously.{" "}
       {docLink("/primitives/pubsub")}
     </>
   ),
@@ -444,7 +444,7 @@ const cacheSection: SnippetSection = {
   heading: "Cache",
   description: (
     <>
-      Here are some snippets for using Encore's cache functionality.
+      Here are some snippets for using Encore's cache functionality.{" "}
       {docLink("/primitives/caching")}
     </>
   ),
@@ -557,7 +557,7 @@ const secretsSection: SnippetSection = {
   heading: "Secrets",
   description: (
     <>
-      Here are some snippets for using Encore's secrets management functionality.
+      Here are some snippets for using Encore's secrets management functionality.{" "}
       {docLink("/primitives/secrets")}
     </>
   ),
@@ -614,7 +614,7 @@ const configSection: SnippetSection = {
   heading: "Configuration",
   description: (
     <>
-      Here are some snippets for using Encore's config functionality.
+      Here are some snippets for using Encore's config functionality.{" "}
       {docLink("/primitives/config")}
     </>
   ),


### PR DESCRIPTION
The TypeScript code did not properly handle that the authorization encoding could be null.

Thanks Paul Smith for the bug report.