### PR TITLE
Show banner if websocket connection is inactive

### DIFF
--- a/cli/daemon/dash/dashapp/package-lock.json
+++ b/cli/daemon/dash/dashapp/package-lock.json
@@ -31,7 +31,8 @@
         "react-dom": "^18.2.0",
         "react-json-tree": "^0.17.0",
         "react-router-dom": "^6.3.0",
-        "react-router-hash-link": "^2.4.3"
+        "react-router-hash-link": "^2.4.3",
+        "reconnecting-websocket": "^4.4.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.18.10",
@@ -8732,6 +8733,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/reconnecting-websocket": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -16452,6 +16458,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "reconnecting-websocket": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
     },
     "redent": {
       "version": "3.0.0",

--- a/cli/daemon/dash/dashapp/package.json
+++ b/cli/daemon/dash/dashapp/package.json
@@ -33,7 +33,8 @@
     "react-dom": "^18.2.0",
     "react-json-tree": "^0.17.0",
     "react-router-dom": "^6.3.0",
-    "react-router-hash-link": "^2.4.3"
+    "react-router-hash-link": "^2.4.3",
+    "reconnecting-websocket": "^4.4.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.10",

--- a/cli/daemon/dash/dashapp/src/App.tsx
+++ b/cli/daemon/dash/dashapp/src/App.tsx
@@ -1,13 +1,21 @@
 import React, { FC, useEffect, useState } from "react";
-import { BrowserRouter as Router, Navigate, Route, Routes, useParams } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+  useParams,
+} from "react-router-dom";
 import Client from "~lib/client/client";
 import JSONRPCConn from "~lib/client/jsonrpc";
 import AppList from "~p/AppList";
 import AppHome from "~p/AppHome";
-import { ConnContext } from "~lib/ctx";
+import { ConnContext, useConn } from "~lib/ctx";
 import AppAPI from "~p/AppAPI";
 import AppDiagram from "~p/AppDiagram";
 import { SnippetContent, SnippetPage } from "~p/SnippetPage";
