### PR TITLE
sqldb: change database name to snake case

### DIFF
--- a/v2/parser/infra/sqldb/sqldb.go
+++ b/v2/parser/infra/sqldb/sqldb.go
@@ -77,7 +77,7 @@ func parseDatabase(d parseutil.ReferenceInfo) {
 	}
 
 	databaseName := parseutil.ParseResourceName(d.Pass.Errs, "sqldb.NewDatabase", "database name",
-		d.Call.Args[0], parseutil.KebabName, "")
+		d.Call.Args[0], parseutil.SnakeName, "")
 	if databaseName == "" {
 		// we already reported the error inside ParseResourceName
 		return


### PR DESCRIPTION
The use of kebab_case was a mistake, it should
be aligned with `package_name` identifiers.

I reviewed the build metadata on the platform side and found very limited use of `database-name`
and have reached out to affected applications to
update them.