### PR TITLE
Show trace logs as JSON 

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/app/AppTraces.tsx
+++ b/cli/daemon/dash/dashapp/src/components/app/AppTraces.tsx
@@ -108,7 +108,7 @@ export default class AppTraces extends React.Component<Props, State> {
                       <p className="text-gray-800 flex-1 truncate text-base font-medium">
                         {icon("h-4 w-4 inline-block mr-2", type)}
                         <a
-                          className="cursor-pointer brandient-5 link-brandient"
+                          className="cursor-pointer link-brandient"
                           onClick={() => this.setState({ selected: tr })}
                         >
                           <span>{endpoint}</span>
@@ -207,22 +207,22 @@ const TraceView: FC<TraceViewProps> = (props) => {
                   </>
                 )}
                 {tr.root?.ext_request_id && (
-                    <>
-                      <tr className="text-left font-normal">
-                        <th className="text-gray-400 pr-2 text-left text-sm font-light">External Request ID</th>
-                        <td className="font-mono">
-                          {tr.root.ext_request_id}
-                        </td>
-                      </tr>
-                    </>
+                  <>
+                    <tr className="text-left font-normal">
+                      <th className="text-gray-400 pr-2 text-left text-sm font-light">
+                        External Request ID
+                      </th>
+                      <td className="font-mono">{tr.root.ext_request_id}</td>
+                    </tr>
+                  </>
                 )}
                 {tr.root?.ext_correlation_id && (
                   <>
                     <tr className="text-left font-normal">
-                      <th className="text-gray-400 pr-2 text-left text-sm font-light">External Correlation ID</th>
-                      <td className="font-mono">
-                        {tr.root.ext_correlation_id}
-                      </td>
+                      <th className="text-gray-400 pr-2 text-left text-sm font-light">
+                        External Correlation ID
+                      </th>
+                      <td className="font-mono">{tr.root.ext_correlation_id}</td>
                     </tr>
                   </>
                 )}

--- a/cli/daemon/dash/dashapp/src/components/icons.tsx
+++ b/cli/daemon/dash/dashapp/src/components/icons.tsx
@@ -6,6 +6,26 @@ export type Icon =
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace icons {
+  export const collapseAll: Icon = (cls, title) => (
+    <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
+      {renderTitle(title)}
+      <path
+        strokeLinecap="round"
+        d="m16.698.125 1.724 1.724L9.5 10.775.577 1.849 2.301.125 9.5 7.327 16.698.125ZM2.301 23.874.578 22.151 9.5 13.225l8.922 8.926-1.724 1.723L9.5 16.673 2.3 23.873Z"
+      />
+    </svg>
+  );
+
+  export const expandAll: Icon = (cls, title) => (
+    <svg className={cls} fill="currentColor" viewBox="0 0 24 24">
+      {renderTitle(title)}
+      <path
+        strokeLinecap="round"
+        d="M2.302 10.775.578 9.052 9.5.126l8.923 8.926-1.724 1.723L9.5 3.574l-7.198 7.201ZM16.7 13.226l1.724 1.723-8.922 8.926L.58 14.949l1.724-1.723 7.198 7.201 7.199-7.201Z"
+      />
+    </svg>
+  );
+
   export const arrowRight: Icon = (cls, title) => (
     <svg className={cls} fill="none" stroke="currentColor" viewBox="0 0 35.7 16">
       {renderTitle(title)}


### PR DESCRIPTION
Copying over what is now live on app.encore.dev so that you can view trace logs as JSON and expand/collapse fields.

<img width="828" alt="Screenshot 2023-02-17 at 10 48 44" src="https://user-images.githubusercontent.com/1826823/219611560-4ff480f1-079d-4b84-966e-f596889fdc1a.png">

Also:
* Remove "view stack trace"-buttons as that functionality is not working at the moment (we will look into that)
* Fix flying link bug (https://encoredev.slack.com/archives/CQFNUESN9/p1675696000355489)