+import Nav from "~c/Nav";
 
 function App() {
   const [conn, setConn] = useState<JSONRPCConn | undefined>(undefined);
@@ -40,7 +48,7 @@ function App() {
         <Routes>
           <Route path="/" element={<AppList />} />
 
-          <Route path="/:appID">
+          <Route path="/:appID" element={<AppWrapper />}>
             <Route index element={<Redirect to="requests" />} />
 
             <Route path="requests" element={<AppHome />} />
@@ -64,4 +72,14 @@ export default App;
 const Redirect: FC<{ to: string }> = ({ to }) => {
   const params = useParams<{ appID: string }>();
   return <Navigate to={`/${params.appID}/${to}`} replace />;
+};
+
+const AppWrapper: FC = () => {
+  const conn = useConn();
+  return (
+    <>
+      <Nav conn={conn} />
+      <Outlet />
+    </>
+  );
 };

--- a/cli/daemon/dash/dashapp/src/pages/AppAPI.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/AppAPI.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { useParams } from "react-router-dom";
 import AppAPI from "~c/app/AppAPI";
-import Nav from "~c/Nav";
 import { useConn } from "~lib/ctx";
 
 const API: FunctionComponent = (props) => {
@@ -9,13 +8,9 @@ const API: FunctionComponent = (props) => {
   const { appID } = useParams<{ appID: string }>();
 
   return (
-    <>
-      <Nav />
-
-      <section className="flex flex-grow flex-col items-center">
-        <AppAPI appID={appID!} conn={conn} />
-      </section>
-    </>
+    <section className="flex flex-grow flex-col items-center">
+      <AppAPI appID={appID!} conn={conn} />
+    </section>
   );
 };
 

--- a/cli/daemon/dash/dashapp/src/pages/AppDiagram.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/AppDiagram.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import Nav from "~c/Nav";
 import { useConn } from "~lib/ctx";
 import { NotificationMsg } from "~lib/client/jsonrpc";
 import { ProcessReload } from "~lib/client/client";
@@ -33,12 +32,7 @@ const Diagram: FunctionComponent = () => {
   }, []);
 
   return (
-    <>
-      <Nav />
-      <div className="h-full-minus-nav w-full">
-        {metaData && <FlowDiagram metaData={metaData} />}
-      </div>
-    </>
+    <div className="h-full-minus-nav w-full">{metaData && <FlowDiagram metaData={metaData} />}</div>
   );
 };
 

--- a/cli/daemon/dash/dashapp/src/pages/AppHome.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/AppHome.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from "react";
 import { useParams } from "react-router-dom";
 import AppCaller from "~c/app/AppCaller";
 import AppTraces from "~c/app/AppTraces";
-import Nav from "~c/Nav";
 import { useConn } from "~lib/ctx";
 
 const AppHome: FunctionComponent = (props) => {
@@ -10,28 +9,24 @@ const AppHome: FunctionComponent = (props) => {
   const conn = useConn();
 
   return (
-    <>
-      <Nav />
-
-      <section className="bg-gray-200 flex flex-grow flex-col items-center py-6">
-        <div className="w-full px-4 md:px-10">
-          <div className="md:flex md:items-stretch">
-            <div className="min-w-0 flex-1 md:mr-8">
-              <h2 className="text-lg font-medium">API Explorer</h2>
-              <div className="mt-2 rounded-lg">
-                <AppCaller key={appID} appID={appID!} conn={conn} />
-              </div>
+    <section className="bg-gray-200 flex flex-grow flex-col items-center py-6">
+      <div className="w-full px-4 md:px-10">
+        <div className="md:flex md:items-stretch">
+          <div className="min-w-0 flex-1 md:mr-8">
+            <h2 className="text-lg font-medium">API Explorer</h2>
+            <div className="mt-2 rounded-lg">
+              <AppCaller key={appID} appID={appID!} conn={conn} />
             </div>
-            <div className="mt-4 min-w-0 flex-1 md:mt-0">
-              <h2 className="text-lg font-medium">Traces</h2>
-              <div className="mt-2 overflow-hidden rounded-lg">
-                <AppTraces key={appID} appID={appID!} conn={conn} />
-              </div>
+          </div>
+          <div className="mt-4 min-w-0 flex-1 md:mt-0">
+            <h2 className="text-lg font-medium">Traces</h2>
+            <div className="mt-2 overflow-hidden rounded-lg">
+              <AppTraces key={appID} appID={appID!} conn={conn} />
             </div>
           </div>
         </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 };
 

--- a/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
+++ b/cli/daemon/dash/dashapp/src/pages/SnippetPage.tsx
@@ -1,7 +1,6 @@
 import React, { FC, FunctionComponent } from "react";
 import { Link, Outlet, useParams } from "react-router-dom";
 import { NavHashLink } from "~c/HashLink";
-import Nav from "~c/Nav";
 import { snippetData, SnippetSection } from "~c/snippets/snippetData";
 import { CircleStackIcon, QuestionMarkCircleIcon } from "@heroicons/react/24/solid";
 
@@ -10,99 +9,91 @@ const getAnchorFromHeader = (header: string) => header.toLowerCase().split(" ").
 export const SnippetPage: FunctionComponent = () => {
   const { appID, slug } = useParams();
   return (
-    <>
-      <Nav />
-
-      <section className="flex flex-grow flex-col items-center">
-        <div className="flex min-h-0 w-full flex-1 flex-col overflow-auto">
-          <div className="flex min-w-0 flex-1 items-stretch overflow-auto">
-            <div className="h-full-minus-nav w-64 flex-shrink-0 overflow-auto bg-black text-white lg:flex lg:flex-col">
-              <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
-                {snippetData.map((section) => (
-                  <div key={section.heading}>
-                    <button
-                      type="button"
-                      className="flex w-full items-center px-2 py-1 text-left focus:outline-none"
-                    >
-                      <div className="flex flex-grow items-center">
-                        <div className="flex-grow font-semibold leading-5 text-white">
-                          <NavHashLink
-                            to={{
-                              pathname: `/${appID}/snippets/${section.slug}`,
-                            }}
-                          >
-                            {section.heading}
-                          </NavHashLink>
-                        </div>
-                      </div>
-                    </button>
-
-                    <div className="space-y-1 text-sm">
-                      {section.subSections.map((subSection) => (
+    <section className="flex flex-grow flex-col items-center">
+      <div className="flex min-h-0 w-full flex-1 flex-col overflow-auto">
+        <div className="flex min-w-0 flex-1 items-stretch overflow-auto">
+          <div className="h-full-minus-nav w-64 flex-shrink-0 overflow-auto bg-black text-white lg:flex lg:flex-col">
+            <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+              {snippetData.map((section) => (
+                <div key={section.heading}>
+                  <button
+                    type="button"
+                    className="flex w-full items-center px-2 py-1 text-left focus:outline-none"
+                  >
+                    <div className="flex flex-grow items-center">
+                      <div className="flex-grow font-semibold leading-5 text-white">
                         <NavHashLink
-                          key={subSection.heading}
                           to={{
                             pathname: `/${appID}/snippets/${section.slug}`,
-                            hash: `#${getAnchorFromHeader(subSection.heading)}`,
                           }}
-                          className="block py-1 pl-4 focus:outline-none hover:bg-white hover:bg-opacity-10"
                         >
-                          {subSection.heading}
+                          {section.heading}
                         </NavHashLink>
-                      ))}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className="flex h-full-minus-nav min-w-0 flex-1 flex-col overflow-auto">
-              <div className="min-h-0 flex-grow p-8 leading-6">
-                <Outlet />
-                {slug === undefined && (
-                  <div className="w-full max-w-5xl">
-                    <div className="mb-5">
-                      When you're familiar with how Encore works, you can simplify your development
-                      workflow by copy-pasting these examples. If you're looking for details on how
-                      Encore works, please refer to the relevant docs section.
-                    </div>
-                    <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
-                      {snippetData.map((section) => {
-                        const Icon = section.icon;
-                        return (
-                          <Link
-                            key={section.slug}
-                            to={section.slug}
-                            className="group relative block"
-                          >
-                            <OverviewCard
-                              heading={section.heading}
-                              description="Learn about what problems Encore solves and the philosophy behind it."
-                              icon={section.icon}
-                            />
-                          </Link>
-                        );
-                      })}
-                      <a
-                        target="_blank"
-                        href="https://encoredev.slack.com/app_redirect?channel=CQFNUESN9"
-                        className="group relative block"
+                  </button>
+
+                  <div className="space-y-1 text-sm">
+                    {section.subSections.map((subSection) => (
+                      <NavHashLink
+                        key={subSection.heading}
+                        to={{
+                          pathname: `/${appID}/snippets/${section.slug}`,
+                          hash: `#${getAnchorFromHeader(subSection.heading)}`,
+                        }}
+                        className="block py-1 pl-4 focus:outline-none hover:bg-white hover:bg-opacity-10"
                       >
-                        <OverviewCard
-                          heading="Something missing?"
-                          description="Are you missing a snippet that would be useful to you? Let us know about
-                            it!"
-                          icon={QuestionMarkCircleIcon}
-                        />
-                      </a>
-                    </div>
+                        {subSection.heading}
+                      </NavHashLink>
+                    ))}
                   </div>
-                )}
-              </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex h-full-minus-nav min-w-0 flex-1 flex-col overflow-auto">
+            <div className="min-h-0 flex-grow p-8 leading-6">
+              <Outlet />
+              {slug === undefined && (
+                <div className="w-full max-w-5xl">
+                  <div className="mb-5">
+                    When you're familiar with how Encore works, you can simplify your development
+                    workflow by copy-pasting these examples. If you're looking for details on how
+                    Encore works, please refer to the relevant docs section.
+                  </div>
+                  <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+                    {snippetData.map((section) => {
+                      const Icon = section.icon;
+                      return (
+                        <Link key={section.slug} to={section.slug} className="group relative block">
+                          <OverviewCard
+                            heading={section.heading}
+                            description="Learn about what problems Encore solves and the philosophy behind it."
+                            icon={section.icon}
+                          />
+                        </Link>
+                      );
+                    })}
+                    <a
+                      target="_blank"
+                      href="https://encoredev.slack.com/app_redirect?channel=CQFNUESN9"
+                      className="group relative block"
+                    >
+                      <OverviewCard
+                        heading="Something missing?"
+                        description="Are you missing a snippet that would be useful to you? Let us know about
+                            it!"
+                        icon={QuestionMarkCircleIcon}
+                      />
+                    </a>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </div>
-      </section>
-    </>
+      </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## What
* Adding banners under the nav bar to make it clear if the websocket connection to the daemon is not active or if you are viewing an app that is not currently running.

## Why
It has been reported a few times that it's frustrating when the websocket connection goes down and the user think it's a problem with the app. Also frustrating when daily jumping between multiple and apps and you are viewing an app in the front-end that is not currently running.

## Screenshots

**Banner when losing connection to the Encore daemon**
Which can happen if you put the computer into sleep mode and come back to the page later

<img width="1109" alt="Screenshot 2023-02-20 at 15 35 09" src="https://user-images.githubusercontent.com/1826823/220135670-017eaada-bb20-41f4-aaa2-315211e5eaa7.png">

**Banner the app you are viewing is not currently running**
Happens quite often when you are switching in between multiple apps, often takes a few sec to realize that the app is not running or that you are viewing the wrong app.

<img width="1110" alt="Screenshot 2023-02-20 at 15 35 32" src="https://user-images.githubusercontent.com/1826823/220135665-32dafda8-5931-4eba-8bd6-8f1f138605e8.png">
