### PR TITLE
Tweaks to snippet page in local dev dash

### DIFF
--- a/cli/daemon/dash/dashapp/src/App.tsx
+++ b/cli/daemon/dash/dashapp/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import React, { FC, useEffect, useState } from "react";
+import { BrowserRouter as Router, Navigate, Route, Routes, useParams } from "react-router-dom";
 import Client from "~lib/client/client";
 import JSONRPCConn from "~lib/client/jsonrpc";
 import AppList from "~p/AppList";
@@ -7,7 +7,7 @@ import AppHome from "~p/AppHome";
 import { ConnContext } from "~lib/ctx";
 import AppAPI from "~p/AppAPI";
 import AppDiagram from "~p/AppDiagram";
-import { SnippetPage, SnippetContent } from "~p/SnippetPage";
+import { SnippetContent, SnippetPage } from "~p/SnippetPage";
 
 function App() {
   const [conn, setConn] = useState<JSONRPCConn | undefined>(undefined);
@@ -38,13 +38,21 @@ function App() {
     <ConnContext.Provider value={conn}>
       <Router>
         <Routes>
-          <Route path="/:appID/snippets" element={<SnippetPage />}>
-            <Route path=":slug" element={<SnippetContent />} />
-          </Route>
-          <Route path="/:appID/flow" element={<AppDiagram />} />
-          <Route path="/:appID/api" element={<AppAPI />} />
-          <Route path="/:appID/requests" element={<AppHome />} />
           <Route path="/" element={<AppList />} />
+
+          <Route path="/:appID">
+            <Route index element={<Redirect to="requests" />} />
+
+            <Route path="requests" element={<AppHome />} />
+
+            <Route path="snippets" element={<SnippetPage />}>
+              <Route path=":slug" element={<SnippetContent />} />
+            </Route>
+
+            <Route path="flow" element={<AppDiagram />} />
+
+            <Route path="api" element={<AppAPI />} />
+          </Route>
         </Routes>
       </Router>
     </ConnContext.Provider>
@@ -52,3 +60,8 @@ function App() {
 }
 
 export default App;
+
+const Redirect: FC<{ to: string }> = ({ to }) => {
+  const params = useParams<{ appID: string }>();
+  return <Navigate to={`/${params.appID}/${to}`} replace />;
+};

--- a/cli/daemon/dash/dashapp/src/App.tsx
+++ b/cli/daemon/dash/dashapp/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
           </Route>
           <Route path="/:appID/flow" element={<AppDiagram />} />
           <Route path="/:appID/api" element={<AppAPI />} />
-          <Route path="/:appID" element={<AppHome />} />
+          <Route path="/:appID/requests" element={<AppHome />} />
           <Route path="/" element={<AppList />} />
         </Routes>
       </Router>

--- a/cli/daemon/dash/dashapp/src/components/Nav.tsx
+++ b/cli/daemon/dash/dashapp/src/components/Nav.tsx
@@ -14,7 +14,7 @@ const menuItems: {
   external?: boolean;
   badge?: string;
 }[] = [
-  { href: "", name: "Requests" },
+  { href: "/requests", name: "Requests" },
   { href: "/api", name: "API Docs" },
   { href: "/flow", name: "Flow" },
   { href: "/snippets", name: "Snippets", badge: "New!" },

--- a/cli/daemon/dash/dashapp/src/components/snippets/Code.tsx
+++ b/cli/daemon/dash/dashapp/src/components/snippets/Code.tsx
@@ -28,7 +28,7 @@ const Code: FC<PropsWithChildren<{ lang: Language; rawContents: string }>> = ({
   }
 
   return (
-    <div className="relative h-full text-xs">
+    <div className="not-prose relative h-full text-xs">
       <pre className="h-full">
         <code
           className={

--- a/cli/daemon/dash/dashapp/src/components/snippets/snippetData.tsx
+++ b/cli/daemon/dash/dashapp/src/components/snippets/snippetData.tsx
@@ -190,7 +190,7 @@ CREATE TABLE todo_item (
       content: (
         <div className="space-y-5">
           <p>
-            One way of inserting data is with a helper function that uses the package function
+            One way of inserting data is with a helper function that uses the package function{" "}
             <code>sqldb.Exec</code>:
           </p>
           <Code
@@ -239,8 +239,7 @@ err := sqldb.QueryRow(ctx, \`
           <p>
             <b>Hint:</b> If <code>sqldb.QueryRow</code> does not find a matching row, it reports an
             error that can be checked against by importing the standard library <code>errors</code>{" "}
-            package and calling
-            <code>errors.Is(err, sqldb.ErrNoRows)</code>.
+            package and calling <code>errors.Is(err, sqldb.ErrNoRows)</code>.
           </p>
         </div>
       ),
@@ -356,7 +355,7 @@ const pubSubSection: SnippetSection = {
   heading: "Pub/Sub",
   description: (
     <>
-      PubSub lets you build systems that communicate by broadcasting events asynchronously.
+      PubSub lets you build systems that communicate by broadcasting events asynchronously.{" "}
       {docLink("/primitives/pubsub")}
     </>
   ),
@@ -456,7 +455,7 @@ const cacheSection: SnippetSection = {
   heading: "Cache",
   description: (
     <>
-      Here are some snippets for using Encore's cache functionality.
+      Here are some snippets for using Encore's cache functionality.{" "}
       {docLink("/primitives/caching")}
     </>
   ),
@@ -490,7 +489,7 @@ var MyCacheCluster = cache.NewCluster("my-cache-cluster", cache.ClusterConfig{
       heading: "Use basic keyspaces",
       content: (
         <>
-          <div className="mb-5 flex flex-col gap-5">
+          <div className="mb-5">
             <p>
               Encore comes with a full suite of keyspace types, each with a wide variety of cache
               operations. Basic keyspace types include{" "}
@@ -569,7 +568,7 @@ const secretsSection: SnippetSection = {
   heading: "Secrets",
   description: (
     <>
-      Here are some snippets for using Encore's secrets management functionality.
+      Here are some snippets for using Encore's secrets management functionality.{" "}
       {docLink("/primitives/secrets")}
     </>
   ),
@@ -626,7 +625,7 @@ const configSection: SnippetSection = {
   heading: "Configuration",
   description: (
     <>
-      Here are some snippets for using Encore's config functionality.
+      Here are some snippets for using Encore's config functionality.{" "}
       {docLink("/primitives/config")}
     </>
   ),

--- a/cli/daemon/dash/dashapp/src/components/snippets/snippetData.tsx
+++ b/cli/daemon/dash/dashapp/src/components/snippets/snippetData.tsx
@@ -50,9 +50,21 @@ const apiSection: SnippetSection = {
         <Code
           lang="go"
           rawContents={`
+import "context"
+
+// PingParams is the request data for the Ping endpoint.
+type PingParams struct {
+    Name string
+}
+
+// PingResponse is the response data for the Ping endpoint.
+type PingResponse struct {
+    Message string
+}
+
 //encore:api public method=POST path=/ping
 func Ping(ctx context.Context, params *PingParams) (*PingResponse, error) {
-    msg := fmt.Sprintf("Hello, %s!", params.Name)
+    msg := "Hello, " + params.Name
     return &PingResponse{Message: msg}, nil
 }
 `.trim()}

--- a/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
@@ -1,10 +1,9 @@
-import { HomeIcon } from "@heroicons/react/20/solid";
-import React, { FunctionComponent } from "react";
+import React, { FC, FunctionComponent } from "react";
 import { Link, Outlet, useParams } from "react-router-dom";
 import { NavHashLink } from "~c/HashLink";
-import { icons } from "~c/icons";
 import Nav from "~c/Nav";
 import { snippetData, SnippetSection } from "~c/snippets/snippetData";
+import { CircleStackIcon, QuestionMarkCircleIcon } from "@heroicons/react/24/solid";
 
 const getAnchorFromHeader = (header: string) => header.toLowerCase().split(" ").join("-");
 
@@ -70,21 +69,31 @@ export const SnippetPage: FunctionComponent = () => {
                       {snippetData.map((section) => {
                         const Icon = section.icon;
                         return (
-                          <Link to={section.slug} className="group relative block">
-                            <div className="absolute inset-0 -z-10 bg-black dark:bg-white"></div>
-                            <div className="relative min-h-full border border-black bg-white p-8 transition-transform duration-100 ease-in-out group-hover:-translate-x-2 group-hover:-translate-y-2 group-active:-translate-x-2 group-active:-translate-y-2 dark:border-white dark:bg-black mobile:p-4">
-                              <div className="flex items-center justify-between">
-                                <h3 className="text-lg font-medium">{section.heading}</h3>
-                                <Icon className="-mt-2 h-8 w-8" />
-                              </div>
-                              <p className="mt-2">
-                                Learn about what problems Encore solves and the philosophy behind
-                                it.
-                              </p>
-                            </div>
+                          <Link
+                            key={section.slug}
+                            to={section.slug}
+                            className="group relative block"
+                          >
+                            <OverviewCard
+                              heading={section.heading}
+                              description="Learn about what problems Encore solves and the philosophy behind it."
+                              icon={section.icon}
+                            />
                           </Link>
                         );
                       })}
+                      <a
+                        target="_blank"
+                        href="https://encoredev.slack.com/app_redirect?channel=CQFNUESN9"
+                        className="group relative block"
+                      >
+                        <OverviewCard
+                          heading="Something missing?"
+                          description="Are you missing a snippet that would be useful to you? Let us know about
+                            it!"
+                          icon={QuestionMarkCircleIcon}
+                        />
+                      </a>
                     </div>
                   </div>
                 )}
@@ -93,6 +102,23 @@ export const SnippetPage: FunctionComponent = () => {
           </div>
         </div>
       </section>
+    </>
+  );
+};
+
+const OverviewCard: FC<{ heading: string; description: string; icon: typeof CircleStackIcon }> = (
+  props
+) => {
+  return (
+    <>
+      <div className="absolute inset-0 -z-10 bg-black dark:bg-white"></div>
+      <div className="relative min-h-full border border-black bg-white p-8 transition-transform duration-100 ease-in-out group-hover:-translate-x-2 group-hover:-translate-y-2 group-active:-translate-x-2 group-active:-translate-y-2 dark:border-white dark:bg-black mobile:p-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-medium">{props.heading}</h3>
+          <props.icon className="-mt-2 h-8 w-8" />
+        </div>
+        <p className="mt-2">{props.description}</p>
+      </div>
     </>
   );
 };

--- a/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
@@ -105,7 +105,7 @@ export const SnippetContent: FunctionComponent = () => {
   return (
     <div className="max-w-4xl">
       <h1 className="mb-5 flex items-center gap-4 text-3xl">{section.heading}</h1>
-      {section.description && <div className="mb-8">{section.description}</div>}
+      {section.description && <div className="prose mb-8 max-w-full">{section.description}</div>}
 
       <div className="space-y-10 pb-10">
         {section.subSections.map((section) => (
@@ -113,7 +113,7 @@ export const SnippetContent: FunctionComponent = () => {
             <h2 className="mb-4 text-2xl" id={getAnchorFromHeader(section.heading)}>
               {section.heading}
             </h2>
-            {section.content}
+            <div className="prose max-w-full">{section.content}</div>
           </div>
         ))}
       </div>

--- a/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
@@ -46,7 +46,7 @@ export const SnippetPage: FunctionComponent = () => {
                             pathname: `/${appID}/snippets/${section.slug}`,
                             hash: `#${getAnchorFromHeader(subSection.heading)}`,
                           }}
-                          className="block py-1 pl-4 focus:outline-none"
+                          className="block py-1 pl-4 focus:outline-none hover:bg-white hover:bg-opacity-10"
                         >
                           {subSection.heading}
                         </NavHashLink>

--- a/cli/daemon/dash/dashapp/tailwind.config.js
+++ b/cli/daemon/dash/dashapp/tailwind.config.js
@@ -188,12 +188,24 @@ module.exports = {
       typography: (theme) => ({
         DEFAULT: {
           css: {
+            "code::before": false,
+            "code::after": false,
+            code: {
+              fontWeight: "400",
+              borderRadius: "4px",
+              borderWidth: "1px",
+              borderColor: "#11111199",
+              paddingLeft: "4px",
+              paddingRight: "4px",
+              paddingTop: "1px",
+              paddingBottom: "2px",
+            },
             "--tw-prose-pre-bg": theme("colors.black"),
             "--tw-prose-body": theme("colors.black"),
             "--tw-prose-pre-code": theme("colors.white"),
             "--tw-prose-bullets": theme("colors.black"),
 
-            a: { textDecoration: "none" },
+            a: {textDecoration: "none"},
             li: {},
           },
         },


### PR DESCRIPTION
## What
* Make the inline code blocks look like in the encore.dev/docs
* Fix nav bar active styling by adding a unique path name to the index page (API explorer)
* Encourage users to suggest new snippets by adding a link to slack   
* Add hover styling to menu items