### PR TITLE
clientgen: fix js/ts clients with optional query/headers

### DIFF
--- a/e2e-tests/testdata/echo_client/js/client.js
+++ b/e2e-tests/testdata/echo_client/js/client.js
@@ -168,10 +168,10 @@ class EchoServiceClient {
      */
     async HeadersEcho(params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "x-int":    String(params.Int),
             "x-string": params.String,
-        }
+        })
 
         // Now make the actual call to the API
         const resp = await this.baseClient.callAPI("POST", `/echo.HeadersEcho`, undefined, {headers})
@@ -188,10 +188,10 @@ class EchoServiceClient {
      */
     async MuteEcho(params) {
         // Convert our params into the objects we need for the request
-        const query = {
+        const query = makeRecord({
             key:   params.Key,
             value: params.Value,
-        }
+        })
 
         await this.baseClient.callAPI("GET", `/echo.MuteEcho`, undefined, {query})
     }
@@ -210,15 +210,15 @@ class EchoServiceClient {
      */
     async NonBasicEcho(pathString, pathInt, pathWild, params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "x-header-number": String(params.HeaderNumber),
             "x-header-string": params.HeaderString,
-        }
+        })
 
-        const query = {
+        const query = makeRecord({
             no:     String(params.QueryNumber),
             string: params.QueryString,
-        }
+        })
 
         // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
         const body = {
@@ -350,7 +350,7 @@ class TestServiceClient {
      */
     async MarshallerTestHandler(params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "x-boolean": String(params.HeaderBoolean),
             "x-bytes":   String(params.HeaderBytes),
             "x-float":   String(params.HeaderFloat),
@@ -360,9 +360,9 @@ class TestServiceClient {
             "x-time":    String(params.HeaderTime),
             "x-user-id": String(params.HeaderUserID),
             "x-uuid":    String(params.HeaderUUID),
-        }
+        })
 
-        const query = {
+        const query = makeRecord({
             boolean:   String(params.QueryBoolean),
             bytes:     String(params.QueryBytes),
             float:     String(params.QueryFloat),
@@ -373,7 +373,7 @@ class TestServiceClient {
             time:      String(params.QueryTime),
             "user-id": String(params.QueryUserID),
             uuid:      String(params.QueryUUID),
-        }
+        })
 
         // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
         const body = {
@@ -443,13 +443,13 @@ class TestServiceClient {
      */
     async RestStyleAPI(objType, name, params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "some-key": params.HeaderValue,
-        }
+        })
 
-        const query = {
+        const query = makeRecord({
             "Some-Key": params.QueryValue,
-        }
+        })
 
         // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
         const body = {
@@ -522,6 +522,17 @@ function encodeQuery(parts) {
         }
     }
     return pairs.join("&")
+}
+
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord(record) {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record
 }
 
 // mustBeSet will throw an APIError with the Data Loss code if value is null or undefined

--- a/e2e-tests/testdata/echo_client/ts/client.ts
+++ b/e2e-tests/testdata/echo_client/ts/client.ts
@@ -315,10 +315,10 @@ export namespace echo {
          */
         public async HeadersEcho(params: HeadersData): Promise<HeadersData> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "x-int":    String(params.Int),
                 "x-string": params.String,
-            }
+            })
 
             // Now make the actual call to the API
             const resp = await this.baseClient.callAPI("POST", `/echo.HeadersEcho`, undefined, {headers})
@@ -335,10 +335,10 @@ export namespace echo {
          */
         public async MuteEcho(params: Data<string, string>): Promise<void> {
             // Convert our params into the objects we need for the request
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 key:   params.Key,
                 value: params.Value,
-            }
+            })
 
             await this.baseClient.callAPI("GET", `/echo.MuteEcho`, undefined, {query})
         }
@@ -357,15 +357,15 @@ export namespace echo {
          */
         public async NonBasicEcho(pathString: string, pathInt: number, pathWild: string[], params: NonBasicData): Promise<NonBasicData> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "x-header-number": String(params.HeaderNumber),
                 "x-header-string": params.HeaderString,
-            }
+            })
 
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 no:     String(params.QueryNumber),
                 string: params.QueryString,
-            }
+            })
 
             // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
             const body: Record<string, any> = {
@@ -558,7 +558,7 @@ export namespace test {
          */
         public async MarshallerTestHandler(params: MarshallerTest<number>): Promise<MarshallerTest<number>> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "x-boolean": String(params.HeaderBoolean),
                 "x-bytes":   String(params.HeaderBytes),
                 "x-float":   String(params.HeaderFloat),
@@ -568,9 +568,9 @@ export namespace test {
                 "x-time":    String(params.HeaderTime),
                 "x-user-id": String(params.HeaderUserID),
                 "x-uuid":    String(params.HeaderUUID),
-            }
+            })
 
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 boolean:   String(params.QueryBoolean),
                 bytes:     String(params.QueryBytes),
                 float:     String(params.QueryFloat),
