### PR TITLE
schemautil: fix infinite recursion

### DIFF
--- a/v2/codegen/cuegen/testdata/generic_named_types_svc.cue
+++ b/v2/codegen/cuegen/testdata/generic_named_types_svc.cue
@@ -41,6 +41,14 @@ package svc
 }
 #Config
 
+#List_string: [...string]
+
+// Generic option which can be disbaled
+#DisablableOption_uint64: {
+	Option:   uint64
+	Disabled: bool // True if this is disabled
+}
+
 // Generic option which can be disbaled
 #DisablableOption_uint16: {
 	Option:   uint16
@@ -50,12 +58,4 @@ package svc
 // A nice generic map
 #Map_string_string: {
 	[string]: string
-}
-
-#List_string: [...string]
-
-// Generic option which can be disbaled
-#DisablableOption_uint64: {
-	Option:   uint64
-	Disabled: bool // True if this is disabled
 }


### PR DESCRIPTION
For mutually recursive types we need to track
which declarations we've already seen.

Thanks Juan Álvarez for the report.