### PR TITLE
Support AWS FIFO topics

### DIFF
--- a/runtime/pubsub/internal/aws/topic_test.go
+++ b/runtime/pubsub/internal/aws/topic_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"encore.dev/appruntime/exported/config"
+	"encore.dev/pubsub/internal/types"
 )
 
 const (
@@ -50,7 +51,7 @@ func Test_AWS_PubSub_E2E(t *testing.T) {
 	defer cancel()
 	mgr := NewManager(ctx)
 
-	topic := mgr.NewTopic(runtime.PubsubProviders[0], runtime.PubsubTopics["test-topic"])
+	topic := mgr.NewTopic(runtime.PubsubProviders[0], types.TopicConfig{DeliveryGuarantee: types.AtLeastOnce}, runtime.PubsubTopics["test-topic"])
 
 	// Purge the queue of any messages from previous failed tests
 	_, err := mgr.getSQSClient(ctx).PurgeQueue(ctx, &sqs.PurgeQueueInput{

--- a/runtime/pubsub/internal/azure/topic.go
+++ b/runtime/pubsub/internal/azure/topic.go
@@ -47,10 +47,10 @@ type topic struct {
 
 var _ types.TopicImplementation = (*topic)(nil)
 
-func (mgr *Manager) NewTopic(providerCfg *config.PubsubProvider, cfg *config.PubsubTopic) types.TopicImplementation {
+func (mgr *Manager) NewTopic(providerCfg *config.PubsubProvider, _ types.TopicConfig, runtimeCfg *config.PubsubTopic) types.TopicImplementation {
 	// Create the topic
 	client := mgr.getClient(providerCfg.Azure)
-	return &topic{mgr: mgr, client: client, topicCfg: cfg}
+	return &topic{mgr: mgr, client: client, topicCfg: runtimeCfg}
 }
 
 func (t *topic) sender() *azservicebus.Sender {

--- a/runtime/pubsub/internal/encorecloud/manager.go
+++ b/runtime/pubsub/internal/encorecloud/manager.go
@@ -43,6 +43,6 @@ func (mgr *Manager) Matches(providerCfg *config.PubsubProvider) bool {
 	return providerCfg.EncoreCloud != nil
 }
 
-func (mgr *Manager) NewTopic(_ *config.PubsubProvider, topicCfg *config.PubsubTopic) types.TopicImplementation {
-	return &topic{mgr, topicCfg}
+func (mgr *Manager) NewTopic(_ *config.PubsubProvider, _ types.TopicConfig, runtimeCfg *config.PubsubTopic) types.TopicImplementation {
+	return &topic{mgr, runtimeCfg}
 }

--- a/runtime/pubsub/internal/gcp/topic.go
+++ b/runtime/pubsub/internal/gcp/topic.go
@@ -39,22 +39,22 @@ func (mgr *Manager) Matches(cfg *config.PubsubProvider) bool {
 	return cfg.GCP != nil
 }
 
-func (mgr *Manager) NewTopic(_ *config.PubsubProvider, cfg *config.PubsubTopic) types.TopicImplementation {
+func (mgr *Manager) NewTopic(_ *config.PubsubProvider, _ types.TopicConfig, runtimeCfg *config.PubsubTopic) types.TopicImplementation {
 	// Create the topic
 	client := mgr.getClient()
-	gcpTopic := client.TopicInProject(cfg.ProviderName, cfg.GCP.ProjectID)
+	gcpTopic := client.TopicInProject(runtimeCfg.ProviderName, runtimeCfg.GCP.ProjectID)
 
 	// Enable message ordering if we have an ordering key set
-	gcpTopic.EnableMessageOrdering = cfg.OrderingKey != ""
+	gcpTopic.EnableMessageOrdering = runtimeCfg.OrderingKey != ""
 
 	// Check we have permissions to interact with the given topic
 	// (note: the call to Topic() above only creates the object, it doesn't verify that we have permissions to interact with it)
 	_, err := gcpTopic.Config(mgr.ctx)
 	if err != nil {
-		panic(fmt.Sprintf("pubsub topic %s status call failed: %s", cfg.EncoreName, err))
+		panic(fmt.Sprintf("pubsub topic %s status call failed: %s", runtimeCfg.EncoreName, err))
 	}
 
-	return &topic{mgr, client, gcpTopic, cfg}
+	return &topic{mgr, client, gcpTopic, runtimeCfg}
 }
 
 func (t *topic) PublishMessage(ctx context.Context, attrs map[string]string, data []byte) (id string, err error) {

--- a/runtime/pubsub/internal/nsq/topic.go
+++ b/runtime/pubsub/internal/nsq/topic.go
@@ -45,11 +45,11 @@ func (mgr *Manager) Matches(cfg *config.PubsubProvider) bool {
 	return cfg.NSQ != nil
 }
 
-func (mgr *Manager) NewTopic(server *config.PubsubProvider, topicCfg *config.PubsubTopic) types.TopicImplementation {
+func (mgr *Manager) NewTopic(providerCfg *config.PubsubProvider, _ types.TopicConfig, runtimeCfg *config.PubsubTopic) types.TopicImplementation {
 	return &topic{
 		mgr:       mgr,
-		name:      topicCfg.EncoreName,
-		addr:      server.NSQ.Host,
+		name:      runtimeCfg.EncoreName,
+		addr:      providerCfg.NSQ.Host,
 		producer:  nil,
 		consumers: make(map[string]*nsq.Consumer),
 		idSeq:     0,

--- a/runtime/pubsub/manager_internal.go
+++ b/runtime/pubsub/manager_internal.go
@@ -125,7 +125,7 @@ func (t *outstandingMessageTracker) Done() <-chan struct{} {
 type provider interface {
 	ProviderName() string
 	Matches(providerCfg *config.PubsubProvider) bool
-	NewTopic(providerCfg *config.PubsubProvider, topicCfg *config.PubsubTopic) types.TopicImplementation
+	NewTopic(providerCfg *config.PubsubProvider, staticCfg TopicConfig, runtimeCfg *config.PubsubTopic) types.TopicImplementation
 }
 
 var providerRegistry []func(*Manager) provider

--- a/runtime/pubsub/topic.go
+++ b/runtime/pubsub/topic.go
@@ -51,8 +51,9 @@ func newTopic[T any](mgr *Manager, name string, cfg TopicConfig) *Topic[T] {
 	tried := make([]string, 0, len(mgr.providers))
 	for _, p := range mgr.providers {
 		if p.Matches(provider) {
-			impl := p.NewTopic(provider, topic)
+			impl := p.NewTopic(provider, cfg, topic)
 			return &Topic[T]{
+				cfg:            cfg,
 				mgr:            mgr,
 				topicCfg:       topic,
 				topic:          impl,


### PR DESCRIPTION
This commit enables support for AWS FIFO queues by adding the two new parameters to the calls to publish; which are required when using FIFO queues which allow for exactly once delivery

1. Providing a grouping ID based on the running instance ID (this is required for FIFO)
2. Providing a unique message ID (this is required for exactly once delivery)