### PR TITLE
Add setting for enabling cgo in `encore.app`

### DIFF
--- a/docs/docs.cue
+++ b/docs/docs.cue
@@ -133,6 +133,7 @@ sections: [
 			{title: "Integrate with GitHub", segment: "github"},
 			{title: "Migrate an existing backend to Encore", segment: "migrate-to-encore"},
 			{title: "Migrate away from Encore", segment: "migrate-away"},
+			{title: "Build with cgo", segment: "cgo"},
 		]
 	},
 	{

--- a/docs/how-to/cgo.md
+++ b/docs/how-to/cgo.md
@@ -1,0 +1,33 @@
+---
+seotitle: Build Go applications with cgo using Encore
+seodesc: Learn how to build Go applications with cgo using Encore
+title: Build with cgo
+---
+
+Cgo is a feature of the Go compiler that enables Go programs to interface
+with libraries written in other languages using C bindings.
+
+By default, for improved portability Encore builds applications with cgo support disabled.
+
+To enable cgo for your application, add `"cgo_enabled": true` to your `encore.app` file.
+
+For example:
+
+```json
+-- encore.app --
+{
+  "id": "my-app-id",
+  "cgo_enabled": true
+}
+```
+
+With this setting Encore's build system will compile the application using an Ubuntu builder image
+with gcc preinstalled.
+
+## Static linking
+
+To keep the resulting Docker images as minimal as possible, Encore compiles applications with static linking.
+This happens even with cgo enabled. As a result the cgo libraries you use must support static linking.
+
+In some cases, you may need to add additional linker flags to properly work with static linking of cgo libraries.
+See the [official cgo docs](https://pkg.go.dev/cmd/cgo) for more information on how to do this.

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -35,6 +35,9 @@ type File struct {
 	// Configure global CORS settings for the application which
 	// will be applied to all API gateways into the application.
 	GlobalCORS *CORS `json:"global_cors,omitempty"`
+
+	// CgoEnabled enables building with cgo.
+	CgoEnabled bool `json:"cgo_enabled,omitempty"`
 }
 
 type CORS struct {


### PR DESCRIPTION
We've had this as a server-enabled setting for some time,
but it's time to open it up and track it in the `encore.app` file.