### PR TITLE
Support resources defined in test files

### DIFF
--- a/pkg/golden/golden.go
+++ b/pkg/golden/golden.go
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 // It can be called instead of TestMain if a package wants to do multiple
 // main function handling.
 func Setup() {
-	flag.BoolVar(&update, "golden-update", false, "update golden files")
+	flag.BoolVar(&update, "golden-update", os.Getenv("GOLDEN_UPDATE") != "", "update golden files")
 	flag.Parse()
 	testMainRan = true
 }

--- a/v2/app/legacymeta/legacymeta.go
+++ b/v2/app/legacymeta/legacymeta.go
@@ -203,9 +203,10 @@ func (b *builder) Build() *meta.Data {
 			}
 			md.CronJobs = append(md.CronJobs, cj)
 			if ep, ok := b.app.Parse.ResourceForQN(r.Endpoint).Get(); ok {
+				endpoint := ep.(*api.Endpoint)
 				cj.Endpoint = &meta.QualifiedName{
-					Pkg:  b.relPath(ep.Package().ImportPath),
-					Name: ep.(*api.Endpoint).Name,
+					Pkg:  b.relPath(endpoint.File.Pkg.ImportPath),
+					Name: endpoint.Name,
 				}
 			} else {
 				b.errs.Addf(r.EndpointAST.Pos(), "could not find endpoint %q", r.Endpoint)

--- a/v2/app/service_discovery.go
+++ b/v2/app/service_discovery.go
@@ -8,6 +8,10 @@ import (
 	"encr.dev/v2/internals/perr"
 	"encr.dev/v2/internals/pkginfo"
 	"encr.dev/v2/parser"
+	"encr.dev/v2/parser/apis/api"
+	"encr.dev/v2/parser/apis/authhandler"
+	"encr.dev/v2/parser/apis/servicestruct"
+	"encr.dev/v2/parser/infra/pubsub"
 	"encr.dev/v2/parser/resource"
 	"encr.dev/v2/parser/resource/usage"
 )
@@ -42,15 +46,15 @@ func discoverServices(pc *parsectx.Context, result *parser.Result) []*Service {
 	}
 
 	for _, r := range result.Resources() {
-		switch r.Kind() {
-		case resource.ServiceStruct:
-			sd.possibleServiceRoot(r.Package(), true)
-		case resource.APIEndpoint:
-			sd.possibleServiceRoot(r.Package(), false)
-		case resource.PubSubSubscription:
-			sd.possibleServiceRoot(r.Package(), false)
-		case resource.AuthHandler:
-			sd.possibleServiceRoot(r.Package(), false)
+		switch r := r.(type) {
+		case *servicestruct.ServiceStruct:
+			sd.possibleServiceRoot(r.Decl.File.Pkg, true)
+		case *api.Endpoint:
+			sd.possibleServiceRoot(r.Decl.File.Pkg, false)
+		case *pubsub.Subscription:
+			sd.possibleServiceRoot(r.File.Pkg, false)
+		case *authhandler.AuthHandler:
+			sd.possibleServiceRoot(r.Decl.File.Pkg, false)
 		}
 	}
 

--- a/v2/app/testdata/resource_sqldb_outside_svc.txt
+++ b/v2/app/testdata/resource_sqldb_outside_svc.txt
@@ -26,3 +26,10 @@ internal compiler error: unknown resource (path "SQLDatabase:moo")
     ⋮     ────────────────────────
  10 │
 ────╯
+
+
+
+
+── Resource defined outside of service ────────────────────────────────────────────────────[E9999]──
+
+Resources can only be defined within a service.

--- a/v2/app/validate_test.go
+++ b/v2/app/validate_test.go
@@ -30,7 +30,7 @@ import (
 	"encr.dev/v2/parser/infra/sqldb"
 )
 
-var goldenUpdate = flag.Bool("golden-update", false, "update golden files")
+var goldenUpdate = flag.Bool("golden-update", os.Getenv("GOLDEN_UPDATE") != "", "update golden files")
 
 func TestValidation(t *testing.T) {
 	type testCfg struct {
@@ -243,7 +243,7 @@ func parse(ts *testscript.TestScript, neg bool, args []string) {
 		case *sqldb.Database:
 			for _, b := range desc.Parse.PkgDeclBinds(res) {
 				printf("resource SQLDBResource %s.%s db=%s",
-					b.Pkg.Name, b.BoundName.Name, res.Name)
+					b.File.Pkg.Name, b.BoundName.Name, res.Name)
 			}
 		case *pubsub.Topic:
 			printf("pubsubTopic %s", res.Name)

--- a/v2/codegen/internal/codegentest/codegentest.go
+++ b/v2/codegen/internal/codegentest/codegentest.go
@@ -28,7 +28,7 @@ type Case struct {
 	WantErrs []string
 }
 
-var goldenUpdate = flag.Bool("golden-update", false, "update golden files")
+var goldenUpdate = flag.Bool("golden-update", os.Getenv("GOLDEN_UPDATE") != "", "update golden files")
 
 func Run(t *testing.T, fn func(*codegen.Generator, *app.Desc)) {
 	flag.Parse()

--- a/v2/parser/apis/api/api.go
+++ b/v2/parser/apis/api/api.go
@@ -66,6 +66,7 @@ func (ep *Endpoint) Kind() resource.Kind       { return resource.APIEndpoint }
 func (ep *Endpoint) Package() *pkginfo.Package { return ep.File.Pkg }
 func (ep *Endpoint) Pos() token.Pos            { return ep.Decl.AST.Pos() }
 func (ep *Endpoint) End() token.Pos            { return ep.Decl.AST.End() }
+func (ep *Endpoint) SortKey() string           { return ep.File.Pkg.ImportPath.String() + "." + ep.Name }
 
 func (ep *Endpoint) RequestEncoding() []*apienc.RequestEncoding {
 	ep.reqEncOnce.Do(func() {

--- a/v2/parser/apis/authhandler/authhandler.go
+++ b/v2/parser/apis/authhandler/authhandler.go
@@ -37,6 +37,7 @@ func (ah *AuthHandler) Kind() resource.Kind       { return resource.AuthHandler 
 func (ah *AuthHandler) Package() *pkginfo.Package { return ah.Decl.File.Pkg }
 func (ah *AuthHandler) Pos() token.Pos            { return ah.Decl.AST.Pos() }
 func (ah *AuthHandler) End() token.Pos            { return ah.Decl.AST.End() }
+func (ah *AuthHandler) SortKey() string           { return ah.Decl.File.Pkg.ImportPath.String() + "." + ah.Name }
 
 type ParseData struct {
 	Errs   *perr.List

--- a/v2/parser/apis/middleware/middleware.go
+++ b/v2/parser/apis/middleware/middleware.go
@@ -44,6 +44,9 @@ func (mw *Middleware) Kind() resource.Kind       { return resource.Middleware }
 func (mw *Middleware) Package() *pkginfo.Package { return mw.File.Pkg }
 func (mw *Middleware) Pos() token.Pos            { return mw.Decl.AST.Pos() }
 func (mw *Middleware) End() token.Pos            { return mw.Decl.AST.End() }
+func (mw *Middleware) SortKey() string {
+	return mw.Decl.File.Pkg.ImportPath.String() + "." + mw.Decl.Name
+}
 
 type ParseData struct {
 	Errs   *perr.List

--- a/v2/parser/apis/parser.go
+++ b/v2/parser/apis/parser.go
@@ -51,7 +51,7 @@ var Parser = &resourceparser.Parser{
 							// This is the case because we generate a package-level
 							// wrapper function that forwards to the service struct
 							// method in that case.
-							p.AddBind(ep.Decl.AST.Name, ep)
+							p.AddBind(file, ep.Decl.AST.Name, ep)
 						}
 
 					case "authhandler":
@@ -66,7 +66,7 @@ var Parser = &resourceparser.Parser{
 						if ah != nil {
 							p.RegisterResource(ah)
 							if ah.Recv.Empty() {
-								p.AddBind(ah.Decl.AST.Name, ah)
+								p.AddBind(file, ah.Decl.AST.Name, ah)
 							}
 						}
 
@@ -83,7 +83,7 @@ var Parser = &resourceparser.Parser{
 						if mw != nil {
 							p.RegisterResource(mw)
 							if mw.Recv.Empty() {
-								p.AddBind(mw.Decl.AST.Name, mw)
+								p.AddBind(file, mw.Decl.AST.Name, mw)
 							}
 						}
 
@@ -118,7 +118,7 @@ var Parser = &resourceparser.Parser{
 
 						if ss != nil {
 							p.RegisterResource(ss)
-							p.AddBind(ss.Decl.AST.Name, ss)
+							p.AddBind(file, ss.Decl.AST.Name, ss)
 						}
 
 					default:

--- a/v2/parser/apis/servicestruct/servicestruct.go
+++ b/v2/parser/apis/servicestruct/servicestruct.go
@@ -30,6 +30,9 @@ func (ss *ServiceStruct) Kind() resource.Kind       { return resource.ServiceStr
 func (ss *ServiceStruct) Package() *pkginfo.Package { return ss.Decl.File.Pkg }
 func (ss *ServiceStruct) Pos() token.Pos            { return ss.Decl.AST.Pos() }
 func (ss *ServiceStruct) End() token.Pos            { return ss.Decl.AST.End() }
+func (ss *ServiceStruct) SortKey() string {
+	return ss.Decl.File.Pkg.ImportPath.String() + "." + ss.Decl.Name
+}
 
 type ParseData struct {
 	Errs   *perr.List

--- a/v2/parser/infra/caches/cluster.go
+++ b/v2/parser/infra/caches/cluster.go
@@ -27,6 +27,7 @@ func (c *Cluster) ASTExpr() ast.Expr         { return c.AST }
 func (c *Cluster) ResourceName() string      { return c.Name }
 func (c *Cluster) Pos() token.Pos            { return c.AST.Pos() }
 func (c *Cluster) End() token.Pos            { return c.AST.End() }
+func (c *Cluster) SortKey() string           { return c.Name }
 
 var ClusterParser = &resourceparser.Parser{
 	Name: "Cache Cluster",
@@ -99,6 +100,6 @@ func parseCluster(d parseutil.ReferenceInfo) {
 
 	d.Pass.RegisterResource(cluster)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, cluster)
+		d.Pass.AddBind(d.File, id, cluster)
 	}
 }

--- a/v2/parser/infra/caches/keyspace.go
+++ b/v2/parser/infra/caches/keyspace.go
@@ -38,6 +38,9 @@ func (k *Keyspace) Package() *pkginfo.Package { return k.File.Pkg }
 func (k *Keyspace) ASTExpr() ast.Expr         { return k.AST }
 func (k *Keyspace) Pos() token.Pos            { return k.AST.Pos() }
 func (k *Keyspace) End() token.Pos            { return k.AST.End() }
+func (k *Keyspace) SortKey() string {
+	return fmt.Sprintf("%s:%s:%d", k.File.Pkg.ImportPath, k.File.Name, k.AST.Pos())
+}
 
 var KeyspaceParser = &resourceparser.Parser{
 	Name: "Cache Keyspace",
@@ -274,6 +277,6 @@ func parseKeyspace(c cacheKeyspaceConstructor, d parseutil.ReferenceInfo) {
 
 	d.Pass.RegisterResource(ks)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, ks)
+		d.Pass.AddBind(d.File, id, ks)
 	}
 }

--- a/v2/parser/infra/config/config.go
+++ b/v2/parser/infra/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 
@@ -33,6 +34,9 @@ func (l *Load) Package() *pkginfo.Package { return l.File.Pkg }
 func (l *Load) ASTExpr() ast.Expr         { return l.AST }
 func (l *Load) Pos() token.Pos            { return l.AST.Pos() }
 func (l *Load) End() token.Pos            { return l.AST.End() }
+func (l *Load) SortKey() string {
+	return fmt.Sprintf("%s:%s:%d", l.File.Pkg.ImportPath, l.File.Name, l.AST.Pos())
+}
 
 var LoadParser = &resourceparser.Parser{
 	Name: "ConfigLoad",
@@ -87,7 +91,7 @@ func parseLoad(d parseutil.ReferenceInfo) {
 
 	d.Pass.RegisterResource(load)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, load)
+		d.Pass.AddBind(d.File, id, load)
 	}
 }
 

--- a/v2/parser/infra/crons/cron.go
+++ b/v2/parser/infra/crons/cron.go
@@ -35,6 +35,7 @@ func (j *Job) ASTExpr() ast.Expr         { return j.AST }
 func (j *Job) ResourceName() string      { return j.Name }
 func (j *Job) Pos() token.Pos            { return j.AST.Pos() }
 func (j *Job) End() token.Pos            { return j.AST.End() }
+func (j *Job) SortKey() string           { return j.Name }
 
 var JobParser = &resourceparser.Parser{
 	Name: "Cron Job",
@@ -156,7 +157,7 @@ func parseCronJob(d parseutil.ReferenceInfo) {
 
 	d.Pass.RegisterResource(job)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, job)
+		d.Pass.AddBind(d.File, id, job)
 	}
 }
 

--- a/v2/parser/infra/metrics/metrics.go
+++ b/v2/parser/infra/metrics/metrics.go
@@ -57,6 +57,7 @@ func (m *Metric) ASTExpr() ast.Expr         { return m.AST }
 func (m *Metric) ResourceName() string      { return m.Name }
 func (m *Metric) Pos() token.Pos            { return m.AST.Pos() }
 func (m *Metric) End() token.Pos            { return m.AST.End() }
+func (m *Metric) SortKey() string           { return m.Name }
 
 type Label struct {
 	Key  string
@@ -212,7 +213,7 @@ func parseMetric(c metricConstructor, d parseutil.ReferenceInfo) {
 
 	d.Pass.RegisterResource(m)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, m)
+		d.Pass.AddBind(d.File, id, m)
 	}
 }
 

--- a/v2/parser/infra/pubsub/subscription.go
+++ b/v2/parser/infra/pubsub/subscription.go
@@ -39,6 +39,9 @@ func (s *Subscription) ASTExpr() ast.Expr         { return s.AST }
 func (s *Subscription) ResourceName() string      { return s.Name }
 func (s *Subscription) Pos() token.Pos            { return s.AST.Pos() }
 func (s *Subscription) End() token.Pos            { return s.AST.End() }
+func (s *Subscription) SortKey() string {
+	return s.Topic.PkgPath.String() + "." + s.Topic.Name + "." + s.Name
+}
 
 var SubscriptionParser = &resourceparser.Parser{
 	Name: "PubSub Subscription",
@@ -161,6 +164,6 @@ func parsePubSubSubscription(d parseutil.ReferenceInfo) {
 	}
 	d.Pass.RegisterResource(sub)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, sub)
+		d.Pass.AddBind(d.File, id, sub)
 	}
 }

--- a/v2/parser/infra/pubsub/topic.go
+++ b/v2/parser/infra/pubsub/topic.go
@@ -41,6 +41,7 @@ func (t *Topic) ASTExpr() ast.Expr         { return t.AST }
 func (t *Topic) ResourceName() string      { return t.Name }
 func (t *Topic) Pos() token.Pos            { return t.AST.Pos() }
 func (t *Topic) End() token.Pos            { return t.AST.End() }
+func (t *Topic) SortKey() string           { return t.Name }
 
 var TopicParser = &resourceparser.Parser{
 	Name: "PubSub Topic",
@@ -157,6 +158,6 @@ func parsePubSubTopic(d parseutil.ReferenceInfo) {
 	}
 	d.Pass.RegisterResource(topic)
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddBind(id, topic)
+		d.Pass.AddBind(d.File, id, topic)
 	}
 }

--- a/v2/parser/infra/secrets/secrets.go
+++ b/v2/parser/infra/secrets/secrets.go
@@ -35,6 +35,9 @@ func (s *Secrets) Package() *pkginfo.Package { return s.File.Pkg }
 func (s *Secrets) ASTExpr() ast.Expr         { return s.AST }
 func (s *Secrets) Pos() token.Pos            { return s.AST.Pos() }
 func (s *Secrets) End() token.Pos            { return s.AST.End() }
+func (s *Secrets) SortKey() string {
+	return fmt.Sprintf("%s:%s:%d", s.File.Pkg.ImportPath, s.File.Name, s.AST.Pos())
+}
 
 var SecretsParser = &resourceparser.Parser{
 	Name:               "Secrets",
@@ -86,6 +89,6 @@ var SecretsParser = &resourceparser.Parser{
 		}
 
 		p.RegisterResource(res)
-		p.AddBind(res.Ident, res)
+		p.AddBind(res.File, res.Ident, res)
 	},
 }

--- a/v2/parser/infra/sqldb/named.go
+++ b/v2/parser/infra/sqldb/named.go
@@ -58,6 +58,6 @@ func parseNamedSQLDB(d parseutil.ReferenceInfo) {
 	}
 
 	if id, ok := d.Ident.Get(); ok {
-		d.Pass.AddPathBind(id, resource.Path{{resource.SQLDatabase, dbName}})
+		d.Pass.AddPathBind(d.File, id, resource.Path{{resource.SQLDatabase, dbName}})
 	}
 }

--- a/v2/parser/infra/sqldb/sqldb.go
+++ b/v2/parser/infra/sqldb/sqldb.go
@@ -32,6 +32,7 @@ func (d *Database) Package() *pkginfo.Package { return d.Pkg }
 func (d *Database) ResourceName() string      { return d.Name }
 func (d *Database) Pos() token.Pos            { return token.NoPos }
 func (d *Database) End() token.Pos            { return token.NoPos }
+func (d *Database) SortKey() string           { return d.Name }
 
 type MigrationFile struct {
 	Filename    string

--- a/v2/parser/parser.go
+++ b/v2/parser/parser.go
@@ -93,10 +93,14 @@ func (p *Parser) Parse() *Result {
 	// as we process modules in parallel we can't rely on the order of the
 	// resources being stable coming into this function.
 	slices.SortFunc(resources, func(a, b resource.Resource) bool {
-		if a.Package() != b.Package() {
-			return a.Package().FSPath < b.Package().FSPath
+		p1, p2 := p.c.FS.Position(a.Pos()), p.c.FS.Position(b.Pos())
+		if p1.Filename != p2.Filename {
+			return p1.Filename < p2.Filename
+		} else if p1.Line != p2.Line {
+			return p1.Line < p2.Line
+		} else if p1.Column != p2.Column {
+			return p1.Column < p2.Column
 		}
-
 		return a.Pos() < b.Pos()
 	})
 

--- a/v2/parser/resource/resource.go
+++ b/v2/parser/resource/resource.go
@@ -2,8 +2,6 @@ package resource
 
 import (
 	"go/ast"
-
-	"encr.dev/v2/internals/pkginfo"
 )
 
 //go:generate stringer -type=Kind -output=resource_string.go
@@ -39,8 +37,11 @@ type Resource interface {
 	// Kind is the kind of resource this is.
 	Kind() Kind
 
-	// Package is the package the resource is declared in.
-	Package() *pkginfo.Package
+	// SortKey is a string that can be used to sort resources.
+	// The sort key's value is arbitrary but should provide a
+	// consistent sort order regardless of the parsing order.
+	// The sort key only matters between resources of the same Kind.
+	SortKey() string
 }
 
 type Named interface {

--- a/v2/parser/resource/resourceparser/resourceparser.go
+++ b/v2/parser/resource/resourceparser/resourceparser.go
@@ -50,22 +50,22 @@ func (p *Pass) Binds() []resource.Bind {
 	return p.binds
 }
 
-func (p *Pass) AddBind(boundName *ast.Ident, res resource.Resource) {
+func (p *Pass) AddBind(file *pkginfo.File, boundName *ast.Ident, res resource.Resource) {
 	if boundName.Name == "_" {
 		p.binds = append(p.binds, &resource.AnonymousBind{
 			Resource: resource.ResourceOrPath{Resource: res},
-			Pkg:      p.Pkg,
+			File:     file,
 		})
 	} else {
 		p.binds = append(p.binds, &resource.PkgDeclBind{
 			Resource:  resource.ResourceOrPath{Resource: res},
-			Pkg:       p.Pkg,
+			File:      file,
 			BoundName: boundName,
 		})
 	}
 }
 
-func (p *Pass) AddPathBind(boundName *ast.Ident, path resource.Path) {
+func (p *Pass) AddPathBind(file *pkginfo.File, boundName *ast.Ident, path resource.Path) {
 	if len(path) == 0 {
 		panic("AddPathBind: empty path")
 	}
@@ -73,12 +73,12 @@ func (p *Pass) AddPathBind(boundName *ast.Ident, path resource.Path) {
 	if boundName.Name == "_" {
 		p.binds = append(p.binds, &resource.AnonymousBind{
 			Resource: resource.ResourceOrPath{Path: path},
-			Pkg:      p.Pkg,
+			File:     file,
 		})
 	} else {
 		p.binds = append(p.binds, &resource.PkgDeclBind{
 			Resource:  resource.ResourceOrPath{Path: path},
-			Pkg:       p.Pkg,
+			File:      file,
 			BoundName: boundName,
 		})
 	}

--- a/v2/parser/resource/usage/usage_test.go
+++ b/v2/parser/resource/usage/usage_test.go
@@ -21,7 +21,7 @@ import (
 	"encr.dev/v2/parser/resource/usage"
 )
 
-var goldenUpdate = flag.Bool("golden-update", false, "update golden files")
+var goldenUpdate = flag.Bool("golden-update", os.Getenv("GOLDEN_UPDATE") != "", "update golden files")
 
 func TestParse(t *testing.T) {
 	flag.Parse()

--- a/v2/v2builder/v2builder.go
+++ b/v2/v2builder/v2builder.go
@@ -282,9 +282,10 @@ func computeConfigs(errs *perr.List, desc *app.Desc, mainModule *pkginfo.Module,
 
 	// TODO this is a hack until we have proper resource usage tracking
 	serviceUsesConfig := make(map[string]resource.Resource, len(desc.Services))
-	for _, r := range desc.Parse.Resources() {
+	for _, b := range desc.Parse.AllBinds() {
+		r := desc.Parse.ResourceForBind(b)
 		if r.Kind() == resource.ConfigLoad {
-			if svc, ok := desc.ServiceForPath(r.Package().FSPath); ok {
+			if svc, ok := desc.ServiceForPath(b.Package().FSPath); ok {
 				serviceUsesConfig[svc.Name] = r
 			}
 		}


### PR DESCRIPTION
Support defining resources in test files even
if the test files themselves aren't part of a service.

Fix this by refactoring the logic to move away from
resource.Package (which is now removed) in favor of
resource binds, which keep track of the file it's declared in.

This is stacked on top of #683.