### PR TITLE
pgproxy: reject gssapi encryption

### DIFF
--- a/pkg/pgproxy/pgproxy.go
+++ b/pkg/pgproxy/pgproxy.go
@@ -411,7 +411,11 @@ StartupMessageLoop:
 			log.Debug().Msg("startup completed")
 			return backend, startup, nil
 		case *pgproto3.GSSEncRequest:
-			return nil, nil, fmt.Errorf("pgproxy: GSSAPI encryption not supported")
+			// We got a GSSAPI encryption request but we don't support it.
+			if _, err := client.Write([]byte{'N'}); err != nil {
+				return nil, nil, err
+			}
+			continue StartupMessageLoop
 		}
 	}
 }


### PR DESCRIPTION
`encore db shell` fails in some circumstances due to the client requesting GSSAPI encryption.

Properly reject this request so the client continues with authentication methods Encore supports.

Thanks Brian Hechinger for the report!