### PR TITLE
runtime: tweak pubsub refs API

### DIFF
--- a/e2e-tests/testdata/testscript/pubsub_ref.txt
+++ b/e2e-tests/testdata/testscript/pubsub_ref.txt
@@ -33,4 +33,15 @@ func TestRefPublish(t *testing.T) {
     if len(msgs) != 1 || msgs[0].Message != "test" {
         t.Fatalf("got %v, want %v", msgs, []Msg{{Message: "test"}})
     }
+
+    meta := ref.Meta()
+    want := pubsub.TopicMeta{
+        Name: "topic",
+        Config: pubsub.TopicConfig{
+            DeliveryGuarantee: pubsub.AtLeastOnce,
+        },
+    }
+    if meta != want {
+        t.Fatalf("got meta %v, want %v", meta, want)
+    }
 }

--- a/runtime/pubsub/refs.go
+++ b/runtime/pubsub/refs.go
@@ -5,7 +5,7 @@ import "context"
 // TopicPerms is the type constraint for all permission-declaring
 // interfaces that can be used with TopicRef.
 type TopicPerms[T any] interface {
-	topicRef() T
+	Meta() TopicMeta
 }
 
 // Publisher is the interface for publishing messages to a topic.
@@ -21,8 +21,11 @@ type TopicPerms[T any] interface {
 // passed around freely within the service, without being subject
 // to Encore's static analysis restrictions that apply to MyTopic.
 type Publisher[T any] interface {
+	// Publish publishes a message to the topic.
 	Publish(ctx context.Context, msg T) (id string, err error)
-	topicRef() T
+
+	// Meta returns metadata about the topic.
+	Meta() TopicMeta
 }
 
 // TopicRef returns an interface reference to a topic,
@@ -42,10 +45,9 @@ type Publisher[T any] interface {
 //	var ref = pubsub.TopicRef[pubsub.Publisher[Msg]](MyTopic)
 //	// ref.Publish(...) can now be used to publish messages to MyTopic.
 func TopicRef[P TopicPerms[T], T any](topic *Topic[T]) P {
-	return any(topic).(P)
+	return any(topicRef[T]{Topic: topic}).(P)
 }
 
-func (t *Topic[T]) topicRef() T {
-	var zero T
-	return zero
+type topicRef[T any] struct {
+	*Topic[T]
 }

--- a/runtime/pubsub/topic.go
+++ b/runtime/pubsub/topic.go
@@ -21,6 +21,7 @@ import (
 //
 // See NewTopic for more information on how to declare a Topic.
 type Topic[T any] struct {
+	cfg            TopicConfig
 	mgr            *Manager
 	topicCfg       *config.PubsubTopic
 	topic          types.TopicImplementation
@@ -30,6 +31,7 @@ type Topic[T any] struct {
 func newTopic[T any](mgr *Manager, name string, cfg TopicConfig) *Topic[T] {
 	if mgr.static.Testing {
 		return &Topic[T]{
+			cfg:            cfg,
 			mgr:            mgr,
 			topicCfg:       &config.PubsubTopic{EncoreName: name},
 			topic:          test.NewTopic[T](mgr.ts, name),
@@ -63,6 +65,24 @@ func newTopic[T any](mgr *Manager, name string, cfg TopicConfig) *Topic[T] {
 	mgr.rootLogger.Fatal().Msgf("unsupported PubSub provider for server[%d], tried: %v",
 		topic.ProviderID, tried)
 	panic("unreachable")
+}
+
+// TopicMeta contains metadata about a topic.
+// The fields should not be modified by the caller.
+// Additional fields may be added in the future.
+type TopicMeta struct {
+	// Name is the name of the topic, as provided in the constructor to NewTopic.
+	Name string
+	// Config is the topic's configuration.
+	Config TopicConfig
+}
+
+// Meta returns metadata about the topic.
+func (t *Topic[T]) Meta() TopicMeta {
+	return TopicMeta{
+		Name:   t.topicCfg.EncoreName,
+		Config: t.cfg,
+	}
 }
 
 // Publish will publish a message to the topic and returns a unique message ID for the message.


### PR DESCRIPTION
Tweak the API to make it easier to mock pubsub references before we release it and lock in the behavior.