### PR TITLE
Begin parsing gRPC endpoints

### DIFF
--- a/v2/parser/apis/grpcservice/directive.go
+++ b/v2/parser/apis/grpcservice/directive.go
@@ -1,11 +1,10 @@
-package servicestruct
+package grpcservice
 
 import (
 	"context"
 	"path/filepath"
 	"strings"
 
-	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"encr.dev/v2/internals/perr"
@@ -13,8 +12,8 @@ import (
 	"encr.dev/v2/parser/apis/internal/directive"
 )
 
-// parseGRPCDirective parses and validates the gRPC path directive.
-func parseGRPCDirective(ctx context.Context, errs *perr.List, proto *protoparse.Parser, f directive.Field) (ok bool) {
+// ParseGRPCDirective parses and validates the gRPC path directive.
+func ParseGRPCDirective(ctx context.Context, errs *perr.List, proto *protoparse.Parser, f directive.Field) (svc protoreflect.ServiceDescriptor, ok bool) {
 	astNode := f // directive.Field implements ast.Node
 	grpcPath := f.Value
 	// Two ways of referencing a service:
@@ -30,16 +29,16 @@ func parseGRPCDirective(ctx context.Context, errs *perr.List, proto *protoparse.
 		svcName = protoreflect.Name(grpcPath[idx+1:])
 		if !svcName.IsValid() {
 			errs.Add(errInvalidGRPCName(f.Value).AtGoNode(astNode))
-			return false
+			return nil, false
 		} else if !filepath.IsLocal(f.Value) {
 			errs.Add(errNonLocalGRPCPath(f.Value).AtGoNode(astNode))
-			return false
+			return nil, false
 		}
 	} else {
 		fullName := protoreflect.FullName(grpcPath)
 		if !fullName.IsValid() {
 			errs.Add(errInvalidGRPCName(f.Value).AtGoNode(astNode))
-			return false
+			return nil, false
 		}
 
 		pkgpath := fullName.Parent()
@@ -47,23 +46,18 @@ func parseGRPCDirective(ctx context.Context, errs *perr.List, proto *protoparse.
 		if pkgpath == "" {
 			// If there's no pkgpath we got a bare "Service" path, without a package name.
 			errs.Add(errInvalidGRPCName(f.Value).AtGoNode(astNode))
-			return false
+			return nil, false
 		}
 		filePath = strings.ReplaceAll(string(pkgpath), ".", "/") + ".proto"
 	}
 
 	file := proto.ParseFile(ctx, astNode, filePath)
-	svc := file.Services().ByName(svcName)
+	svc = file.Services().ByName(svcName)
 
 	if svc == nil {
 		errs.Add(errGRPCServiceNotFound(string(svcName), filePath).AtGoNode(astNode))
-		return false
+		return nil, false
 	}
 
-	methods := svc.Methods()
-	for i := 0; i < methods.Len(); i++ {
-		m := methods.Get(i)
-		log.Printf("service %s: method %s", svc.FullName(), m.Name())
-	}
-	return true
+	return svc, true
 }

--- a/v2/parser/apis/grpcservice/endpoints.go
+++ b/v2/parser/apis/grpcservice/endpoints.go
@@ -1,0 +1,84 @@
+package grpcservice
+
+import (
+	"go/ast"
+	"go/token"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"encr.dev/v2/internals/perr"
+	"encr.dev/v2/internals/pkginfo"
+	"encr.dev/v2/internals/resourcepaths"
+	"encr.dev/v2/internals/schema"
+	"encr.dev/v2/parser/apis/api"
+)
+
+type ServiceDesc struct {
+	Errs   *perr.List
+	Schema *schema.Parser
+	Proto  protoreflect.ServiceDescriptor
+	Pkg    *pkginfo.Package
+	Decl   *schema.TypeDecl // decl is the type implementing the service
+}
+
+// ParseEndpoints parses the endpoints for the given service descriptor.
+func ParseEndpoints(desc ServiceDesc) []*api.GRPCEndpoint {
+	// Construct a map of method names to method descriptors so we can quickly
+	// determine whether a func declaration is a candidate for being an endpoint.
+	methodsByName := make(map[string]protoreflect.MethodDescriptor)
+	methods := desc.Proto.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		m := methods.Get(i)
+		methodsByName[string(m.Name())] = m
+	}
+
+	structQual := desc.Decl.Info.QualifiedName()
+
+	var endpoints []*api.GRPCEndpoint
+	for _, file := range desc.Pkg.Files {
+		for _, decl := range file.AST().Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv.NumFields() == 0 {
+				continue
+			}
+			method := methodsByName[fd.Name.Name]
+			if method == nil {
+				continue
+			}
+			// We have a match on the method name.
+			// Make sure the receiver type is the same as the service decl.
+			funcDecl, ok := desc.Schema.ParseFuncDecl(file, fd)
+			if !ok || funcDecl.Recv.Empty() {
+				continue
+			} else if qual := funcDecl.Recv.MustGet().Decl.Info.QualifiedName(); qual != structQual {
+				// The receiver belongs to a different type; ignore it.
+				continue
+			}
+
+			endpoints = append(endpoints, &api.GRPCEndpoint{
+				Name:      string(method.Name()),
+				FullName:  method.FullName(),
+				Decl:      funcDecl,
+				ProtoDesc: method,
+				Path: &resourcepaths.Path{
+					StartPos: token.NoPos,
+					// "/path.to.Service/Method"
+					Segments: []resourcepaths.Segment{
+						{
+							Type:      resourcepaths.Literal,
+							Value:     string(desc.Proto.FullName()),
+							ValueType: schema.String,
+						},
+						{
+							Type:      resourcepaths.Literal,
+							Value:     string(method.Name()),
+							ValueType: schema.String,
+						},
+					},
+				},
+			})
+		}
+	}
+
+	return endpoints
+}

--- a/v2/parser/apis/grpcservice/errors.go
+++ b/v2/parser/apis/grpcservice/errors.go
@@ -1,0 +1,29 @@
+package grpcservice
+
+import (
+	"encr.dev/pkg/errors"
+)
+
+var (
+	errRange = errors.Range(
+		"grpcservice",
+		"For more information on service structs, see https://encore.dev/docs/primitives/services-and-apis#service-structs",
+
+		errors.WithRangeSize(20),
+	)
+
+	errInvalidGRPCName = errRange.Newf(
+		"Invalid gRPC service name",
+		"The grpc field must be a valid, fully-qualified gRPC service name (got \"%s\").",
+	)
+
+	errNonLocalGRPCPath = errRange.Newf(
+		"Invalid gRPC file path",
+		"The grpc field must be a relative path from a protobuf include directory (got \"%s\").",
+	)
+
+	errGRPCServiceNotFound = errRange.Newf(
+		"gRPC service not found",
+		"The gRPC service \"%s\" cannot be found in the file \"%s\".",
+	)
+)

--- a/v2/parser/apis/grpcservice/grpcservice_test.go
+++ b/v2/parser/apis/grpcservice/grpcservice_test.go
@@ -1,0 +1,158 @@
+package grpcservice_test
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/rogpeppe/go-internal/txtar"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"encr.dev/pkg/paths"
+	"encr.dev/v2/internals/pkginfo"
+	"encr.dev/v2/internals/protoparse"
+	"encr.dev/v2/internals/resourcepaths"
+	"encr.dev/v2/internals/schema"
+	"encr.dev/v2/internals/testutil"
+	"encr.dev/v2/parser/apis/api"
+	"encr.dev/v2/parser/apis/grpcservice"
+	"encr.dev/v2/parser/apis/internal/directive"
+	"encr.dev/v2/parser/apis/servicestruct"
+)
+
+func TestParseEndpoints(t *testing.T) {
+	type testCase struct {
+		name     string
+		imports  []string
+		def      string
+		want     []*api.GRPCEndpoint
+		wantErrs []string
+	}
+	tests := []testCase{
+		{
+			name: "with_grpc_pkgpath",
+			def: `
+//encore:service grpc=path.to.grpc.Service
+type Foo struct {}
+
+func (f *Foo) Bar(ctx context.Context) error { return nil }
+-- proto/path/to/grpc.proto --
+syntax = "proto3";
+package path.to.grpc;
+
+service Service {
+	rpc Bar (BarRequest) returns (BarResponse);
+}
+message BarRequest {}
+message BarResponse {}
+`,
+			want: []*api.GRPCEndpoint{
+				{
+					Name:     "Bar",
+					FullName: "path.to.grpc.Service.Bar",
+					Path: &resourcepaths.Path{
+						Segments: []resourcepaths.Segment{
+							{Type: resourcepaths.Literal, Value: "path.to.grpc.Service", ValueType: schema.String},
+							{Type: resourcepaths.Literal, Value: "Bar", ValueType: schema.String},
+						},
+					},
+					Decl: &schema.FuncDecl{Name: "Bar"},
+				},
+			},
+		},
+	}
+
+	// testArchive renders the txtar archive to use for a given test.
+	testArchive := func(test testCase) *txtar.Archive {
+		importList := append([]string{"context"}, test.imports...)
+		imports := ""
+		if len(importList) > 0 {
+			imports = "import (\n"
+			for _, imp := range importList {
+				imports += "\t" + strconv.Quote(imp) + "\n"
+			}
+			imports += ")\n"
+		}
+
+		return testutil.ParseTxtar(`
+-- go.mod --
+module example.com
+require encore.dev v1.13.4
+-- code.go --
+package foo
+` + imports + `
+
+` + test.def + `
+`)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			a := testArchive(test)
+			tc := testutil.NewContext(c, false, a)
+			tc.GoModDownload()
+
+			l := pkginfo.New(tc.Context)
+			schemaParser := schema.NewParser(tc.Context, l)
+			protoParser := protoparse.NewParser(tc.Errs, []paths.FS{
+				tc.MainModuleDir.Join("proto"),
+			})
+
+			if len(test.wantErrs) > 0 {
+				defer tc.DeferExpectError(test.wantErrs...)
+			} else {
+				tc.FailTestOnErrors()
+				defer tc.FailTestOnBailout()
+			}
+
+			pkg := l.MustLoadPkg(token.NoPos, "example.com")
+			f := pkg.Files[0]
+			gd := testutil.FindNodes[*ast.GenDecl](f.AST())[1]
+
+			// Parse the directive from the func declaration.
+			dir, doc, ok := directive.Parse(tc.Errs, gd.Doc)
+			c.Assert(ok, qt.IsTrue)
+
+			pd := servicestruct.ParseData{
+				Errs:   tc.Errs,
+				Proto:  protoParser,
+				Schema: schemaParser,
+				File:   f,
+				Decl:   gd,
+				Dir:    dir,
+				Doc:    doc,
+			}
+
+			var endpoints []*api.GRPCEndpoint
+			if ss := servicestruct.Parse(tc.Ctx, pd); ss != nil {
+				if proto, ok := ss.Proto.Get(); ok {
+					endpoints = grpcservice.ParseEndpoints(grpcservice.ServiceDesc{
+						Errs:   tc.Errs,
+						Proto:  proto,
+						Schema: schemaParser,
+						Pkg:    pd.File.Pkg,
+						Decl:   ss.Decl,
+					})
+				}
+			}
+			if len(test.wantErrs) == 0 {
+				// Check for equality, ignoring all the AST nodes and pkginfo types.
+				cmpEqual := qt.CmpEquals(
+					cmpopts.IgnoreInterfaces(struct{ protoreflect.MethodDescriptor }{}),
+					cmpopts.IgnoreTypes(&schema.FuncDecl{}, &schema.TypeDecl{}, &pkginfo.File{}, &pkginfo.Package{}, token.Pos(0)),
+					cmpopts.EquateEmpty(),
+					cmpopts.IgnoreUnexported(schema.StructField{}, schema.NamedType{}),
+					cmp.Comparer(func(a, b *pkginfo.Package) bool {
+						return a.ImportPath == b.ImportPath
+					}),
+				)
+				c.Assert(endpoints, cmpEqual, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds the stating point of an *api.GRPCEndpoint resource and
begins emitting that resource based on methods on service structs.