### PR TITLE
Add docs for pubsub consumers around ctx deadlines

### DIFF
--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -209,6 +209,10 @@ subscription to a single topic receives the events independently of any other su
 that if one subscription is running very slowly, it will grow a backlog of unprocessed events.
 However, any other subscriptions will still be processing events in real-time as they are published.
 
+The `ctx` passed to the handler function is cancelled when the `AckDeadline` for the subscription is reached, this is the
+time when the message is considered to have timed out and can be redelivered to another subscriber. By default if you
+do not specify an `AckDeadline` the default value of 30 seconds is used.
+
 ### Method-based handlers
 
 When using [service structs](/docs/primitives/services-and-apis#service-structs) for dependency injection

--- a/docs/primitives/pubsub.md
+++ b/docs/primitives/pubsub.md
@@ -209,9 +209,9 @@ subscription to a single topic receives the events independently of any other su
 that if one subscription is running very slowly, it will grow a backlog of unprocessed events.
 However, any other subscriptions will still be processing events in real-time as they are published.
 
-The `ctx` passed to the handler function is cancelled when the `AckDeadline` for the subscription is reached, this is the
-time when the message is considered to have timed out and can be redelivered to another subscriber. By default if you
-do not specify an `AckDeadline` the default value of 30 seconds is used.
+The `ctx` passed to the handler function is cancelled when the `AckDeadline` for the subscription is reached.
+This is the time when the message is considered to have timed out and can be redelivered to another subscriber.
+The timeout defaults to 30 seconds if you don't explicitly configure `AckDeadline`.
 
 ### Method-based handlers
 

--- a/runtime/pubsub/types.go
+++ b/runtime/pubsub/types.go
@@ -37,6 +37,9 @@ type SubscriptionConfig[T any] struct {
 	// negatively acknowledged (nacked), which will cause a redelivery
 	// attempt to be made (unless the retry policy's MaxRetries has been reached).
 	//
+	// The ctx passed to the handler will be cancelled when
+	// the AckDeadline passes.
+	//
 	// This field is required.
 	//
 	// [Encore service struct]: https://encore.dev/docs/primitives/services-and-apis#service-structs


### PR DESCRIPTION
This commit adds to the subscription docs the information that the `ctx` of the handler will be cancelled after the `AckDeadline` has passed.

Thanks to @Willyham for the suggestion