### PR TITLE
Add `--test` flag to `encore db reset`

### DIFF
--- a/cli/cmd/encore/db.go
+++ b/cli/cmd/encore/db.go
@@ -255,6 +255,7 @@ func init() {
 	rootCmd.AddCommand(dbCmd)
 
 	dbResetCmd.Flags().BoolVar(&resetAll, "all", false, "Reset all services in the application")
+	dbResetCmd.Flags().BoolVarP(&testDB, "test", "t", false, "Reset databases in the test cluster instead")
 	dbCmd.AddCommand(dbResetCmd)
 
 	dbShellCmd.Flags().StringVarP(&dbEnv, "env", "e", "local", "Environment name to connect to (such as \"prod\")")


### PR DESCRIPTION
It was already mostly wired up and was only missing the flag itself.