### PR TITLE
cors: support globs in allowed origins

### DIFF
--- a/runtime/appruntime/config/config.go
+++ b/runtime/appruntime/config/config.go
@@ -78,6 +78,9 @@ type CORS struct {
 	// that include credentials. If a request is made from an Origin in this list
 	// Encore responds with Access-Control-Allow-Origin: <Origin>.
 	// If DisableCredentials is true this field is not used.
+	//
+	// The URLs in this list may include wildcards (e.g. "https://*.example.com"
+	// or "https://*-myapp.example.com").
 	AllowOriginsWithCredentials []string `json:"allow_origins_with_credentials,omitempty"`
 
 	// AllowOriginsWithoutCredentials specifies the allowed origins for requests

--- a/runtime/appruntime/cors/cors_test.go
+++ b/runtime/appruntime/cors/cors_test.go
@@ -46,6 +46,22 @@ func TestOptions(t *testing.T) {
 			nocredsBadOrigins:  []string{},
 		},
 		{
+			name: "allowed_glob_creds",
+			cfg: config.CORS{
+				AllowOriginsWithCredentials: []string{"https://*.example.com", "wss://ok1-*.example.com", "https://*-ok2.example.com"},
+			},
+			credsGoodOrigins: []string{"https://foo.example.com", "wss://ok1-foo.example.com", "https://foo-ok2.example.com"},
+			credsBadOrigins: []string{
+				"http://foo.example.com",   // Wrong scheme
+				"htts://.example.com",      // No subdomain
+				"ws://ok1-foo.example.com", // Wrong scheme
+				".example.com",             // No scheme
+				"https://evil.com",         // bad domain
+			},
+			nocredsGoodOrigins: []string{},
+			nocredsBadOrigins:  []string{},
+		},
+		{
 			name: "allowed_nocreds",
 			cfg: config.CORS{
 				AllowOriginsWithoutCredentials: []string{"localhost", "ok.org"},
@@ -190,12 +206,12 @@ func TestOptions(t *testing.T) {
 			checkOrigins(t, c, false, false, tt.nocredsBadOrigins)
 
 			// Only good headers should always be ok
-			checkHeaders(t, c, tt.goodHeaders, true)
+			checkHeaders(t, c, tt.goodHeaders, nil, true)
 
 			// Make sure all the bad headers are invalid, one by one
 			for _, vad := range tt.badHeaders {
 				headers := append(tt.goodHeaders, vad)
-				checkHeaders(t, c, headers, false)
+				checkHeaders(t, c, headers, nil, false)
 			}
 		})
 	}


### PR DESCRIPTION
It's quite common to want to allow-list many origins that match a pattern. A common use case is all Vercel Preview Environments with a certain URL pattern.

This extends our CORS handling to support glob matching on allowed origins.