### PR TITLE
Bump GNU libc to 2.34

### DIFF
--- a/pkg/make-release/make-release.go
+++ b/pkg/make-release/make-release.go
@@ -74,13 +74,9 @@ func (b *Builder) BuildBinaries() error {
 	case b.GOOS == "linux" && b.GOARCH == "arm64":
 		// GitHub Actions doesn't have builders for linux/arm64 so we need to
 		// cross-compile. Unfortunately we need cgo for sqlite so use zig to do so.
-		mustWriteFile("/usr/local/bin/zcc", 0755,
-			"#!/bin/sh\nzig cc -Wl,--no-gc-sections -target aarch64-linux-gnu.2.28 $@")
-		mustWriteFile("/usr/local/bin/zxx", 0755,
-			"#!/bin/sh\nzig c++ -Wl,--no-gc-sections -target aarch64-linux-gnu.2.28 $@")
 		env = append(env,
-			"CC=/usr/local/bin/zcc",
-			"CXX=/usr/local/bin/zxx",
+			"CC=zig cc -Wl,--no-gc-sections -target aarch64-linux-gnu.2.34",
+			"CXX=zig c++ -Wl,--no-gc-sections -target aarch64-linux-gnu.2.34",
 		)
 	}
 


### PR DESCRIPTION
We updated to Go 1.20 with the v2 parser, and that now requires something a symbol `res_search` which was added in GNU libc 2.34 (released 2021-08-02).

Once bumped, the ARM64 linux build works again