### PR TITLE
Simple first pass on JSON-based metrics exporter

### DIFF
--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -276,6 +276,10 @@ func (mgr *Manager) generateConfig(p generateConfigParams) (*config.Runtime, err
 		return nil, errors.Wrap(err, "failed to get global CORS")
 	}
 
+	metricsConfig := &config.Metrics{
+		JSONBased: &config.JSONBasedMetricsProvider{},
+	}
+
 	return &config.Runtime{
 		AppID:           p.ConfigAppID,
 		AppSlug:         p.App.PlatformID(),
@@ -305,5 +309,6 @@ func (mgr *Manager) generateConfig(p generateConfigParams) (*config.Runtime, err
 			ExtraAllowedHeaders:            globalCORS.AllowHeaders,
 			AllowPrivateNetworkAccess:      true,
 		},
+		Metrics: metricsConfig,
 	}, nil
 }

--- a/runtime/appruntime/api/server.go
+++ b/runtime/appruntime/api/server.go
@@ -69,6 +69,7 @@ type Server struct {
 	rt             *reqtrack.RequestTracker
 	pc             *platform.Client // if nil, requests are not authenticated against platform
 	encoreMgr      *encore.Manager
+	registry       *metrics.Registry
 	requestsTotal  *metrics.CounterGroup[requestsTotalLabels, uint64]
 	clock          clock.Clock
 	rootLogger     zerolog.Logger
@@ -127,6 +128,7 @@ func NewServer(
 		pc:             pc,
 		rt:             rt,
 		encoreMgr:      encoreMgr,
+		registry:       reg,
 		requestsTotal:  requestsTotal,
 		clock:          clock,
 		rootLogger:     rootLogger,

--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -291,6 +291,7 @@ type Metrics struct {
 	CloudWatch         *AWSCloudWatchMetricsProvider  `json:"aws_cloud_watch,omitempty"`
 	LogsBased          *LogsBasedMetricsProvider      `json:"logs_based,omitempty"`
 	Prometheus         *PrometheusRemoteWriteProvider `json:"prometheus,omitempty"`
+	JSONBased          *JSONBasedMetricsProvider      `json:"json_based,omitempty"`
 }
 
 type GCPCloudMonitoringProvider struct {
@@ -321,3 +322,6 @@ type PrometheusRemoteWriteProvider struct {
 }
 
 type LogsBasedMetricsProvider struct{}
+
+type JSONBasedMetricsProvider struct {
+}

--- a/runtime/appruntime/metrics/json_based/json_based.go
+++ b/runtime/appruntime/metrics/json_based/json_based.go
@@ -1,0 +1,141 @@
+package json_based
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"encore.dev/appruntime/config"
+	"encore.dev/metrics"
+)
+
+func New(svcs []string, cfg *config.JSONBasedMetricsProvider, rootLogger zerolog.Logger) *Exporter {
+	return &Exporter{
+		svcs:       svcs,
+		cfg:        cfg,
+		rootLogger: rootLogger,
+	}
+}
+
+type Exporter struct {
+	svcs       []string
+	cfg        *config.JSONBasedMetricsProvider
+	rootLogger zerolog.Logger
+}
+
+// Can be easily marshaled into a reasonable JSON object
+type JSONMetrics struct {
+	Metrics []JSONMetric `json:"metrics"`
+}
+
+type Label map[string]string
+
+type JSONMetric struct {
+	Name   string  `json:"name"`
+	Type   string  `json:"type"`
+	Labels []Label `json:"labels"`
+	Value  any     `json:"value"`
+}
+
+func (x *Exporter) Shutdown(_ context.Context) {}
+
+func (x *Exporter) Export(ctx context.Context, collected []metrics.CollectedMetric) error {
+	// This is a no-op since there's currently no need to export JSON metrics;
+	// they're only emitted via an internal api endpoint in runtime/appruntime/api/encore_routes.go
+	return nil
+}
+
+// Use to export a slice of CollectedMetric into a shape that's useful when rendering
+// metrics into JSON. Marshalling the return value will result in nicely formatted JSON
+func (x *Exporter) GetMetricData(collected []metrics.CollectedMetric) JSONMetrics {
+	// This method is based largely on the prometheus.Exporter.getMetricData method.
+	// It handles the complexities of multi-value metrics and adding labels.
+	data := make([]JSONMetric, 0, len(collected))
+
+	doAdd := func(val float64, metricName string, metricType metrics.MetricType, baseLabels []Label, svcIdx uint16) {
+		labels := make([]Label, len(baseLabels))
+		copy(labels, baseLabels)
+		// If there are services for this exporter, add labels
+		if len(x.svcs) > 0 {
+			svcLabel := Label{"service": x.svcs[svcIdx]}
+			labels = append(labels, svcLabel)
+		}
+		data = append(data, JSONMetric{
+			Name:   metricName,
+			Type:   metricType.Name(),
+			Labels: labels,
+			Value:  val,
+		})
+	}
+
+	for _, m := range collected {
+		var labels []Label
+		if n := len(m.Labels); n > 0 {
+			labels = make([]Label, 0, n)
+			for _, label := range m.Labels {
+				l := Label{}
+				l[label.Key] = label.Value
+				labels = append(labels, l)
+			}
+		}
+
+		svcNum := m.Info.SvcNum()
+		switch vals := m.Val.(type) {
+		case []float64:
+			if svcNum > 0 {
+				if m.Valid[0].Load() {
+					doAdd(vals[0], m.Info.Name(), m.Info.Type(), labels, svcNum-1)
+				}
+			} else {
+				for i, val := range vals {
+					if m.Valid[i].Load() {
+						doAdd(val, m.Info.Name(), m.Info.Type(), labels, uint16(i))
+					}
+				}
+			}
+		case []int64:
+			if svcNum > 0 {
+				if m.Valid[0].Load() {
+					doAdd(float64(vals[0]), m.Info.Name(), m.Info.Type(), labels, svcNum-1)
+				}
+			} else {
+				for i, val := range vals {
+					if m.Valid[i].Load() {
+						doAdd(float64(val), m.Info.Name(), m.Info.Type(), labels, uint16(i))
+					}
+				}
+			}
+		case []uint64:
+			if svcNum > 0 {
+				if m.Valid[0].Load() {
+					doAdd(float64(vals[0]), m.Info.Name(), m.Info.Type(), labels, svcNum-1)
+				}
+			} else {
+				for i, val := range vals {
+					if m.Valid[i].Load() {
+						doAdd(float64(val), m.Info.Name(), m.Info.Type(), labels, uint16(i))
+					}
+				}
+			}
+		case []time.Duration:
+			if svcNum > 0 {
+				if m.Valid[0].Load() {
+					doAdd(float64(vals[0]/time.Second), m.Info.Name(), m.Info.Type(), labels, svcNum-1)
+				}
+			} else {
+				for i, val := range vals {
+					if m.Valid[i].Load() {
+						doAdd(float64(val/time.Second), m.Info.Name(), m.Info.Type(), labels, uint16(i))
+					}
+				}
+			}
+		default:
+			x.rootLogger.Error().Msgf("encore: internal error: unknown value type %T for metric %s",
+				m.Val, m.Info.Name())
+		}
+	}
+
+	return JSONMetrics{Metrics: data}
+
+}

--- a/runtime/appruntime/metrics/json_based/json_based_test.go
+++ b/runtime/appruntime/metrics/json_based/json_based_test.go
@@ -1,0 +1,160 @@
+package json_based
+
+import (
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"encore.dev/metrics"
+)
+
+type metricInfo struct {
+	name   string
+	typ    metrics.MetricType
+	svcNum uint16
+}
+
+func (m metricInfo) Name() string             { return m.name }
+func (m metricInfo) Type() metrics.MetricType { return m.typ }
+func (m metricInfo) SvcNum() uint16           { return m.svcNum }
+
+func TestGetMetricData(t *testing.T) {
+	now := time.Now()
+	svcs := []string{"foo", "bar"}
+	tests := []struct {
+		name   string
+		metric metrics.CollectedMetric
+		data   JSONMetrics
+	}{
+		{
+			name: "counter",
+			metric: metrics.CollectedMetric{
+				Info: metricInfo{"test_counter", metrics.CounterType, 1},
+				Val:  []int64{10},
+				Valid: func() []atomic.Bool {
+					valid := make([]atomic.Bool, 1)
+					valid[0].Store(true)
+					return valid
+				}(),
+			},
+			data: JSONMetrics{
+				Metrics: []JSONMetric{
+					{
+						Name: "test_counter",
+						Type: "Counter",
+						Labels: []Label{
+							{
+								"service": "foo",
+							},
+						},
+						Value: float64(10),
+					},
+				},
+			},
+		},
+		{
+			name: "gauge",
+			metric: metrics.CollectedMetric{
+				Info: metricInfo{"test_gauge", metrics.GaugeType, 2},
+				Val:  []float64{0.5},
+				Valid: func() []atomic.Bool {
+					valid := make([]atomic.Bool, 1)
+					valid[0].Store(true)
+					return valid
+				}(),
+			},
+			data: JSONMetrics{
+				Metrics: []JSONMetric{
+					{
+						Name: "test_gauge",
+						Type: "Gauge",
+						// Labels: []Label{},
+						Labels: []Label{
+							{
+								"service": "bar",
+							},
+						},
+						Value: 0.5,
+					},
+				},
+			},
+		},
+		{
+			name: "labels",
+			metric: metrics.CollectedMetric{
+				Info:   metricInfo{"test_labels", metrics.GaugeType, 1},
+				Labels: []metrics.KeyValue{{"key", "value"}},
+				Val:    []float64{-1.5},
+				Valid: func() []atomic.Bool {
+					valid := make([]atomic.Bool, 1)
+					valid[0].Store(true)
+					return valid
+				}(),
+			},
+			data: JSONMetrics{
+				Metrics: []JSONMetric{
+					{
+						Name: "test_labels",
+						Type: "Gauge",
+						Labels: []Label{
+							{
+								"key": "value",
+							},
+							{
+								"service": "foo",
+							},
+						},
+						Value: float64(-1.5),
+					},
+				},
+			},
+		},
+		{
+			name: "multiple services",
+			metric: metrics.CollectedMetric{
+				Info: metricInfo{"test_counter", metrics.CounterType, 0},
+				Val:  []int64{1, 1},
+				Valid: func() []atomic.Bool {
+					valid := make([]atomic.Bool, 2)
+					valid[0].Store(true)
+					valid[1].Store(true)
+					return valid
+				}(),
+			},
+			data: JSONMetrics{
+				Metrics: []JSONMetric{
+					{
+						Name: "test_counter",
+						Type: "Counter",
+						Labels: []Label{
+							{
+								"service": "foo",
+							},
+						},
+						Value: float64(1),
+					},
+					{
+						Name: "test_counter",
+						Type: "Counter",
+						Labels: []Label{
+							{
+								"service": "bar",
+							},
+						},
+						Value: float64(1),
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			x := &Exporter{svcs: svcs}
+			got := x.GetMetricData(now, []metrics.CollectedMetric{test.metric})
+			if !reflect.DeepEqual(got, test.data) {
+				t.Errorf("got %+v, want %+v", got, test.data)
+			}
+		})
+	}
+}

--- a/runtime/appruntime/metrics/json_metrics_exporter.go
+++ b/runtime/appruntime/metrics/json_metrics_exporter.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"encore.dev/appruntime/config"
+	"encore.dev/appruntime/metrics/json_based"
+)
+
+func init() {
+	registerProvider(providerDesc{
+		name: "json_based",
+		matches: func(cfg *config.Metrics) bool {
+			return cfg.JSONBased != nil
+		},
+		newExporter: func(m *Manager) exporter {
+			return json_based.New(m.cfg.Static.BundledServices, m.cfg.Runtime.Metrics.JSONBased, m.rootLogger)
+		},
+	})
+}

--- a/runtime/metrics/registry_internal.go
+++ b/runtime/metrics/registry_internal.go
@@ -68,6 +68,21 @@ func (r *Registry) Collect() []CollectedMetric {
 
 type MetricType int
 
+// Converts MetricType enum values into their common English names
+func (mt MetricType) Name() string {
+	switch mt {
+	case CounterType:
+		return "Counter"
+	case GaugeType:
+		return "Gauge"
+	case HistogramType:
+		return "Historgram"
+	default:
+		return "Unknown"
+	}
+
+}
+
 const (
 	CounterType MetricType = iota
 	GaugeType


### PR DESCRIPTION
This PR was a result of asking the Encore team if there was a way to view metrics locally during development. The answer was "not yet", so I asked if they could provide some direction so that I could help get this implemented. @campesel gave some guidance, so here's a pull request as promised.

This also adds a development-only route at /__encore/metrics that renders the result of this exporter. This page will now render JSON response that look something like this:

```json
{
  "metrics": [
    {
      "name": "orders_processed",
      "type": "Counter",
      "labels": [],
      "value": 12
    },
    {
      "name": "e_requests_total",
      "type": "Counter",
      "labels": [
        {
          "endpoint": "Index"
        },
        {
          "code": "ok"
        }
      ],
      "value": 2
    }
  ]
}
```

Initially I wrote this just a few functions in the `runtime/appruntime/api/encore_routes.go` file, but it was clear that I was mimicking a lot of the functionality in the existing metrics exporters, and there was no simple, obvious (to me at least) place to test this if it was defined in `runtime/appruntime/api/encore_routes.go`, so I rewrote this to be a new exporter called `JSONBased`, following the existing patterns. 

I borrowed the tests from `runtime/appruntime/metrics/prometheus/prometheus_test.go` and adjusted them based on the shape of the JSON that @campesel requested. This was helpful since there were lots of little details I would have missed. I ended up borrowing heavily from the `getMetricData` in the `runtime/appruntime/metrics/prometheus/prometheus.go`.

This is enabled in development mode only (so far as I can understand) via a new field on `config.Config.Metrics`, but I believe it would be possible to enable this is non-local environments if desired.

I'm still a Golang rookie and I'm sure I've made some rookie mistakes here, so please don't hold back on feedback. Additionally, if the exporter-based approach is wrong, I'm happy to scrap this and take another approach. Cheers! 🤠