@@ -581,7 +581,7 @@ export namespace test {
                 time:      String(params.QueryTime),
                 "user-id": String(params.QueryUserID),
                 uuid:      String(params.QueryUUID),
-            }
+            })
 
             // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
             const body: Record<string, any> = {
@@ -651,13 +651,13 @@ export namespace test {
          */
         public async RestStyleAPI(objType: number, name: string, params: RestParams): Promise<RestParams> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "some-key": params.HeaderValue,
-            }
+            })
 
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 "Some-Key": params.QueryValue,
-            }
+            })
 
             // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
             const body: Record<string, any> = {
@@ -734,6 +734,17 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
         }
     }
     return pairs.join("&")
+}
+
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record as Record<K, V>
 }
 
 

--- a/internal/clientgen/javascript.go
+++ b/internal/clientgen/javascript.go
@@ -267,9 +267,9 @@ func (js *javascript) rpcCallSite(w *indentWriter, rpc *meta.RPC, rpcPath string
 				dict[field.WireFormat] = js.convertBuiltinToString(field.Type.GetBuiltin(), ref)
 			}
 
-			w.WriteString("const headers = ")
+			w.WriteString("const headers = makeRecord(")
 			js.Values(w, dict)
-			w.WriteString("\n")
+			w.WriteString(")\n\n")
 		}
 
 		// Generate the query string
@@ -289,9 +289,9 @@ func (js *javascript) rpcCallSite(w *indentWriter, rpc *meta.RPC, rpcPath string
 				}
 			}
 
-			w.WriteString("const query = ")
+			w.WriteString("const query = makeRecord(")
 			js.Values(w, dict)
-			w.WriteString("\n")
+			w.WriteString(")\n\n")
 		}
 
 		// Generate the body
@@ -311,7 +311,7 @@ func (js *javascript) rpcCallSite(w *indentWriter, rpc *meta.RPC, rpcPath string
 
 				w.WriteString("// Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)\nconst body = ")
 				js.Values(w, dict)
-				w.WriteString("\n")
+				w.WriteString("\n\n")
 			}
 		}
 	}
@@ -631,6 +631,17 @@ function encodeQuery(parts) {
     }
     return pairs.join("&")
 }
