### PR TITLE
v2/parser: validate duplicate dbs

### DIFF
--- a/v2/app/validate.go
+++ b/v2/app/validate.go
@@ -27,6 +27,7 @@ func (d *Desc) validate(pc *parsectx.Context, result *parser.Result) {
 	d.validateCaches(pc, result)
 	d.validateConfigs(pc, result)
 	d.validateCrons(pc, result)
+	d.validateDatabases(pc, result)
 	d.validatePubSub(pc, result)
 
 	// Validate all resources are defined within a service

--- a/v2/app/validate_databases.go
+++ b/v2/app/validate_databases.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"encr.dev/v2/internals/parsectx"
+	"encr.dev/v2/parser"
+	"encr.dev/v2/parser/infra/sqldb"
+)
+
+func (d *Desc) validateDatabases(pc *parsectx.Context, result *parser.Result) {
+	foundDBs := make(map[string]*sqldb.Database)
+
+	dbs := parser.Resources[*sqldb.Database](result)
+	for _, db := range dbs {
+		if previous, ok := foundDBs[db.Name]; ok {
+			pc.Errs.Add(
+				sqldb.ErrDuplicateNames.
+					AtGoNode(db.AST.Args[0]).
+					AtGoNode(previous.AST.Args[0]),
+			)
+		}
+		foundDBs[db.Name] = db
+	}
+}

--- a/v2/parser/infra/sqldb/errors.go
+++ b/v2/parser/infra/sqldb/errors.go
@@ -5,6 +5,11 @@ import (
 )
 
 var (
+	ErrDuplicateNames = errRange.New(
+		"Duplicate Databases",
+		"Multiple databases with the same name were found. Database names must be unique.",
+	)
+
 	errRange = errors.Range(
 		"sqldb",
 		"For more information about how to use databases in Encore, see https://encore.dev/docs/primitives/databases",

--- a/v2/parser/infra/sqldb/sqldb.go
+++ b/v2/parser/infra/sqldb/sqldb.go
@@ -23,6 +23,7 @@ import (
 )
 
 type Database struct {
+	AST          *ast.CallExpr
 	Pkg          *pkginfo.Package
 	Name         string // The database name
 	Doc          string
@@ -126,6 +127,7 @@ func parseDatabase(d parseutil.ReferenceInfo) {
 	}
 
 	db := &Database{
+		AST:          d.Call,
 		Pkg:          d.Pass.Pkg,
 		Name:         databaseName,
 		Doc:          d.Doc,


### PR DESCRIPTION
With the introduction of sqldb.NewDatabase
the possibility arises to have multiple databases
with the same name. Return an error if that's
the case.