### PR TITLE
Implement initial Ordered PubSub Support

### DIFF
--- a/cli/daemon/run/infra/infra.go
+++ b/cli/daemon/run/infra/infra.go
@@ -275,10 +275,6 @@ func (rm *ResourceManager) UpdateConfig(cfg *config.Runtime, md *meta.Data, dbPr
 				Subscriptions: make(map[string]*config.PubsubSubscription),
 			}
 
-			if t.OrderingKey != "" {
-				topicCfg.OrderingKey = t.OrderingKey
-			}
-
 			for _, s := range t.Subscriptions {
 				subscriptionID := t.Name
 				if useLocalEncoreCloudAPIForTesting {

--- a/go.mod
+++ b/go.mod
@@ -48,10 +48,10 @@ require (
 	github.com/rs/zerolog v1.29.1
 	github.com/spf13/cobra v1.6.1
 	github.com/tailscale/hujson v0.0.0-20220630195928-54599719472f
-	go.encore.dev/platform-sdk v1.0.0
+	go.encore.dev/platform-sdk v1.1.0
 	go.uber.org/goleak v1.1.12
 	go4.org v0.0.0-20201209231011-d4a079459e60
-	golang.org/x/crypto v0.8.0
+	golang.org/x/crypto v0.9.0
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/mod v0.10.0
 	golang.org/x/oauth2 v0.7.0
@@ -133,8 +133,8 @@ require (
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	golang.org/x/net v0.9.0 // indirect
-	golang.org/x/term v0.7.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1408,8 +1408,8 @@ github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPS
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
-go.encore.dev/platform-sdk v1.0.0 h1:I+x7Z/m2E/1K9HuC5Hta7xUm2d+1TWKEp5QOQaKAc+o=
-go.encore.dev/platform-sdk v1.0.0/go.mod h1:ImcJU8p0V3bSXb+d++Ni/8hFDwVZaFpUAAySTY2x6FY=
+go.encore.dev/platform-sdk v1.1.0 h1:0BYLt7ZAoPje3KMLee6/gA2FECHwzi1sKgp3SqC+QRo=
+go.encore.dev/platform-sdk v1.1.0/go.mod h1:ImcJU8p0V3bSXb+d++Ni/8hFDwVZaFpUAAySTY2x6FY=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
@@ -1500,8 +1500,8 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
-golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
+golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
+golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1625,8 +1625,8 @@ golang.org/x/net v0.0.0-20220111093109-d55c255bac03/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
-golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1803,8 +1803,8 @@ golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
-golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=
-golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
+golang.org/x/term v0.8.0 h1:n5xxQn2i3PC0yLAbjTpNT85q/Kgzcr2gIoX9OrJUols=
+golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/runtime/appruntime/exported/config/config.go
+++ b/runtime/appruntime/exported/config/config.go
@@ -193,7 +193,6 @@ type PubsubTopic struct {
 	EncoreName   string   `json:"encore_name"`       // the Encore name for the pubsub topic
 	ProviderID   int      `json:"provider_id"`       // The index into (*Runtime).PubsubProviders.
 	ProviderName string   `json:"provider_name"`     // the name for the pubsub topic as defined by the provider
-	OrderingKey  string   `json:"ordering_key"`      // the ordering key for the pubsub topic (blank if not ordered)
 	Limiter      *Limiter `json:"limiter,omitempty"` // the rate limiter for the topic
 
 	// Subscriptions contains the subscriptions to this topic,

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d
 	github.com/rs/xid v1.4.0
 	github.com/rs/zerolog v1.29.1
-	go.encore.dev/platform-sdk v1.0.0
+	go.encore.dev/platform-sdk v1.1.0
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/time v0.3.0
 	google.golang.org/api v0.119.0
@@ -79,8 +79,8 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/crypto v0.8.0 // indirect
-	golang.org/x/net v0.9.0 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect

--- a/runtime/go.sum
+++ b/runtime/go.sum
@@ -250,6 +250,8 @@ github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 h1:5mLPGnFdSsevFRF
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.encore.dev/platform-sdk v1.0.0 h1:I+x7Z/m2E/1K9HuC5Hta7xUm2d+1TWKEp5QOQaKAc+o=
 go.encore.dev/platform-sdk v1.0.0/go.mod h1:ImcJU8p0V3bSXb+d++Ni/8hFDwVZaFpUAAySTY2x6FY=
+go.encore.dev/platform-sdk v1.1.0 h1:0BYLt7ZAoPje3KMLee6/gA2FECHwzi1sKgp3SqC+QRo=
+go.encore.dev/platform-sdk v1.1.0/go.mod h1:ImcJU8p0V3bSXb+d++Ni/8hFDwVZaFpUAAySTY2x6FY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
@@ -259,6 +261,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
+golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
+golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
 golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
@@ -281,6 +285,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
+golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
+golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=

--- a/runtime/pubsub/internal/aws/topic_test.go
+++ b/runtime/pubsub/internal/aws/topic_test.go
@@ -82,7 +82,7 @@ func Test_AWS_PubSub_E2E(t *testing.T) {
 	})
 
 	// Publish a message on the queue
-	sentMessageID, err = topic.PublishMessage(context.Background(), map[string]string{"attr-1": "foo"}, []byte("{\"hello\":\"world\"}"))
+	sentMessageID, err = topic.PublishMessage(context.Background(), "", map[string]string{"attr-1": "foo"}, []byte("{\"hello\":\"world\"}"))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/runtime/pubsub/internal/azure/topic.go
+++ b/runtime/pubsub/internal/azure/topic.go
@@ -64,7 +64,7 @@ func (t *topic) sender() *azservicebus.Sender {
 	return t._sender
 }
 
-func (t *topic) PublishMessage(ctx context.Context, attrs map[string]string, data []byte) (id string, err error) {
+func (t *topic) PublishMessage(ctx context.Context, groupingKey string, attrs map[string]string, data []byte) (id string, err error) {
 
 	messageID, err := uuid.NewV4()
 	if err != nil {

--- a/runtime/pubsub/internal/encorecloud/topic.go
+++ b/runtime/pubsub/internal/encorecloud/topic.go
@@ -15,8 +15,8 @@ type topic struct {
 	cfg *config.PubsubTopic
 }
 
-func (t *topic) PublishMessage(ctx context.Context, attrs map[string]string, data []byte) (id string, err error) {
-	return t.mgr.client.PublishToTopic(ctx, t.cfg.ProviderName, attrs, data)
+func (t *topic) PublishMessage(ctx context.Context, orderingKey string, attrs map[string]string, data []byte) (id string, err error) {
+	return t.mgr.client.PublishToTopic(ctx, t.cfg.ProviderName, orderingKey, attrs, data)
 }
 
 func (t *topic) Subscribe(logger *zerolog.Logger, _ time.Duration, _ *types.RetryPolicy, subCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {

--- a/runtime/pubsub/internal/nsq/topic.go
+++ b/runtime/pubsub/internal/nsq/topic.go
@@ -130,7 +130,7 @@ func (l *topic) Subscribe(logger *zerolog.Logger, ackDeadline time.Duration, ret
 }
 
 // PublishMessage publishes a message to an nsq Topic
-func (l *topic) PublishMessage(_ context.Context, attrs map[string]string, data []byte) (id string, err error) {
+func (l *topic) PublishMessage(ctx context.Context, orderingKey string, attrs map[string]string, data []byte) (id string, err error) {
 	// instantiate a Producer if there isn;t one already
 	if l.producer == nil {
 		l.m.Lock()

--- a/runtime/pubsub/internal/test/topic.go
+++ b/runtime/pubsub/internal/test/topic.go
@@ -42,7 +42,7 @@ func NewTopic[T any](ts *testsupport.Manager, name string) types.TopicImplementa
 // PublishMessage will record the message against the test instance
 // and if subscribers are enabled for the test instance, it will also trigger
 // those subscribers. (The default behaviour is subscribers are disabled in tests)
-func (t *TestTopic[T]) PublishMessage(ctx context.Context, attrs map[string]string, data []byte) (id string, err error) {
+func (t *TestTopic[T]) PublishMessage(ctx context.Context, orderingKey string, attrs map[string]string, data []byte) (id string, err error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}

--- a/runtime/pubsub/internal/types/private.go
+++ b/runtime/pubsub/internal/types/private.go
@@ -14,6 +14,6 @@ type RawSubscriptionCallback func(ctx context.Context, msgID string, publishTime
 
 // TopicImplementation gives us a private API to implementing topics, which we can change without impacting the public API
 type TopicImplementation interface {
-	PublishMessage(ctx context.Context, attrs map[string]string, data []byte) (id string, err error)
+	PublishMessage(ctx context.Context, orderingKey string, attrs map[string]string, data []byte) (id string, err error)
 	Subscribe(logger *zerolog.Logger, ackDeadline time.Duration, retryPolicy *RetryPolicy, implCfg *config.PubsubSubscription, f RawSubscriptionCallback)
 }

--- a/runtime/pubsub/internal/types/public.go
+++ b/runtime/pubsub/internal/types/public.go
@@ -90,10 +90,49 @@ type TopicConfig struct {
 	// This field is required.
 	DeliveryGuarantee DeliveryGuarantee
 
-	// OrderingKey is the name of the message attribute used to group
-	// messages and delivery messages with the same OrderingKey value
-	// in the order they were published.
+	// OrderingAttribute is the message attribute to use as a ordering key for
+	// messages and delivery will ensure that messages with the same value will
+	// be delivered in the order they where published.
 	//
-	// If OrderingKey is not set, messages can be delivered in any order.
-	// OrderingKey string - OrderingKey is currently not supported.
+	// If OrderingAttribute is not set, messages can be delivered in any order.
+	//
+	// It is important to note, that in the case of an error being returned by a
+	// subscription handler, the message will be retried before any subsequent
+	// messages for that ordering key are delivered. This means depending on the
+	// retry configuration, a large backlog of messages for a given ordering key
+	// may build up. When using OrderingAttribute, it is recommended to use reason
+	// about your failure modes and set the retry configuration appropriately.
+	//
+	// Once the maximum number of retries has been reached, the message will be
+	// forwarded to the dead letter queue, and the next message for that ordering
+	// key will be delivered.
+	//
+	// To create attributes on a message, use the `pubsub-attr` struct tag:
+	//
+	//	type UserEvent struct {
+	//		UserID string `pubsub-attr:"user-id"`
+	//		Action string
+	//	}
+	//
+	//  var topic = pubsub.NewTopic[UserEvent]("user-events", pubsub.TopicConfig{
+	// 		DeliveryGuarantee: pubsub.AtLeastOnce,
+	//		OrderingAttribute: "user-id", // Messages with the same user-id will be delivered in the order they where published
+	//	})
+	//
+	//  topic.Publish(ctx, &UserEvent{UserID: "1", Action: "login"})  // This message will be delivered before the logout
+	//  topic.Publish(ctx, &UserEvent{UserID: "2", Action: "login"})  // This could be delivered at any time because it has a different user id
+	//  topic.Publish(ctx, &UserEvent{UserID: "1", Action: "logout"}) // This message will be delivered after the first message
+	//
+	// By using OrderingAttribute, the throughput will be limited depending on the cloud provider:
+	//
+	// - AWS: 300 messages per second for the topic (see [AWS SQS Quotas]).
+	// - GCP: 1MB/s for each ordering key (see [GCP PubSub Quotas]).
+	//
+	// Note: OrderingAttribute is not supported for local development.
+	//
+	// [AWS SQS Quotas]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
+	// [GCP PubSub Quotas]: https://cloud.google.com/pubsub/quotas#resource_limits
+	//
+	//publicapigen:drop
+	OrderingAttribute string
 }

--- a/runtime/pubsub/internal/types/public.go
+++ b/runtime/pubsub/internal/types/public.go
@@ -128,7 +128,7 @@ type TopicConfig struct {
 	// - AWS: 300 messages per second for the topic (see [AWS SQS Quotas]).
 	// - GCP: 1MB/s for each ordering key (see [GCP PubSub Quotas]).
 	//
-	// Note: OrderingAttribute is not supported for local development.
+	// Note: OrderingAttribute currently has no effect during local development.
 	//
 	// [AWS SQS Quotas]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
 	// [GCP PubSub Quotas]: https://cloud.google.com/pubsub/quotas#resource_limits

--- a/runtime/pubsub/subscription.go
+++ b/runtime/pubsub/subscription.go
@@ -56,7 +56,7 @@ type Subscription[T any] struct {
 //	  return nil
 //	}
 func NewSubscription[T any](topic *Topic[T], name string, cfg SubscriptionConfig[T]) *Subscription[T] {
-	if topic.topicCfg == nil || topic.topic == nil || topic.mgr == nil {
+	if topic.runtimeCfg == nil || topic.topic == nil || topic.mgr == nil {
 		panic("pubsub topic was not created using pubsub.NewTopic")
 	}
 	mgr := topic.mgr
@@ -95,7 +95,7 @@ func NewSubscription[T any](topic *Topic[T], name string, cfg SubscriptionConfig
 
 	log := mgr.rootLogger.With().
 		Str("service", staticCfg.Service).
-		Str("topic", topic.topicCfg.EncoreName).
+		Str("topic", topic.runtimeCfg.EncoreName).
 		Str("subscription", name).
 		Logger()
 
@@ -159,7 +159,7 @@ func NewSubscription[T any](topic *Topic[T], name string, cfg SubscriptionConfig
 			Start:            time.Now(),
 			MsgData: &model2.PubSubMsgData{
 				Service:        staticCfg.Service,
-				Topic:          topic.topicCfg.EncoreName,
+				Topic:          topic.runtimeCfg.EncoreName,
 				Subscription:   subscription.EncoreName,
 				MessageID:      msgID,
 				Attempt:        deliveryAttempt,
@@ -250,14 +250,14 @@ func (t *Topic[T]) getSubscriptionConfig(name string) (*config.PubsubSubscriptio
 	}
 
 	// Fetch the subscription configuration
-	subscription, ok := t.topicCfg.Subscriptions[name]
+	subscription, ok := t.runtimeCfg.Subscriptions[name]
 	if !ok {
-		t.mgr.rootLogger.Fatal().Msgf("unregistered/unknown subscription on topic %s: %s", t.topicCfg.EncoreName, name)
+		t.mgr.rootLogger.Fatal().Msgf("unregistered/unknown subscription on topic %s: %s", t.runtimeCfg.EncoreName, name)
 	}
 
-	staticCfg, ok := t.mgr.static.PubsubTopics[t.topicCfg.EncoreName].Subscriptions[name]
+	staticCfg, ok := t.mgr.static.PubsubTopics[t.runtimeCfg.EncoreName].Subscriptions[name]
 	if !ok {
-		t.mgr.rootLogger.Fatal().Msgf("unregistered/unknown subscription on topic %s: %s", t.topicCfg.EncoreName, name)
+		t.mgr.rootLogger.Fatal().Msgf("unregistered/unknown subscription on topic %s: %s", t.runtimeCfg.EncoreName, name)
 	}
 
 	return subscription, staticCfg

--- a/runtime/pubsub/topic.go
+++ b/runtime/pubsub/topic.go
@@ -21,9 +21,9 @@ import (
 //
 // See NewTopic for more information on how to declare a Topic.
 type Topic[T any] struct {
-	cfg            TopicConfig
 	mgr            *Manager
-	topicCfg       *config.PubsubTopic
+	staticCfg      TopicConfig         // The config as defined in the applications source code
+	runtimeCfg     *config.PubsubTopic // The config for this running instance of the apllication
 	topic          types.TopicImplementation
 	publishLimiter limiter.Limiter
 }
@@ -31,9 +31,9 @@ type Topic[T any] struct {
 func newTopic[T any](mgr *Manager, name string, cfg TopicConfig) *Topic[T] {
 	if mgr.static.Testing {
 		return &Topic[T]{
-			cfg:            cfg,
+			staticCfg:      cfg,
 			mgr:            mgr,
-			topicCfg:       &config.PubsubTopic{EncoreName: name},
+			runtimeCfg:     &config.PubsubTopic{EncoreName: name},
 			topic:          test.NewTopic[T](mgr.ts, name),
 			publishLimiter: limiter.New(nil), // Create a no-op limiter
 		}
@@ -53,9 +53,9 @@ func newTopic[T any](mgr *Manager, name string, cfg TopicConfig) *Topic[T] {
 		if p.Matches(provider) {
 			impl := p.NewTopic(provider, cfg, topic)
 			return &Topic[T]{
-				cfg:            cfg,
+				staticCfg:      cfg,
 				mgr:            mgr,
-				topicCfg:       topic,
+				runtimeCfg:     topic,
 				topic:          impl,
 				publishLimiter: limiter.New(topic.Limiter),
 			}
@@ -81,8 +81,8 @@ type TopicMeta struct {
 // Meta returns metadata about the topic.
 func (t *Topic[T]) Meta() TopicMeta {
 	return TopicMeta{
-		Name:   t.topicCfg.EncoreName,
-		Config: t.cfg,
+		Name:   t.runtimeCfg.EncoreName,
+		Config: t.staticCfg,
 	}
 }
 
@@ -93,20 +93,36 @@ func (t *Topic[T]) Meta() TopicMeta {
 // If an error is returned, it is probable that the message failed to be published, however it is possible
 // that the message could still be received by subscriptions to the topic.
 func (t *Topic[T]) Publish(ctx context.Context, msg T) (id string, err error) {
-	if t.topicCfg == nil || t.topic == nil {
+	if t.runtimeCfg == nil || t.topic == nil {
 		return "", errs.B().Code(errs.Unimplemented).Msg("pubsub topic was not created using pubsub.NewTopic").Err()
 	}
 
 	// Extract the message attributes
 	attrs, err := utils.MarshalFields(msg, utils.AttrTag)
 	if err != nil {
-		return "", errs.B().Cause(err).Code(errs.InvalidArgument).Msgf("failed to extract message attributes for topic %s", t.topicCfg.EncoreName).Err()
+		return "", errs.B().Cause(err).Code(errs.InvalidArgument).Msgf("failed to extract message attributes for topic %s", t.runtimeCfg.EncoreName).Err()
 	}
 
 	// Marshal the message to JSON
 	data, err := json.Marshal(msg)
 	if err != nil {
-		return "", errs.B().Cause(err).Code(errs.InvalidArgument).Msgf("failed to marshal message to JSON for topic %s", t.topicCfg.EncoreName).Err()
+		return "", errs.B().Cause(err).Code(errs.InvalidArgument).Msgf("failed to marshal message to JSON for topic %s", t.runtimeCfg.EncoreName).Err()
+	}
+
+	// Add the ordering attribute if it is set
+	var orderingKey string
+	if t.staticCfg.OrderingAttribute != "" {
+		value, found := attrs[t.staticCfg.OrderingAttribute]
+		if !found {
+			// This is checked statically, so this should never happen
+			return "", errs.B().Code(errs.InvalidArgument).Msgf("ordering attribute %s not found in message for topic %s", t.staticCfg.OrderingAttribute, t.runtimeCfg.EncoreName).Err()
+		}
+
+		if value == "" {
+			return "", errs.B().Code(errs.InvalidArgument).Msgf("ordering attribute %s cannot be an empty string for topic %s", t.staticCfg.OrderingAttribute, t.runtimeCfg.EncoreName).Err()
+		}
+
+		orderingKey = value
 	}
 
 	// Add the correlation ID to the attributes
@@ -129,13 +145,13 @@ func (t *Topic[T]) Publish(ctx context.Context, msg T) (id string, err error) {
 	publishTraceID := atomic.AddUint64(&t.mgr.publishCounter, 1)
 	curr := t.mgr.rt.Current()
 	if curr.Req != nil && curr.Trace != nil {
-		curr.Trace.PublishStart(t.topicCfg.EncoreName, data, curr.Req.SpanID, curr.Goctr, publishTraceID, 2)
+		curr.Trace.PublishStart(t.runtimeCfg.EncoreName, data, curr.Req.SpanID, curr.Goctr, publishTraceID, 2)
 	}
 
 	// Publish once the rate limiter allows it
 	if err = t.publishLimiter.Wait(ctx); err == nil {
 		// Publish to the clouds topic
-		id, err = t.topic.PublishMessage(ctx, attrs, data)
+		id, err = t.topic.PublishMessage(ctx, orderingKey, attrs, data)
 	}
 
 	// End the trace span
@@ -144,7 +160,7 @@ func (t *Topic[T]) Publish(ctx context.Context, msg T) (id string, err error) {
 	}
 
 	if err != nil {
-		return "", errs.B().Cause(err).Code(errs.Unavailable).Msgf("failed to publish message to %s", t.topicCfg.EncoreName).Err()
+		return "", errs.B().Cause(err).Code(errs.Unavailable).Msgf("failed to publish message to %s", t.runtimeCfg.EncoreName).Err()
 	}
 
 	return id, nil

--- a/v2/app/legacymeta/legacymeta.go
+++ b/v2/app/legacymeta/legacymeta.go
@@ -244,7 +244,7 @@ func (b *builder) Build() *meta.Data {
 				Name:          r.Name,
 				Doc:           r.Doc,
 				MessageType:   b.typeDeclRefUnwrapPointer(r.MessageType),
-				OrderingKey:   r.OrderingKey,
+				OrderingKey:   r.OrderingAttribute,
 				Publishers:    nil,
 				Subscriptions: nil, // filled in later
 			}

--- a/v2/app/testdata/pubsub_err_ordering_attribute_missing.txt
+++ b/v2/app/testdata/pubsub_err_ordering_attribute_missing.txt
@@ -1,0 +1,42 @@
+# Verify that pub sub is parsed
+! parse
+err 'PubSub message attributes must not be prefixed with "encore".'
+
+-- shared/topics.go --
+package shared
+
+import (
+    "encore.dev/pubsub"
+)
+
+type MessageType struct {
+    ID   int64  `pubsub-attr:"msg-id"`
+    Name string `pubsub-attr:"name"`
+}
+
+var BasicTopic = pubsub.NewTopic[*MessageType]("same-name", pubsub.TopicConfig{
+    DeliveryGuarantee: pubsub.AtLeastOnce,
+    OrderingAttribute: "ID",
+})
+
+-- want: errors --
+
+── Invalid PubSub topic config ────────────────────────────────────────────────────────────[E9999]──
+
+The configuration field named "OrderingAttribute" must be a one of the export attributes on the
+message type.
+
+    ╭─[ shared/topics.go:14:24 ]
+    │
+ 12 │ var BasicTopic = pubsub.NewTopic[*MessageType]("same-name", pubsub.TopicConfig{
+ 13 │     DeliveryGuarantee: pubsub.AtLeastOnce,
+ 14 │     OrderingAttribute: "ID",
+    ⋮                        ────
+ 15 │ })
+ 16 │
+────╯
+
+For example `pubsub.NewTopic[MyMessage]("my-topic", pubsub.TopicConfig{ DeliveryGuarantee:
+pubsub.AtLeastOnce })`
+
+For more information on PubSub, see https://encore.dev/docs/primitives/pubsub

--- a/v2/app/testdata/pubsub_err_ordering_attribute_missing.txt
+++ b/v2/app/testdata/pubsub_err_ordering_attribute_missing.txt
@@ -1,6 +1,5 @@
 # Verify that pub sub is parsed
 ! parse
-err 'PubSub message attributes must not be prefixed with "encore".'
 
 -- shared/topics.go --
 package shared

--- a/v2/app/testdata/pubsub_publish_in_middleware.txt
+++ b/v2/app/testdata/pubsub_publish_in_middleware.txt
@@ -11,16 +11,20 @@ import (
 )
 
 type MessageType struct {
+    UserID int64 `pubsub-attr:"user_id"`
     Name string
 }
 
 var (
-    BasicTopic = pubsub.NewTopic[*MessageType]("basic", pubsub.TopicConfig{ DeliveryGuarantee: pubsub.AtLeastOnce })
+    BasicTopic = pubsub.NewTopic[*MessageType]("basic", pubsub.TopicConfig{
+        DeliveryGuarantee: pubsub.AtLeastOnce,
+        OrderingAttribute: "user_id",
+    })
 )
 
 // encore:api
 func DoStuff(ctx context.Context) error {
-    return BasicTopic.Publish(ctx, &MessageType{Name: "foo"})
+    return BasicTopic.Publish(ctx, &MessageType{UserID: 1, Name: "foo"})
 }
 
 
@@ -38,7 +42,7 @@ import (
 
 //encore:middleware global target=all
 func MiddlewareFunc(req middleware.Request, next middleware.Next) middleware.Response {
-    svc.BasicTopic.Publish(req.Context(), &svc.MessageType{Name: "bar"})
+    svc.BasicTopic.Publish(req.Context(), &svc.MessageType{UserID: 1, Name: "bar"})
 
 	return next(req)
 }

--- a/v2/parser/infra/pubsub/errors.go
+++ b/v2/parser/infra/pubsub/errors.go
@@ -42,7 +42,7 @@ var (
 
 	errOrderingKeyNotExported = errRange.New(
 		"Invalid PubSub topic config",
-		"The configuration field named \"OrderingKey\" must be a one of the exported fields on the message type.",
+		"The configuration field named \"OrderingAttribute\" must be a one of the export attributes on the message type.",
 		errors.PrependDetails(pubsubNewTopicHelp),
 	)
 


### PR DESCRIPTION
This commit adds initial support for ordered pubsub on AWS, GCP and EncoreCloud.

It uses a new `OrderingAttribute` configuration from the topic to extract the ordering key from the message attributes at the time of the publish.