### PR TITLE
selector: fix computation when other is empty

### DIFF
--- a/v2/parser/apis/selector/selector.go
+++ b/v2/parser/apis/selector/selector.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	meta "encr.dev/proto/encore/parser/meta/v1"
 	"encr.dev/v2/internals/perr"
 )
@@ -173,6 +175,11 @@ func (s *Set) Contains(sel Selector) bool {
 // It compares in linear time O(N) where N is the number of selectors in the
 // larger set. It is faster than calling Contains for each selector in other.
 func (s *Set) ContainsAny(other Set) bool {
+	// If this set contains the "all" selector it always matches.
+	if slices.IndexFunc(s.vals, func(sel Selector) bool { return sel.Type == All }) != -1 {
+		return true
+	}
+
 	i, j := 0, 0
 	for i < len(s.vals) && j < len(other.vals) {
 		if s.vals[i].Equals(other.vals[j]) {

--- a/v2/parser/apis/selector/selector_test.go
+++ b/v2/parser/apis/selector/selector_test.go
@@ -1,0 +1,28 @@
+package selector
+
+import "testing"
+
+func TestSet_ContainsAny(t *testing.T) {
+	tests := []struct {
+		name  string
+		set   []Selector
+		input []Selector
+		want  bool
+	}{
+		{
+			name:  "empty_input",
+			set:   []Selector{{Type: All}},
+			input: nil,
+			want:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewSet(tt.set...)
+			in := NewSet(tt.input...)
+			if got := s.ContainsAny(in); got != tt.want {
+				t.Errorf("ContainsAny() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If the target set was empty the logic to check for the "all" selector did not run. Fix this by lifting the check out of the loop.

Thanks Patryk Siemiński for the report.