### PR TITLE
fix/errs-wrapCode

### DIFF
--- a/runtime/beta/errs/error.go
+++ b/runtime/beta/errs/error.go
@@ -91,7 +91,6 @@ func WrapCode(err error, code ErrCode, msg string, metaPairs ...interface{}) err
 	e := &Error{Code: code, Message: msg, underlying: err}
 	if ee, ok := err.(*Error); ok {
 		e.Details = ee.Details
-		e.Code = ee.Code
 		e.Meta = mergeMeta(ee.Meta, metaPairs)
 		e.stack = ee.stack
 	} else {


### PR DESCRIPTION
Fixes overriding of error code when using `WrapCode()`

I had thrown an error down in my service layer, and wanted to add `code` on the API layer.

Current Behavior

```go
if err != nil {
		return "", errs.WrapCode(err, errs.FailedPrecondition, "ErrorMsg: ")
}
```

which gives me the following response
```
HTTP 500 Internal Server Error: { "code": "unknown", "message": "ErrorMsg: : Message", "details": null }
```

Expected Behavior

The `code` should be defined