### PR TITLE
.github/dockerimg: fix platform mismatch

### DIFF
--- a/.github/dockerimg/Dockerfile
+++ b/.github/dockerimg/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS build
+FROM --platform=$TARGETPLATFORM ubuntu:22.04 AS build
 ARG TARGETPLATFORM
 ARG RELEASE_VERSION
 ADD artifacts /artifacts
 RUN mkdir /encore
 RUN /bin/bash -c 'SRC=encore-$RELEASE_VERSION-$(echo $TARGETPLATFORM | tr '/' '_'); tar -C /encore -xzf /artifacts/$SRC/$SRC.tar.gz'
 
-FROM --platform=$BUILDPLATFORM ubuntu:22.04
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
 RUN apt-get update && apt-get install -y -f ca-certificates
 ENV PATH="/encore/bin:${PATH}"
 WORKDIR /src


### PR DESCRIPTION
Use the target platform instead of the build platform.