### PR TITLE
runtime: fix leveled logging for encore cloud

### DIFF
--- a/runtime/appruntime/app/app.go
+++ b/runtime/appruntime/app/app.go
@@ -182,7 +182,7 @@ func (app *App) ReconfigureZerologFormat() {
 	// mapCloudFieldNamesToExpected in cli/cmd/encore/logs.go
 	// as that reverses this for log streaming
 	switch app.cfg.Runtime.EnvCloud {
-	case cloud.GCP:
+	case cloud.GCP, cloud.Encore:
 		zerolog.LevelFieldName = "severity"
 		zerolog.TimestampFieldName = "timestamp"
 		zerolog.TimeFieldFormat = time.RFC3339Nano

--- a/runtime/appruntime/service/service.go
+++ b/runtime/appruntime/service/service.go
@@ -65,7 +65,7 @@ func doSetupService[T any](mgr *Manager, decl *Decl[T]) (err error) {
 
 	i, err := setupFn()
 	if err != nil {
-		mgr.rt.Logger().Error().Err(err).Str("service", decl.Name).Msg("service initialization failed")
+		mgr.rt.Logger().Error().Err(err).Str("service", decl.Service).Msg("service initialization failed")
 		return errs.B().Code(errs.Internal).Msg("service initialization failed").Err()
 	}
 	decl.instance = i


### PR DESCRIPTION
Since it's running on GCP under the hood it's easier
to unify how we process logs from GCP.