### PR TITLE
Add docs for Ordered PubSub Topics

### DIFF
--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -89,7 +89,6 @@ The `OrderingAttribute` currently has no effect in local environments.
 
 </Callout>
 
-<Toggle label="Example Ordered Topic">
 
 ```go
 package example

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -81,7 +81,7 @@ To maintain topic order, messages with the same ordering key aren't delivered un
 
 Each cloud provider enforces certain throughput limitations for ordered topics:
 - **AWS:** 300 messages per second for the topic (see [AWS SQS Quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html)).
-- **GCP:** 1 MBps for each ordering key (See [GCP PubSub Resource Limits](https://cloud.google.com/pubsub/quotas#resource_limits))
+- **GCP:** 1 MBps for each ordering key (See [GCP Pub/Sub Resource Limits](https://cloud.google.com/pubsub/quotas#resource_limits))
 
 <Callout type="info">
 

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -89,6 +89,7 @@ Each cloud provider enforces certain throughput limitations for ordered topics:
 - **AWS:** 300 messages per second for the topic (see [AWS SQS Quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html)).
 - **GCP:** 1 MBps for each ordering key (See [GCP Pub/Sub Resource Limits](https://cloud.google.com/pubsub/quotas#resource_limits))
 
+#### Ordered topic example
 
 ```go
 package example

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -85,7 +85,7 @@ Each cloud provider enforces certain throughput limitations for ordered topics:
 
 <Callout type="info">
 
-The OrderingAttribute currently has no effect in local environments.
+The `OrderingAttribute` currently has no effect in local environments.
 
 </Callout>
 

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -73,7 +73,7 @@ the same message, the message will be delivered twice.
 
 Topics are unordered by default, meaning that messages can be delivered in any order. This allows for better throughput on the topic as messages can be processed in parallel. However, in some cases, messages must be delivered in the order they were published for a given entity.
 
-To create an ordered topic, configure the topic's OrderingAttribute to match the pubsub-attr tag on one of the top-level fields of the event type. This field ensures that messages delivered to the same subscriber are delivered in the order of publishing for that specific field value. Messages with a different value on the ordering attribute are delivered in an unspecified order.
+To create an ordered topic, configure the topic's `OrderingAttribute` to match the `pubsub-attr` tag on one of the top-level fields of the event type. This field ensures that messages delivered to the same subscriber are delivered in the order of publishing for that specific field value. Messages with a different value on the ordering attribute are delivered in an unspecified order.
 
 To maintain topic order, messages with the same ordering key aren't delivered until the earliest message is processed or dead-lettered, potentially causing delays due to [head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking). Mitigate processing issues by ensuring robust logging and alerts, and appropriate subscription retry policies.
 

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -77,6 +77,12 @@ To create an ordered topic, configure the topic's `OrderingAttribute` to match t
 
 To maintain topic order, messages with the same ordering key aren't delivered until the earliest message is processed or dead-lettered, potentially causing delays due to [head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking). Mitigate processing issues by ensuring robust logging and alerts, and appropriate subscription retry policies.
 
+<Callout type="info">
+
+The `OrderingAttribute` currently has no effect in local environments.
+
+</Callout>
+
 #### Throughput limitations
 
 Each cloud provider enforces certain throughput limitations for ordered topics:

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -86,7 +86,7 @@ The `OrderingAttribute` currently has no effect in local environments.
 #### Throughput limitations
 
 Each cloud provider enforces certain throughput limitations for ordered topics:
-- **AWS:** 300 messages per second for the topic (see [AWS SQS Quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html)).
+- **AWS:** 300 messages per second for the topic (see [AWS SQS Quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html))
 - **GCP:** 1 MBps for each ordering key (See [GCP Pub/Sub Resource Limits](https://cloud.google.com/pubsub/quotas#resource_limits))
 
 #### Ordered topic example

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -110,14 +110,12 @@ var CartEvents = pubsub.NewTopic[*CartEvent]("cart-events", pubsub.TopicConfig{
 })
 
 func Example(ctx context.Context) error {
-	// The following events will be delivered in order as they all have the same
-	// shopping cart ID
+	// These are delivered in order as they all have the same shopping cart ID
 	CartEvents.Publish(ctx, &CartEvent{ShoppingCartID: 1, Event: "item_added"})
 	CartEvents.Publish(ctx, &CartEvent{ShoppingCartID: 1, Event: "checkout_started"})
 	CartEvents.Publish(ctx, &CartEvent{ShoppingCartID: 1, Event: "checkout_completed"})
 
-	// However this event could be delievered at any point as it has a different shopping
-	// cart ID
+	// This event may be delivered at any point as it has a different shopping cart ID
 	CartEvents.Publish(ctx, &CartEvent{ShoppingCartID: 2, Event: "item_added"})
 }
 ```

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -121,11 +121,6 @@ func Example(ctx context.Context) error {
 }
 ```
 
-</Toggle>
-
-
-
-
 ## Publishing events
 
 To publish an **Event**, call `Publish` on the topic passing in the event object (which is the type specified in the `pubsub.NewTopic[Type]` constructor).

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -83,12 +83,6 @@ Each cloud provider enforces certain throughput limitations for ordered topics:
 - **AWS:** 300 messages per second for the topic (see [AWS SQS Quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html)).
 - **GCP:** 1 MBps for each ordering key (See [GCP Pub/Sub Resource Limits](https://cloud.google.com/pubsub/quotas#resource_limits))
 
-<Callout type="info">
-
-The `OrderingAttribute` currently has no effect in local environments.
-
-</Callout>
-
 
 ```go
 package example

--- a/runtime/pubsub/internal/types/public.go
+++ b/runtime/pubsub/internal/types/public.go
@@ -132,7 +132,5 @@ type TopicConfig struct {
 	//
 	// [AWS SQS Quotas]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
 	// [GCP PubSub Quotas]: https://cloud.google.com/pubsub/quotas#resource_limits
-	//
-	//publicapigen:drop
 	OrderingAttribute string
 }


### PR DESCRIPTION
This commit adds the docs for creating ordered pubsub topics and allows the public API generator to expose the OrderingAttribute