### PR TITLE
Fix Stack traces on panics

### DIFF
--- a/runtime/appruntime/apisdk/api/handler.go
+++ b/runtime/appruntime/apisdk/api/handler.go
@@ -314,8 +314,8 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 			defer func() {
 				// Catch middleware panic
 				if e := recover(); e != nil {
-					panicStack := stack.Build(0)
-					resp.Err = errs.B().Code(errs.Internal).Meta("panic_stack", panicStack).Msgf("panic executing middleware %s.%s: %v",
+					panicStack := stack.BuildWithoutGoRuntime(2)
+					resp.Err = errs.B().Code(errs.Internal).Stack(panicStack).Meta("panic_stack", panicStack).Msgf("panic executing middleware %s.%s: %v",
 						mw.PkgName, mw.Name, e).Err()
 					resp.HTTPStatus = 500
 				}
@@ -326,8 +326,8 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 			defer func() {
 				// Catch handler panic
 				if e := recover(); e != nil {
-					panicStack := stack.Build(0)
-					resp.Err = errs.B().Code(errs.Internal).Meta("panic_stack", panicStack).Msgf(
+					panicStack := stack.BuildWithoutGoRuntime(2)
+					resp.Err = errs.B().Code(errs.Internal).Stack(panicStack).Meta("panic_stack", panicStack).Msgf(
 						"panic handling request: %v", e).Err()
 					resp.HTTPStatus = 500
 				}

--- a/runtime/beta/errs/builder.go
+++ b/runtime/beta/errs/builder.go
@@ -11,10 +11,12 @@ import (
 //
 // Use Err() to construct the error.
 type Builder struct {
-	code    ErrCode
-	codeSet bool
-	det     ErrDetails
-	detSet  bool
+	code     ErrCode
+	codeSet  bool
+	det      ErrDetails
+	detSet   bool
+	stack    stack.Stack
+	stackSet bool
 
 	msg  string
 	meta []interface{}
@@ -66,6 +68,10 @@ func (b *Builder) Cause(err error) *Builder {
 		if !b.detSet {
 			b.det = e.Details
 		}
+		if !b.stackSet {
+			b.stack = e.stack
+			b.stackSet = true
+		}
 	}
 	return b
 }
@@ -91,7 +97,9 @@ func (b *Builder) Err() error {
 
 	var errMeta Metadata
 	var s stack.Stack
-	if e, ok := b.err.(*Error); ok {
+	if b.stackSet {
+		s = b.stack
+	} else if e, ok := b.err.(*Error); ok {
 		errMeta = e.Meta
 		s = e.stack
 	} else {

--- a/runtime/beta/errs/errs_internal.go
+++ b/runtime/beta/errs/errs_internal.go
@@ -50,6 +50,13 @@ func DropStackFrame(err error) error {
 	return err
 }
 
+// Stack sets the stack of the new error.
+func (b *Builder) Stack(s stack.Stack) *Builder {
+	b.stack = s
+	b.stackSet = true
+	return b
+}
+
 // RoundTrip copies an error, returning an equivalent error
 // for replicating across RPC boundaries.
 func RoundTrip(err error) error {
@@ -61,6 +68,11 @@ func RoundTrip(err error) error {
 			Message: e.Message,
 			stack:   stack.Build(3), // skip caller of RoundTrip as well
 		}
+
+		// Register the stack type, even though we don't use it here as
+		// we pass "panic_stack" via the meta data and gob will error
+		// if the type hasn't been registered.
+		gob.Register(e2.stack)
 
 		if e.underlying != nil {
 			e2.underlying = errors.New(func() (rtn string) {


### PR DESCRIPTION
This commit fixes an issue where panic stack traces where not be propagated via the `RoundTrip` function, because `gob` did not know about the stack type.

This also improves panic stacks by removing all frames back to the user's code which caused the panic