### PR TITLE
Ignore TS compile errors for makeRecord function

### DIFF
--- a/e2e-tests/testdata/echo_client/ts/client.ts
+++ b/e2e-tests/testdata/echo_client/ts/client.ts
@@ -745,6 +745,7 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
 
 // makeRecord takes a record and strips any undefined values from it,
 // and returns the same record with a narrower type.
+// @ts-ignore - TS ignore because makeRecord is not always used
 function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
     for (const key in record) {
         if (record[key] === undefined) {

--- a/internal/clientgen/testdata/expected_baseauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_baseauth_typescript.ts
@@ -27,7 +27,7 @@ export function PreviewEnv(pr: number | string): BaseURL {
 }
 
 /**
- * Client is an API client for the app Encore application. 
+ * Client is an API client for the app Encore application.
  */
 export default class Client {
     public readonly svc: svc.ServiceClient
@@ -128,6 +128,7 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
 
 // makeRecord takes a record and strips any undefined values from it,
 // and returns the same record with a narrower type.
+// @ts-ignore - TS ignore because makeRecord is not always used
 function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
     for (const key in record) {
         if (record[key] === undefined) {
@@ -182,7 +183,7 @@ class BaseClient {
             if (typeof auth === "function") {
                 this.authGenerator = auth
             } else {
-                this.authGenerator = () => auth                
+                this.authGenerator = () => auth
             }
         }
 
@@ -258,7 +259,7 @@ interface APIErrorResponse {
 
 function isAPIErrorResponse(err: any): err is APIErrorResponse {
     return (
-        err !== undefined && err !== null && 
+        err !== undefined && err !== null &&
         isErrCode(err.code) &&
         typeof(err.message) === "string" &&
         (err.details === undefined || err.details === null || typeof(err.details) === "object")
@@ -291,7 +292,7 @@ export class APIError extends Error {
     constructor(status: number, response: APIErrorResponse) {
         // extending errors causes issues after you construct them, unless you apply the following fixes
         super(response.message);
-        
+
         // set error name as constructor name, make it not enumerable to keep native Error behavior
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
         Object.defineProperty(this, 'name', {
@@ -299,14 +300,14 @@ export class APIError extends Error {
             enumerable:   false,
             configurable: true,
         })
-        
+
         // fix the prototype chain
-        if ((Object as any).setPrototypeOf == undefined) { 
-            (this as any).__proto__ = APIError.prototype 
+        if ((Object as any).setPrototypeOf == undefined) {
+            (this as any).__proto__ = APIError.prototype
         } else {
             Object.setPrototypeOf(this, APIError.prototype);
         }
-        
+
         // capture a stack trace
         if ((Error as any).captureStackTrace !== undefined) {
             (Error as any).captureStackTrace(this, this.constructor);

--- a/internal/clientgen/testdata/expected_baseauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_baseauth_typescript.ts
@@ -27,7 +27,7 @@ export function PreviewEnv(pr: number | string): BaseURL {
 }
 
 /**
- * Client is an API client for the app Encore application.
+ * Client is an API client for the app Encore application. 
  */
 export default class Client {
     public readonly svc: svc.ServiceClient
@@ -183,7 +183,7 @@ class BaseClient {
             if (typeof auth === "function") {
                 this.authGenerator = auth
             } else {
-                this.authGenerator = () => auth
+                this.authGenerator = () => auth                
             }
         }
 
@@ -259,7 +259,7 @@ interface APIErrorResponse {
 
 function isAPIErrorResponse(err: any): err is APIErrorResponse {
     return (
-        err !== undefined && err !== null &&
+        err !== undefined && err !== null && 
         isErrCode(err.code) &&
         typeof(err.message) === "string" &&
         (err.details === undefined || err.details === null || typeof(err.details) === "object")
@@ -292,7 +292,7 @@ export class APIError extends Error {
     constructor(status: number, response: APIErrorResponse) {
         // extending errors causes issues after you construct them, unless you apply the following fixes
         super(response.message);
-
+        
         // set error name as constructor name, make it not enumerable to keep native Error behavior
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
         Object.defineProperty(this, 'name', {
@@ -300,14 +300,14 @@ export class APIError extends Error {
             enumerable:   false,
             configurable: true,
         })
-
+        
         // fix the prototype chain
-        if ((Object as any).setPrototypeOf == undefined) {
-            (this as any).__proto__ = APIError.prototype
+        if ((Object as any).setPrototypeOf == undefined) { 
+            (this as any).__proto__ = APIError.prototype 
         } else {
             Object.setPrototypeOf(this, APIError.prototype);
         }
-
+        
         // capture a stack trace
         if ((Error as any).captureStackTrace !== undefined) {
             (Error as any).captureStackTrace(this, this.constructor);

--- a/internal/clientgen/testdata/expected_noauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_noauth_typescript.ts
@@ -27,7 +27,7 @@ export function PreviewEnv(pr: number | string): BaseURL {
 }
 
 /**
- * Client is an API client for the app Encore application. 
+ * Client is an API client for the app Encore application.
  */
 export default class Client {
     public readonly svc: svc.ServiceClient
@@ -96,6 +96,7 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
 
 // makeRecord takes a record and strips any undefined values from it,
 // and returns the same record with a narrower type.
+// @ts-ignore - TS ignore because makeRecord is not always used
 function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
     for (const key in record) {
         if (record[key] === undefined) {
@@ -201,7 +202,7 @@ interface APIErrorResponse {
 
 function isAPIErrorResponse(err: any): err is APIErrorResponse {
     return (
-        err !== undefined && err !== null && 
+        err !== undefined && err !== null &&
         isErrCode(err.code) &&
         typeof(err.message) === "string" &&
         (err.details === undefined || err.details === null || typeof(err.details) === "object")
@@ -234,7 +235,7 @@ export class APIError extends Error {
     constructor(status: number, response: APIErrorResponse) {
         // extending errors causes issues after you construct them, unless you apply the following fixes
         super(response.message);
-        
+
         // set error name as constructor name, make it not enumerable to keep native Error behavior
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
         Object.defineProperty(this, 'name', {
@@ -242,14 +243,14 @@ export class APIError extends Error {
             enumerable:   false,
             configurable: true,
         })
-        
+
         // fix the prototype chain
-        if ((Object as any).setPrototypeOf == undefined) { 
-            (this as any).__proto__ = APIError.prototype 
+        if ((Object as any).setPrototypeOf == undefined) {
+            (this as any).__proto__ = APIError.prototype
         } else {
             Object.setPrototypeOf(this, APIError.prototype);
         }
-        
+
         // capture a stack trace
         if ((Error as any).captureStackTrace !== undefined) {
             (Error as any).captureStackTrace(this, this.constructor);

--- a/internal/clientgen/testdata/expected_noauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_noauth_typescript.ts
@@ -27,7 +27,7 @@ export function PreviewEnv(pr: number | string): BaseURL {
 }
 
 /**
- * Client is an API client for the app Encore application.
+ * Client is an API client for the app Encore application. 
  */
 export default class Client {
     public readonly svc: svc.ServiceClient
@@ -202,7 +202,7 @@ interface APIErrorResponse {
 
 function isAPIErrorResponse(err: any): err is APIErrorResponse {
     return (
-        err !== undefined && err !== null &&
+        err !== undefined && err !== null && 
         isErrCode(err.code) &&
         typeof(err.message) === "string" &&
         (err.details === undefined || err.details === null || typeof(err.details) === "object")
@@ -235,7 +235,7 @@ export class APIError extends Error {
     constructor(status: number, response: APIErrorResponse) {
         // extending errors causes issues after you construct them, unless you apply the following fixes
         super(response.message);
-
+        
         // set error name as constructor name, make it not enumerable to keep native Error behavior
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
         Object.defineProperty(this, 'name', {
@@ -243,14 +243,14 @@ export class APIError extends Error {
             enumerable:   false,
             configurable: true,
         })
-
+        
         // fix the prototype chain
-        if ((Object as any).setPrototypeOf == undefined) {
-            (this as any).__proto__ = APIError.prototype
+        if ((Object as any).setPrototypeOf == undefined) { 
+            (this as any).__proto__ = APIError.prototype 
         } else {
             Object.setPrototypeOf(this, APIError.prototype);
         }
-
+        
         // capture a stack trace
         if ((Error as any).captureStackTrace !== undefined) {
             (Error as any).captureStackTrace(this, this.constructor);

--- a/internal/clientgen/testdata/expected_typescript.ts
+++ b/internal/clientgen/testdata/expected_typescript.ts
@@ -27,7 +27,7 @@ export function PreviewEnv(pr: number | string): BaseURL {
 }
 
 /**
- * Client is an API client for the app Encore application. 
+ * Client is an API client for the app Encore application.
  */
 export default class Client {
     public readonly products: products.ServiceClient
@@ -369,6 +369,7 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
 
 // makeRecord takes a record and strips any undefined values from it,
 // and returns the same record with a narrower type.
+// @ts-ignore - TS ignore because makeRecord is not always used
 function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
     for (const key in record) {
         if (record[key] === undefined) {
@@ -438,7 +439,7 @@ class BaseClient {
             if (typeof auth === "function") {
                 this.authGenerator = auth
             } else {
-                this.authGenerator = () => auth                
+                this.authGenerator = () => auth
             }
         }
 
@@ -514,7 +515,7 @@ interface APIErrorResponse {
 
 function isAPIErrorResponse(err: any): err is APIErrorResponse {
     return (
-        err !== undefined && err !== null && 
+        err !== undefined && err !== null &&
         isErrCode(err.code) &&
         typeof(err.message) === "string" &&
         (err.details === undefined || err.details === null || typeof(err.details) === "object")
@@ -547,7 +548,7 @@ export class APIError extends Error {
     constructor(status: number, response: APIErrorResponse) {
         // extending errors causes issues after you construct them, unless you apply the following fixes
         super(response.message);
-        
+
         // set error name as constructor name, make it not enumerable to keep native Error behavior
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
         Object.defineProperty(this, 'name', {
@@ -555,14 +556,14 @@ export class APIError extends Error {
             enumerable:   false,
             configurable: true,
         })
-        
+
         // fix the prototype chain
-        if ((Object as any).setPrototypeOf == undefined) { 
-            (this as any).__proto__ = APIError.prototype 
+        if ((Object as any).setPrototypeOf == undefined) {
+            (this as any).__proto__ = APIError.prototype
         } else {
             Object.setPrototypeOf(this, APIError.prototype);
         }
-        
+
         // capture a stack trace
         if ((Error as any).captureStackTrace !== undefined) {
             (Error as any).captureStackTrace(this, this.constructor);

--- a/internal/clientgen/testdata/expected_typescript.ts
+++ b/internal/clientgen/testdata/expected_typescript.ts
@@ -27,7 +27,7 @@ export function PreviewEnv(pr: number | string): BaseURL {
 }
 
 /**
- * Client is an API client for the app Encore application.
+ * Client is an API client for the app Encore application. 
  */
 export default class Client {
     public readonly products: products.ServiceClient
@@ -439,7 +439,7 @@ class BaseClient {
             if (typeof auth === "function") {
                 this.authGenerator = auth
             } else {
-                this.authGenerator = () => auth
+                this.authGenerator = () => auth                
             }
         }
 
@@ -515,7 +515,7 @@ interface APIErrorResponse {
 
 function isAPIErrorResponse(err: any): err is APIErrorResponse {
     return (
-        err !== undefined && err !== null &&
+        err !== undefined && err !== null && 
         isErrCode(err.code) &&
         typeof(err.message) === "string" &&
         (err.details === undefined || err.details === null || typeof(err.details) === "object")
@@ -548,7 +548,7 @@ export class APIError extends Error {
     constructor(status: number, response: APIErrorResponse) {
         // extending errors causes issues after you construct them, unless you apply the following fixes
         super(response.message);
-
+        
         // set error name as constructor name, make it not enumerable to keep native Error behavior
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
         Object.defineProperty(this, 'name', {
@@ -556,14 +556,14 @@ export class APIError extends Error {
             enumerable:   false,
             configurable: true,
         })
-
+        
         // fix the prototype chain
-        if ((Object as any).setPrototypeOf == undefined) {
-            (this as any).__proto__ = APIError.prototype
+        if ((Object as any).setPrototypeOf == undefined) { 
+            (this as any).__proto__ = APIError.prototype 
         } else {
             Object.setPrototypeOf(this, APIError.prototype);
         }
-
+        
         // capture a stack trace
         if ((Error as any).captureStackTrace !== undefined) {
             (Error as any).captureStackTrace(this, this.constructor);

--- a/internal/clientgen/typescript.go
+++ b/internal/clientgen/typescript.go
@@ -858,6 +858,7 @@ function encodeQuery(parts: Record<string, string | string[]>): string {
 
 // makeRecord takes a record and strips any undefined values from it,
 // and returns the same record with a narrower type.
+// @ts-ignore - TS ignore because makeRecord is not always used
 function makeRecord<K extends string | number | symbol, V>(record: Record<K, V | undefined>): Record<K, V> {
     for (const key in record) {
         if (record[key] === undefined) {


### PR DESCRIPTION
Adding a `@ts-ignore` comment before the `makeRecord`-function in the generated TS client. 

I get a Typescript compilation error for this function, I can not build my project after generating the client. The reason is that we are adding that function but in my case it is never used, so I get error TS6133: 'makeRecord' is declared but its value is never read.

Another option is to add a `@ts-nocheck` comment at the top of the file but ignoring everything feels a bit scary, then we run the risk of introducing runtime errors instead.
