### PR TITLE
Add support for cookies in auth handlers

### DIFF
--- a/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
+++ b/cli/daemon/dash/dashapp/src/components/api/RPCCaller.tsx
@@ -125,7 +125,7 @@ const RPCCaller: FC<Props> = ({ md, apiEncoding, svc, rpc, conn, appID, addr }) 
     render.asResponse = false;
     render.typeArgumentStack.push(named.type_arguments);
     const structType = md.decls[named.id].type.struct!;
-    const [queryString, headers, js] = render.structBits(structType, false, true);
+    const [queryString, headers, cookies, js] = render.structBits(structType, false, true);
 
     const bits: string[] = ["{\n"];
     let previousSection = false;
@@ -139,6 +139,14 @@ const RPCCaller: FC<Props> = ({ md, apiEncoding, svc, rpc, conn, appID, addr }) 
       }
 
       bits.push("    // Query string", queryString);
+      previousSection = true;
+    }
+    if (cookies) {
+      if (previousSection) {
+        bits.push(",\n\n");
+      }
+
+      bits.push("    // Cookies", cookies);
       previousSection = true;
     }
     if (js) {

--- a/cli/daemon/dash/dashapp/src/components/api/schema.ts
+++ b/cli/daemon/dash/dashapp/src/components/api/schema.ts
@@ -16,6 +16,7 @@ export enum FieldLocation {
   Body = "JSON Payload",
   Header = "HTTP Header",
   Query = "Query String",
+  Cookie = "Cookies",
   UnusedField = "hidden",
 }
 
@@ -67,6 +68,13 @@ export function fieldNameAndLocation(
 
         return [tag.name, FieldLocation.Header];
 
+      case "cookie":
+        if (tag.name === "-") {
+          return ["-", FieldLocation.UnusedField];
+        }
+
+        return [tag.name, FieldLocation.Cookie];
+
       case "json":
         if (tag.name === "-") {
           return ["-", FieldLocation.UnusedField];
@@ -91,6 +99,8 @@ export function locationDescription(name: string, location: FieldLocation): stri
       return `"${name}" is sent as a HTTP Header`;
     case FieldLocation.Query:
       return `"${name}" is sent as a query string parameter`;
+    case FieldLocation.Cookie:
+      return `"${name}" is sent as a cookie`;
     default:
       return "";
   }
@@ -105,6 +115,7 @@ export function splitFieldsByLocation(
     [FieldLocation.Body]: [],
     [FieldLocation.Query]: [],
     [FieldLocation.Header]: [],
+    [FieldLocation.Cookie]: [],
     [FieldLocation.UnusedField]: [],
   };
 

--- a/parser/testdata/auth_handler_invalid_field_source.txt
+++ b/parser/testdata/auth_handler_invalid_field_source.txt
@@ -24,8 +24,8 @@ func MyAuth(ctx context.Context, p *Params) (auth.UID, error) { return "", nil }
 
 ── Invalid auth payload ───────────────────────────────────────────────────────────────────[E9999]──
 
-All fields used within an auth payload must originate from either an HTTP header or a query
-parameter.
+All fields used within an auth payload must originate from either an HTTP header, a query
+parameter, or a cookie.
 
     ╭─[ svc/svc.go:10:5 ]
     │
@@ -33,17 +33,17 @@ parameter.
   9 │     Authorization string `header:"Authorization"`
  10 │     Foo string
     ⋮     ────┬─────
-    ⋮         ╰─ you must specify a "header" or "query" tag for this field
+    ⋮         ╰─ you must specify a "header", "query", or "cookie" tag for this field
  11 │     ClientID string `query:"client_id"`
  12 │     Bar int
     ⋮     ───┬───
-    ⋮        ╰─ you must specify a "header" or "query" tag for this field
+    ⋮        ╰─ you must specify a "header", "query", or "cookie" tag for this field
  13 │ }
  14 │
 ────╯
 
-You can specify them for each field using the struct tags, for example with `header:"X-My-Header"`
-or `query:"my-query"`.
+You can specify them for each field using the struct tags, for example with `header:"X-My-Header"`,
+`query:"my-query", or `cookie:"my-cookie"`.
 
 For more information on auth handlers and how to define them, see
 https://encore.dev/docs/develop/auth

--- a/runtime/appruntime/shared/etype/unmarshal.go
+++ b/runtime/appruntime/shared/etype/unmarshal.go
@@ -46,6 +46,13 @@ func UnmarshalList[T any](u *Unmarshaller, fn ElemUnmarshaller[T], field string,
 	return list
 }
 
+// IncNonEmpty increments the number of non-empty values this decoder has decoded.
+// It's useful when decoding something that doesn't go through the unmarshaller
+// but still was present, so that code that checks NonEmptyValues is correct.
+func (u *Unmarshaller) IncNonEmpty() {
+	u.NonEmptyValues++
+}
+
 // Unmarshaller is used to serialize request data into strings and deserialize response data from strings
 type Unmarshaller struct {
 	Error          error // The last error that occurred

--- a/v2/codegen/apigen/authhandlergen/authhandlergen.go
+++ b/v2/codegen/apigen/authhandlergen/authhandlergen.go
@@ -103,6 +103,7 @@ func renderDecodeAuth(gen *codegen.Generator, f *codegen.File, ah *authhandler.A
 		g.Add(dec.Init())
 		apigenutil.DecodeHeaders(g, Id("httpReq"), Id("params"), dec, enc.HeaderParameters)
 		apigenutil.DecodeQuery(g, Id("httpReq"), Id("params"), dec, enc.QueryParameters)
+		apigenutil.DecodeCookie(gen.Errs, g, Id("httpReq"), Id("params"), dec, enc.CookieParameters)
 
 		g.If(dec.NumNonEmptyValues().Op("==").Lit(0)).Block(
 			Return(gu.Zero(ah.Param), apigenutil.BuildErr("Unauthenticated", "missing auth param")),

--- a/v2/codegen/apigen/authhandlergen/testdata/struct.txt
+++ b/v2/codegen/apigen/authhandlergen/testdata/struct.txt
@@ -1,11 +1,14 @@
 -- code.go --
 package code
 
-import ("context"; "encore.dev/beta/auth")
+import ("context"; "net/http"; "encore.dev/beta/auth")
 
 type MyAuthParams struct {
 	ClientID string `header:"X-Client-ID"`
 	APIKey   string `query:"key"`
+	SessionToken string `cookie:"session_token"`
+	OtherCookie *http.Cookie `cookie:"other_cookie"`
+	IntCookie int `cookie:"int_cookie"`
 }
 
 //encore:authhandler
@@ -39,6 +42,18 @@ var EncoreInternal_authhandler_AuthDesc_AuthHandler = &__api.AuthHandlerDesc[*My
 		// Decode query string
 		qs := httpReq.URL.Query()
 		params.APIKey = __etype.UnmarshalOne(dec, __etype.UnmarshalString, "key", qs.Get("key"), false)
+
+		// Decode cookies
+		if c, _ := httpReq.Cookie("session_token"); c != nil {
+			params.SessionToken = __etype.UnmarshalOne(dec, __etype.UnmarshalString, "session_token", c.Value, false)
+		}
+		if c, _ := httpReq.Cookie("other_cookie"); c != nil {
+			params.OtherCookie = c
+			dec.IncNonEmpty()
+		}
+		if c, _ := httpReq.Cookie("int_cookie"); c != nil {
+			params.IntCookie = __etype.UnmarshalOne(dec, __etype.UnmarshalInt, "int_cookie", c.Value, false)
+		}
 
 		if dec.NonEmptyValues == 0 {
 			return (*MyAuthParams)(nil), errs.B().Code(errs.Unauthenticated).Msg("missing auth param").Err()

--- a/v2/codegen/internal/genutil/etype.go
+++ b/v2/codegen/internal/genutil/etype.go
@@ -62,6 +62,12 @@ func (u *TypeUnmarshaller) NumNonEmptyValues() *Statement {
 	return u.unmarshallerExpr.Clone().Dot("NonEmptyValues")
 }
 
+// IncNonEmpty returns a statement to increment the number of
+// non-empty values the unmarshaller has processed.
+func (u *TypeUnmarshaller) IncNonEmpty() *Statement {
+	return u.unmarshallerExpr.Clone().Dot("IncNonEmpty").Call()
+}
+
 func (u *TypeUnmarshaller) UnmarshalBuiltin(kind schema.BuiltinKind, fieldName string, value *Statement, required bool) *Statement {
 	return Qual("encore.dev/appruntime/shared/etype", "UnmarshalOne").Call(
 		u.unmarshallerExpr.Clone(),

--- a/v2/internals/pkginfo/names.go
+++ b/v2/internals/pkginfo/names.go
@@ -620,6 +620,10 @@ type PkgDeclInfo struct {
 	Recv *PkgDeclInfo
 }
 
+func (i *PkgDeclInfo) QualifiedName() QualifiedName {
+	return Q(i.File.Pkg.ImportPath, i.Name)
+}
+
 // PkgNames contains name information that's package-global.
 type PkgNames struct {
 	// PkgDecls contains package-level declarations, keyed by name.

--- a/v2/internals/schema/schemautil/schemautil.go
+++ b/v2/internals/schema/schemautil/schemautil.go
@@ -12,6 +12,7 @@ import (
 
 	"encr.dev/pkg/paths"
 	"encr.dev/v2/internals/perr"
+	"encr.dev/v2/internals/pkginfo"
 	"encr.dev/v2/internals/schema"
 )
 
@@ -98,6 +99,23 @@ func ResolveNamedStruct(t schema.Type, requirePointer bool) (ref *schema.TypeDec
 				TypeArgs: named.TypeArgs,
 			}, true
 		}
+	}
+	return nil, false
+}
+
+// DerefNamedInfo returns what package declaration a given named type references, if any.
+//
+// It always requires at most one pointer dereference, and if
+// requirePointer is true it must be exactly one pointer dereference.
+//
+// If the type is not a named type or otherwise doesn't match the requirements, it returns (nil, false).
+func DerefNamedInfo(t schema.Type, requirePointer bool) (info *pkginfo.PkgDeclInfo, ok bool) {
+	t, derefs := Deref(t)
+	if derefs > 1 || (requirePointer && derefs == 0) {
+		return nil, false
+	}
+	if named, ok := t.(schema.NamedType); ok {
+		return named.DeclInfo, true
 	}
 	return nil, false
 }

--- a/v2/parser/apis/api/apienc/encoding.go
+++ b/v2/parser/apis/api/apienc/encoding.go
@@ -23,6 +23,7 @@ const (
 	Header    WireLoc = "header"    // Parameter is placed in the HTTP header
 	Query     WireLoc = "query"     // Parameter is placed in the query string
 	Body      WireLoc = "body"      // Parameter is placed in the body
+	Cookie    WireLoc = "cookie"    // Parameter is placed in cookies
 )
 
 var (
@@ -40,6 +41,11 @@ var (
 		location:        Body,
 		omitEmptyOption: "omitempty",
 		overrideDefault: false,
+	}
+	CookieTag = tagDescription{
+		location:        Cookie,
+		omitEmptyOption: "omitempty",
+		overrideDefault: true,
 	}
 )
 
@@ -61,6 +67,7 @@ var responseTags = map[string]tagDescription{
 var authTags = map[string]tagDescription{
 	"query":  QueryTag,
 	"header": HeaderTag,
+	"cookie": CookieTag,
 }
 
 // tagDescription is used to map struct field tags to param locations
@@ -279,6 +286,7 @@ type AuthEncoding struct {
 	// Contains metadata about how to marshal an HTTP parameter
 	HeaderParameters []*ParameterEncoding `json:"header_parameters"`
 	QueryParameters  []*ParameterEncoding `json:"query_parameters"`
+	CookieParameters []*ParameterEncoding `json:"cookie_parameters"`
 }
 
 // DescribeAuth generates a ParameterEncoding per field of the auth struct and returns it as
@@ -307,7 +315,7 @@ func DescribeAuth(errs *perr.List, authSchema schema.Type) *AuthEncoding {
 		// reported by describeParams
 		return nil
 	}
-	if locationDiff := keyDiff(fields, Header, Query); len(locationDiff) > 0 {
+	if locationDiff := keyDiff(fields, Header, Query, Cookie); len(locationDiff) > 0 {
 		err := authhandler.ErrInvalidFieldTags.AtGoNode(authSchema.ASTExpr())
 
 		for _, k := range locationDiff {
@@ -321,6 +329,7 @@ func DescribeAuth(errs *perr.List, authSchema schema.Type) *AuthEncoding {
 	return &AuthEncoding{
 		QueryParameters:  fields[Query],
 		HeaderParameters: fields[Header],
+		CookieParameters: fields[Cookie],
 	}
 }
 

--- a/v2/parser/apis/authhandler/authhandler.go
+++ b/v2/parser/apis/authhandler/authhandler.go
@@ -130,7 +130,7 @@ nextField:
 	for _, field := range ref.Fields {
 		// No tags, then we tell them they need to specify it
 		if field.Tag.Len() == 0 {
-			fieldErr = fieldErr.AtGoNode(field.AST, errors.AsError("you must specify a \"header\" or \"query\" tag for this field"))
+			fieldErr = fieldErr.AtGoNode(field.AST, errors.AsError("you must specify a \"header\", \"query\", or \"cookie\" tag for this field"))
 			continue
 		}
 
@@ -141,7 +141,7 @@ nextField:
 			tag, err := field.Tag.Get(tagKey)
 			if err == nil {
 				switch tagKey {
-				case "header", "query", "qs":
+				case "header", "query", "qs", "cookie":
 					if tag.Name != "" && tag.Name != "-" {
 						continue nextField
 					} else {

--- a/v2/parser/apis/authhandler/errors.go
+++ b/v2/parser/apis/authhandler/errors.go
@@ -66,10 +66,10 @@ note: *Params and *UserData are custom data types you define
 
 	ErrInvalidFieldTags = errRange.New(
 		"Invalid auth payload",
-		"All fields used within an auth payload must originate from either an HTTP header or a query parameter.",
+		"All fields used within an auth payload must originate from either an HTTP header, a query parameter, or a cookie.",
 
 		errors.WithDetails(
-			"You can specify them for each field using the struct tags, for example with `header:\"X-My-Header\"` or `query:\"my-query\"`.\n\n"+
+			"You can specify them for each field using the struct tags, for example with `header:\"X-My-Header\"`, `query:\"my-query\", or `cookie:\"my-cookie\"`.\n\n"+
 				authLink,
 		),
 	)


### PR DESCRIPTION
In order to support more types of authentication schemes (in particular [Ory](https://www.ory.sh/)) it's sometimes necessary to use cookie-based authentication. This adds support for reading cookie values for auth handler types.