+
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord(record) {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record
+}
 `)
 
 	if js.seenHeaderResponse {
@@ -761,7 +772,7 @@ func (js *javascript) Values(w *indentWriter, dict map[string]string) {
 			w.WriteStringf("%s: %s%s,\n", ident, strings.Repeat(" ", largestKey-len(ident)), dict[key])
 		}
 	}
-	w.WriteString("}\n")
+	w.WriteString("}")
 }
 
 func (js *javascript) typeName(identifier string) string {

--- a/internal/clientgen/testdata/expected_baseauth_javascript.js
+++ b/internal/clientgen/testdata/expected_baseauth_javascript.js
@@ -85,6 +85,17 @@ function encodeQuery(parts) {
     return pairs.join("&")
 }
 
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord(record) {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record
+}
+
 
 const boundFetch = fetch.bind(this)
 

--- a/internal/clientgen/testdata/expected_baseauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_baseauth_typescript.ts
@@ -123,6 +123,17 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
     return pairs.join("&")
 }
 
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record as Record<K, V>
+}
+
 // CallParameters is the type of the parameters to a method call, but require headers to be a Record type
 type CallParameters = Omit<RequestInit, "method" | "body"> & {
     /** Any headers to be sent with the request */

--- a/internal/clientgen/testdata/expected_javascript.js
+++ b/internal/clientgen/testdata/expected_javascript.js
@@ -48,9 +48,9 @@ class ProductsServiceClient {
 
     async Create(params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "idempotency-key": params.IdempotencyKey,
-        }
+        })
 
         // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
         const body = {
@@ -88,24 +88,24 @@ class SvcServiceClient {
 
     async Get(params) {
         // Convert our params into the objects we need for the request
-        const query = {
+        const query = makeRecord({
             boo: String(params.Baz),
-        }
+        })
 
         await this.baseClient.callAPI("GET", `/svc.Get`, undefined, {query})
     }
 
     async GetRequestWithAllInputTypes(params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "x-alice": String(params.A),
-        }
+        })
 
-        const query = {
+        const query = makeRecord({
             Bob:  params.B.map((v) => String(v)),
             c:    String(params["Charlies-Bool"]),
             dave: String(params.Dave),
-        }
+        })
 
         // Now make the actual call to the API
         const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
@@ -126,7 +126,7 @@ class SvcServiceClient {
 
     async HeaderOnlyRequest(params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "x-boolean": String(params.Boolean),
             "x-bytes":   String(params.Bytes),
             "x-float":   String(params.Float),
@@ -136,7 +136,7 @@ class SvcServiceClient {
             "x-time":    String(params.Time),
             "x-user-id": String(params.UserID),
             "x-uuid":    String(params.UUID),
-        }
+        })
 
         await this.baseClient.callAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
     }
@@ -147,13 +147,13 @@ class SvcServiceClient {
 
     async RequestWithAllInputTypes(params) {
         // Convert our params into the objects we need for the request
-        const headers = {
+        const headers = makeRecord({
             "x-alice": String(params.A),
-        }
+        })
 
-        const query = {
+        const query = makeRecord({
             Bob: params.B.map((v) => String(v)),
-        }
+        })
 
         // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
         const body = {
@@ -199,6 +199,17 @@ function encodeQuery(parts) {
         }
     }
     return pairs.join("&")
+}
+
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord(record) {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record
 }
 
 // mustBeSet will throw an APIError with the Data Loss code if value is null or undefined

--- a/internal/clientgen/testdata/expected_noauth_javascript.js
+++ b/internal/clientgen/testdata/expected_noauth_javascript.js
@@ -69,6 +69,17 @@ function encodeQuery(parts) {
     return pairs.join("&")
 }
 
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord(record) {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record
+}
+
 
 const boundFetch = fetch.bind(this)
 

--- a/internal/clientgen/testdata/expected_noauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_noauth_typescript.ts
@@ -91,6 +91,17 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
     return pairs.join("&")
 }
 
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record as Record<K, V>
+}
+
 // CallParameters is the type of the parameters to a method call, but require headers to be a Record type
 type CallParameters = Omit<RequestInit, "method" | "body"> & {
     /** Any headers to be sent with the request */

--- a/internal/clientgen/testdata/expected_typescript.ts
+++ b/internal/clientgen/testdata/expected_typescript.ts
@@ -113,9 +113,9 @@ export namespace products {
 
         public async Create(params: CreateProductRequest): Promise<Product> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "idempotency-key": params.IdempotencyKey,
-            }
+            })
 
             // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
             const body: Record<string, any> = {
@@ -229,24 +229,24 @@ export namespace svc {
 
         public async Get(params: GetRequest): Promise<void> {
             // Convert our params into the objects we need for the request
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 boo: String(params.Baz),
-            }
+            })
 
             await this.baseClient.callAPI("GET", `/svc.Get`, undefined, {query})
         }
 
         public async GetRequestWithAllInputTypes(params: AllInputTypes<number>): Promise<HeaderOnlyStruct> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "x-alice": String(params.A),
-            }
+            })
 
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 Bob:  params.B.map((v) => String(v)),
                 c:    String(params["Charlies-Bool"]),
                 dave: String(params.Dave),
-            }
+            })
 
             // Now make the actual call to the API
             const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
@@ -267,7 +267,7 @@ export namespace svc {
 
         public async HeaderOnlyRequest(params: HeaderOnlyStruct): Promise<void> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "x-boolean": String(params.Boolean),
                 "x-bytes":   String(params.Bytes),
                 "x-float":   String(params.Float),
@@ -277,7 +277,7 @@ export namespace svc {
                 "x-time":    String(params.Time),
                 "x-user-id": String(params.UserID),
                 "x-uuid":    String(params.UUID),
-            }
+            })
 
             await this.baseClient.callAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
         }
@@ -288,13 +288,13 @@ export namespace svc {
 
         public async RequestWithAllInputTypes(params: AllInputTypes<string>): Promise<AllInputTypes<number>> {
             // Convert our params into the objects we need for the request
-            const headers: Record<string, string> = {
+            const headers = makeRecord<string, string>({
                 "x-alice": String(params.A),
-            }
+            })
 
-            const query: Record<string, string | string[]> = {
+            const query = makeRecord<string, string | string[]>({
                 Bob: params.B.map((v) => String(v)),
-            }
+            })
 
             // Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
             const body: Record<string, any> = {
@@ -340,6 +340,17 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
         }
     }
     return pairs.join("&")
+}
+
+// makeRecord takes a record and strips any undefined values from it,
+// and returns the same record with a narrower type.
+function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
+    for (const key in record) {
+        if (record[key] === undefined) {
+            delete record[key]
+        }
+    }
+    return record as Record<K, V>
 }
 
 


### PR DESCRIPTION
The code worked fine, but it was generating invalid type definitions. Fix this by introducing a helper function `makeRecord` that clears undefined values and narrows down the type.

Thanks Phakorn Kiong for the report.