### PR TITLE
Push CPU usage

### DIFF
--- a/runtime/appruntime/metrics/aws/cloudwatch.go
+++ b/runtime/appruntime/metrics/aws/cloudwatch.go
@@ -5,6 +5,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"runtime"
 	gometrics "runtime/metrics"
 	"sync"
 	"time"
@@ -165,6 +166,10 @@ func (x *Exporter) getSysMetrics(now time.Time) []types.MetricDatum {
 		default:
 			x.rootLogger.Warn().Str("metric_name", sysMetric.Sample.Name).Msg("internal: unexpected metric kind")
 			continue
+		}
+
+		if sysMetric.EncoreName == system.MetricNameTotalCPUSeconds {
+			*val /= float64(runtime.NumCPU())
 		}
 
 		output = append(output, types.MetricDatum{

--- a/runtime/appruntime/metrics/gcp/cloud_monitoring.go
+++ b/runtime/appruntime/metrics/gcp/cloud_monitoring.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"runtime"
 	gometrics "runtime/metrics"
 	"sync"
 	"time"
@@ -346,6 +347,11 @@ func (x *Exporter) getSysMetrics(now time.Time) []*monitoringpb.TimeSeries {
 				}},
 			})
 		case gometrics.KindFloat64:
+			val := sysMetric.Sample.Value.Float64()
+			if sysMetric.EncoreName == system.MetricNameTotalCPUSeconds {
+				val /= float64(runtime.NumCPU())
+			}
+
 			output = append(output, &monitoringpb.TimeSeries{
 				MetricKind: metricKind,
 				Metric: &metricpb.Metric{
@@ -355,7 +361,7 @@ func (x *Exporter) getSysMetrics(now time.Time) []*monitoringpb.TimeSeries {
 				Resource: monitoredResource,
 				Points: []*monitoringpb.Point{{
 					Interval: interval,
-					Value:    floatVal(sysMetric.Sample.Value.Float64()),
+					Value:    floatVal(val),
 				}},
 			})
 		default:

--- a/runtime/appruntime/metrics/prometheus/prometheus.go
+++ b/runtime/appruntime/metrics/prometheus/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime"
 	gometrics "runtime/metrics"
 	"time"
 
@@ -181,6 +182,10 @@ func (x *Exporter) getSysMetrics(now time.Time) []*prompb.TimeSeries {
 		default:
 			x.rootLogger.Warn().Str("metric_name", sysMetric.Sample.Name).Msg("internal: unexpected metric kind")
 			continue
+		}
+
+		if sysMetric.EncoreName == system.MetricNameTotalCPUSeconds {
+			val /= float64(runtime.NumCPU())
 		}
 
 		output = append(output, &prompb.TimeSeries{


### PR DESCRIPTION
Adds the `/cpu/classes/total:cpu-seconds` metric exposed by the Go standard library to the list of system metrics exported by Encore.