### PR TITLE
Update zig

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,7 +51,7 @@ jobs:
     # for failures. We will also fail fast so that we don't waste time running tests
     # that are already failing.
     - name: Run all tests multiple times
-      run:  cd encr.dev && go test -v --count=25 -failfast -shuffle=on -tags=dev_build ./...
+      run:  cd encr.dev && go test -v --count=5 -failfast -shuffle=on -tags=dev_build ./...
       if:   github.event.schedule == '30 2 * * *'
       env:
         ENCORE_GOROOT: ${{ github.workspace }}/encore-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Zig
       uses: goto-bus-stop/setup-zig@v1
       with:
-        version: 0.9.1
+        version: 0.10.1
 
     - name: Install encore-go
       run: curl --fail -o encore-go.tar.gz -L https://github.com/encoredev/go/releases/download/${{ github.event.inputs.encorego_version }}/${{ matrix.release_key }}.tar.gz && tar -C ${{ github.workspace }} -xzf ./encore-go.tar.gz


### PR DESCRIPTION
We had an issue with our cross compile failing, because Zig was too old to understand a flag that go uses.

See ziglang/zig#11863