### PR TITLE
Fix v2 user facing code gen

### DIFF
--- a/v2/v2builder/v2builder.go
+++ b/v2/v2builder/v2builder.go
@@ -24,9 +24,11 @@ import (
 	"encr.dev/pkg/promise"
 	"encr.dev/pkg/vfs"
 	"encr.dev/v2/app"
+	"encr.dev/v2/app/apiframework"
 	"encr.dev/v2/app/legacymeta"
 	"encr.dev/v2/codegen"
 	"encr.dev/v2/codegen/apigen"
+	"encr.dev/v2/codegen/apigen/servicestructgen"
 	"encr.dev/v2/codegen/apigen/userfacinggen"
 	"encr.dev/v2/codegen/cuegen"
 	"encr.dev/v2/codegen/infragen"
@@ -35,6 +37,7 @@ import (
 	"encr.dev/v2/internals/perr"
 	"encr.dev/v2/internals/pkginfo"
 	"encr.dev/v2/parser"
+	"encr.dev/v2/parser/apis/servicestruct"
 	"encr.dev/v2/parser/resource"
 )
 
@@ -337,7 +340,12 @@ func (i BuilderImpl) GenUserFacing(ctx context.Context, p builder.GenUserFacingP
 			// Generate the user-facing Go code.
 			{
 				// Service structs are not needed if there is no implementation to be generated
-				svcStruct := option.None[*codegen.VarDecl]()
+				svcStruct := option.FlatMap(svc.Framework, func(fw *apiframework.ServiceDesc) option.Option[*codegen.VarDecl] {
+					return option.Map(fw.ServiceStruct, func(ss *servicestruct.ServiceStruct) *codegen.VarDecl {
+						return servicestructgen.Gen(gg, svc, ss)
+					})
+				})
+
 				if f, ok := userfacinggen.Gen(gg, svc, svcStruct, false).Get(); ok {
 					buf.Reset()
 					if err := f.Render(&buf); err != nil {


### PR DESCRIPTION
This commit fixes an issue where the `encore.gen.go` file would be empty when using the v2 parser. This was due to the `service struct` `VarDecl` being hard coded to none