### PR TITLE
Allow serving a root path

### DIFF
--- a/parser/paths/paths.go
+++ b/parser/paths/paths.go
@@ -105,7 +105,8 @@ func (t Type) SupportsWildcards() bool {
 }
 
 // Parse parses a slash-separated path into path segments.
-func Parse(pos token.Pos, path string, typ Type) (*Path, error) {
+func Parse(pos token.Pos, initialPath string, typ Type) (*Path, error) {
+	path := initialPath
 	leadingSlash := typ.LeadingSlash()
 	if path == "" {
 		return nil, errors.New("empty path")
@@ -158,7 +159,7 @@ func Parse(pos token.Pos, path string, typ Type) (*Path, error) {
 	for i, s := range segs {
 		switch s.Type {
 		case Literal:
-			if s.Value == "" {
+			if s.Value == "" && initialPath != "/" {
 				return nil, fmt.Errorf("path cannot contain trailing slash")
 			}
 		case Param:

--- a/parser/paths/paths_test.go
+++ b/parser/paths/paths_test.go
@@ -17,6 +17,7 @@ func TestParseURL(t *testing.T) {
 		Want []Segment
 		Err  string
 	}{
+		{"/", []Segment{{Literal, "", str}}, ""},
 		{"foo", nil, "path must begin with '/'"},
 		{"/foo", []Segment{{Literal, "foo", str}}, ""},
 		{"/foo/", nil, "path cannot contain trailing slash"},
@@ -94,6 +95,8 @@ func TestAdd(t *testing.T) {
 	}{
 		{"POST", "/foo", ``},
 		{"POST", "/foo", `.+ /foo and /foo: duplicate path`},
+		{"POST", "/", ``},
+		{"POST", "/", `.+ / and /: duplicate path`},
 		{"GET", "/foo", ``},
 		{"*", "/foo", `.+ /foo and /foo: duplicate path`},
 		{"*", "/bar", ``},


### PR DESCRIPTION
Hello there !

I'd like to have an endpoint serve things from the service's root path.

I'm totally hacking around things here, but I'd like to serve some HTML from that index, 'cause YOLO.

Basically I want to have everything runing in that encore server.