### PR TITLE
codegen: fix appinit insertion logic

### DIFF
--- a/v2/codegen/gen.go
+++ b/v2/codegen/gen.go
@@ -118,7 +118,7 @@ func (g *Generator) InsertAppInit(pkg *pkginfo.Package) {
 	// Find the first non-test file if any; otherwise fall back to the first file.
 	var file *pkginfo.File
 	for _, f := range pkg.Files {
-		if f.TestFile {
+		if !f.TestFile {
 			file = f
 			break
 		}


### PR DESCRIPTION
The conditional was accidentally inverted, causing packages
whose first test file was an external package (foo_test.go)
to not be initialized correctly.

Thanks Emily Rymer for the report.