### PR TITLE
Add new `MaxConcurrency` to PubSub subscriptions

### DIFF
--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.19.10
 	github.com/benbjohnson/clock v1.3.3
 	github.com/felixge/httpsnoop v1.0.3
+	github.com/frankban/quicktest v1.14.5
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3
@@ -27,11 +28,13 @@ require (
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/modern-go/reflect2 v1.0.2
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d
 	github.com/rs/xid v1.4.0
 	github.com/rs/zerolog v1.29.1
 	go.encore.dev/platform-sdk v1.1.0
+	golang.org/x/crypto v0.9.0
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	golang.org/x/time v0.3.0
 	google.golang.org/api v0.119.0
@@ -71,15 +74,16 @@ require (
 	github.com/jackc/puddle/v2 v2.2.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/runtime/go.sum
+++ b/runtime/go.sum
@@ -89,6 +89,7 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -104,6 +105,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
+github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -194,7 +196,9 @@ github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -219,12 +223,14 @@ github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d h1:gNEXs+4IbftZmT6WnAJbBWgbPrjDjqaMfuNeKODqBhc=
 github.com/rs/cors v1.8.3-0.20221003140808-fcebdb403f4d/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
@@ -248,8 +254,6 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 h1:5mLPGnFdSsevFRFc9q3yYbBkB6tsm4aCwwQV/j1JQAQ=
 github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
-go.encore.dev/platform-sdk v1.0.0 h1:I+x7Z/m2E/1K9HuC5Hta7xUm2d+1TWKEp5QOQaKAc+o=
-go.encore.dev/platform-sdk v1.0.0/go.mod h1:ImcJU8p0V3bSXb+d++Ni/8hFDwVZaFpUAAySTY2x6FY=
 go.encore.dev/platform-sdk v1.1.0 h1:0BYLt7ZAoPje3KMLee6/gA2FECHwzi1sKgp3SqC+QRo=
 go.encore.dev/platform-sdk v1.1.0/go.mod h1:ImcJU8p0V3bSXb+d++Ni/8hFDwVZaFpUAAySTY2x6FY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
@@ -259,8 +263,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
-golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -283,8 +285,6 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
-golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/runtime/pubsub/internal/aws/topic.go
+++ b/runtime/pubsub/internal/aws/topic.go
@@ -82,6 +82,10 @@ func (t *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadlin
 
 	ackDeadline = utils.Clamp(ackDeadline, time.Second, 12*time.Hour)
 
+	if maxConcurrency == 0 {
+		maxConcurrency = 1 // FIXME(domblack): This retains the old behaviour, but allows user customisation - in a future release we should remove this
+	}
+
 	go func() {
 		for t.ctx.Err() == nil {
 			err := utils.WorkConcurrently(

--- a/runtime/pubsub/internal/aws/topic_test.go
+++ b/runtime/pubsub/internal/aws/topic_test.go
@@ -63,7 +63,7 @@ func Test_AWS_PubSub_E2E(t *testing.T) {
 	// Subscribe to the queue
 	msgChan := make(chan string)
 	var sentMessageID string
-	topic.Subscribe(&log.Logger, time.Second, nil, runtime.PubsubTopics["test-topic"].Subscriptions["test-subscription"], func(ctx context.Context, msgID string, publishTime time.Time, deliveryAttempt int, attrs map[string]string, data []byte) error {
+	topic.Subscribe(&log.Logger, 0, time.Second, nil, runtime.PubsubTopics["test-topic"].Subscriptions["test-subscription"], func(ctx context.Context, msgID string, publishTime time.Time, deliveryAttempt int, attrs map[string]string, data []byte) error {
 		if attrs["attr-1"] != "foo" {
 			t.Errorf("expected attr-1 to be foo, got %s", attrs["attr-1"])
 		}

--- a/runtime/pubsub/internal/azure/topic.go
+++ b/runtime/pubsub/internal/azure/topic.go
@@ -153,6 +153,11 @@ func (t *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadlin
 	if err != nil {
 		panic(fmt.Sprintf("failed to create pubsub receiver for subscription %s: %s", subCfg.EncoreName, err))
 	}
+
+	if maxConcurrency == 0 {
+		maxConcurrency = 1 // FIXME(domblack): This retains the old behaviour, but allows user customisation - in a future release we should remove this
+	}
+
 	// Start the subscription
 	go func() {
 		for t.mgr.ctx.Err() == nil {

--- a/runtime/pubsub/internal/encorecloud/topic.go
+++ b/runtime/pubsub/internal/encorecloud/topic.go
@@ -19,7 +19,7 @@ func (t *topic) PublishMessage(ctx context.Context, orderingKey string, attrs ma
 	return t.mgr.client.PublishToTopic(ctx, t.cfg.ProviderName, orderingKey, attrs, data)
 }
 
-func (t *topic) Subscribe(logger *zerolog.Logger, _ time.Duration, _ *types.RetryPolicy, subCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {
+func (t *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadline time.Duration, retryPolicy *types.RetryPolicy, subCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {
 	if subCfg.ID == "" {
 		panic("encorecloud pubsub subscriptions must have an ID")
 	}

--- a/runtime/pubsub/internal/gcp/topic.go
+++ b/runtime/pubsub/internal/gcp/topic.go
@@ -92,6 +92,10 @@ func (t *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadlin
 		// Create the subscription object (and then check it exists on GCP's side)
 		subscription := t.client.SubscriptionInProject(subCfg.ProviderName, gcpCfg.ProjectID)
 
+		if maxConcurrency == 0 {
+			maxConcurrency = 1000 // FIXME(domblack): This retains the old behaviour, but allows user customisation - in a future release we should remove this
+		}
+
 		// Set the concurrency
 		subscription.ReceiveSettings.MaxOutstandingMessages = maxConcurrency
 		subscription.ReceiveSettings.NumGoroutines = utils.Clamp(maxConcurrency, 1, maxConcurrency)

--- a/runtime/pubsub/internal/nsq/topic.go
+++ b/runtime/pubsub/internal/nsq/topic.go
@@ -82,7 +82,11 @@ func (l *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadlin
 	// only log warnings and above from the NSQ library
 	consumer.SetLogger(&LogAdapter{Logger: logger}, nsq.LogLevelWarning)
 
-	if maxConcurrency <= 0 {
+	if maxConcurrency == 0 {
+		maxConcurrency = 1 // FIXME(domblack): This retains the old behaviour, but allows user customisation - in a future release we should remove this
+	}
+
+	if maxConcurrency < 0 {
 		// nsq does not support the concept of unlimited concurrency, so we set it to a high number here
 		// (value of 0 will pause consumption)
 		maxConcurrency = 100

--- a/runtime/pubsub/internal/test/topic.go
+++ b/runtime/pubsub/internal/test/topic.go
@@ -81,7 +81,7 @@ func (t *TestTopic[T]) PublishMessage(ctx context.Context, orderingKey string, a
 }
 
 // Subscribe will register a new subscriber for the pub sub topic. By default these will not be called during tests
-func (t *TestTopic[T]) Subscribe(logger *zerolog.Logger, ackDeadline time.Duration, retryPolicy *types.RetryPolicy, implCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {
+func (t *TestTopic[T]) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadline time.Duration, retryPolicy *types.RetryPolicy, implCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {
 	t.m.Lock()
 	defer t.m.Unlock()
 	t.subscribers[implCfg.EncoreName] = f

--- a/runtime/pubsub/internal/types/private.go
+++ b/runtime/pubsub/internal/types/private.go
@@ -15,5 +15,5 @@ type RawSubscriptionCallback func(ctx context.Context, msgID string, publishTime
 // TopicImplementation gives us a private API to implementing topics, which we can change without impacting the public API
 type TopicImplementation interface {
 	PublishMessage(ctx context.Context, orderingKey string, attrs map[string]string, data []byte) (id string, err error)
-	Subscribe(logger *zerolog.Logger, ackDeadline time.Duration, retryPolicy *RetryPolicy, implCfg *config.PubsubSubscription, f RawSubscriptionCallback)
+	Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadline time.Duration, retryPolicy *RetryPolicy, implCfg *config.PubsubSubscription, f RawSubscriptionCallback)
 }

--- a/runtime/pubsub/internal/utils/workers.go
+++ b/runtime/pubsub/internal/utils/workers.go
@@ -1,0 +1,246 @@
+package utils
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// Between work processors finishing a work item, how long we debounce before fetching more work
+	// (this is to avoid fetching work items in batches of 1)
+	workFetchDebounce = 25 * time.Millisecond
+
+	// What is the maximum amount of time we wait before fetching work items when debouncing
+	maxFetchDebounce = 250 * time.Millisecond
+)
+
+// WorkFetcher is a function that fetches work from a queue, it should fetch at most maxToFetch items
+// and block until it has at least one item to return.
+type WorkFetcher[Work any] func(ctx context.Context, maxToFetch int) ([]Work, error)
+
+// WorkProcessor is a function that processes a single work item, it should block until the work item is processed
+type WorkProcessor[Work any] func(ctx context.Context, work Work) error
+
+// WorkConcurrently fetches work using the given fetch function and then passes it to the worker function
+//
+// It will fetch at most maxBatchSize items at a time and guarantees that at most maxConcurrency items have been fetched
+// and are being processed at any given time.
+//
+// If maxBatchSize >= 1, will fetch at most maxBatchSize items at a time
+// If maxBatchSize <= 0, will fetch as most maxConcurrency items at a time
+//
+// If maxConcurrency <= 0 then there is no limit on the number of items being processed at a time
+//
+// This function will block until an error is returned from either the fetcher or the worker functions or until
+// the context is cancelled.
+func WorkConcurrently[Work any](ctx context.Context, maxConcurrency int, maxBatchSize int, fetch WorkFetcher[Work], worker WorkProcessor[Work]) error {
+	if maxConcurrency == 1 {
+		// If there's no concurrency, we can just do everything synchronously within this goroutine
+		// This avoids the overhead of creating mutexes being used
+		return workInSingleRoutine(ctx, fetch, worker)
+
+	} else if maxConcurrency <= 0 {
+		// If there's infinite concurrency, we can just do everything by spawning goroutines
+		// for each work item
+		return workInInfiniteRoutines(ctx, maxBatchSize, fetch, worker)
+
+	} else {
+		// Else there's a cap on concurrency, we need to use channels to communicate between the fetcher and the workers
+		return workInWorkPool(ctx, maxConcurrency, maxBatchSize, fetch, worker)
+	}
+}
+
+func workInSingleRoutine[Work any](ctx context.Context, fetch WorkFetcher[Work], worker WorkProcessor[Work]) error {
+	for {
+		// check if the context has been cancelled before fetching work
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+
+		// fetch 1 item
+		work, err := fetch(ctx, 1)
+		if err != nil {
+			return err
+		}
+
+		// loop over the items (we might get zero, and a buggy implementation might return more than 1, so a loop is safer)
+		for _, w := range work {
+			// check if the context has been cancelled before processing the work
+			if err := ctx.Err(); err != nil {
+				return nil
+			}
+
+			// process the work
+			if err := worker(ctx, w); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func workInInfiniteRoutines[Work any](ctx context.Context, maxBatchSize int, fetch WorkFetcher[Work], worker WorkProcessor[Work]) error {
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var firstError error
+	var errMutex sync.Mutex
+	recordError := func(err error) {
+		errMutex.Lock()
+		defer errMutex.Unlock()
+		if firstError == nil {
+			firstError = err
+			cancel()
+		}
+	}
+
+	if maxBatchSize <= 0 {
+		maxBatchSize = 100
+	}
+
+	for workerCtx.Err() == nil {
+		work, err := fetch(workerCtx, maxBatchSize)
+		if err != nil {
+			recordError(err)
+			break
+		}
+
+		for _, w := range work {
+			w := w
+			go func() {
+				if err := worker(workerCtx, w); err != nil {
+					recordError(err)
+				}
+			}()
+		}
+	}
+
+	// Return the first error that was encountered
+	errMutex.Lock()
+	defer errMutex.Unlock()
+	return firstError
+}
+
+func workInWorkPool[Work any](ctx context.Context, maxConcurrency int, maxBatchSize int, fetch WorkFetcher[Work], worker WorkProcessor[Work]) error {
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// workChan is a channel that is used to pass work from the fetcher to the workers
+	workChan := make(chan Work)
+
+	// workDone is a channel that is used to signal that a worker has finished processing an item
+	workDone := make(chan struct{}, maxConcurrency)
+
+	var firstError error
+	var errMutex sync.Mutex
+	recordError := func(err error) {
+		errMutex.Lock()
+		defer errMutex.Unlock()
+		if firstError == nil {
+			firstError = err
+			cancel()
+		}
+	}
+
+	var inFlight atomic.Int64
+
+	// workProcessor is a small wrapper around the worker function that tracks the number of items being processed
+	// and cancels the context if an error is returned
+	workProcessor := func(work Work) {
+		inFlight.Add(1)
+		defer inFlight.Add(-1)
+		defer func() { workDone <- struct{}{} }()
+
+		if err := worker(workerCtx, work); err != nil {
+			recordError(err)
+		}
+	}
+
+	// fetchProcessor is a small wrapper around the fetcher function that passes the fetched work to the workers
+	// it will fetch upto maxConcurrency items at a time in batches of maxBatchSize items
+	var lastFetch time.Time
+	var debounceTimer *time.Timer
+	var fetchLock sync.Mutex
+	fetchProcessor := func() {
+		// Lock the fetcher so that we don't have multiple fetchers running at the same time
+		fetchLock.Lock()
+		defer fetchLock.Unlock()
+		defer func() { lastFetch = time.Now() }()
+
+		// Work out how many items we need to fetch
+		need := maxConcurrency - int(inFlight.Load())
+
+		// Fetch work in batches
+		for need > 0 {
+			// calculate how many items we need to fetch in this batch
+			toFetch := need
+			if maxBatchSize > 0 && toFetch > maxBatchSize {
+				toFetch = maxBatchSize
+			}
+
+			// fetch the work
+			work, err := fetch(workerCtx, toFetch)
+			if err != nil {
+				recordError(err)
+				return
+			}
+
+			// Pass work to workers
+			for _, w := range work {
+				workChan <- w
+			}
+
+			// Update the number of items we need to fetch
+			// if nothing was returned, we will immediately loop and try again
+			need -= len(work)
+		}
+	}
+
+	// Start the workers
+	for i := 0; i < maxConcurrency; i++ {
+		go func() {
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+
+				case work := <-workChan:
+					workProcessor(work)
+				}
+			}
+		}()
+	}
+
+	// Add a dummy item to the workDone channel so that the fetcher will be triggered
+	// for the first time
+	workDone <- struct{}{}
+
+	// Start fetching work
+fetchLoop:
+	for {
+		select {
+		case <-workerCtx.Done():
+			// If the context is cancelled, we need to stop fetching work
+			break fetchLoop
+
+		case <-workDone:
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+				debounceTimer = nil
+			}
+
+			if time.Since(lastFetch) > maxFetchDebounce {
+				fetchProcessor()
+			} else {
+				debounceTimer = time.AfterFunc(workFetchDebounce, fetchProcessor)
+			}
+
+		}
+	}
+
+	// Return the first error that was encountered
+	errMutex.Lock()
+	defer errMutex.Unlock()
+	return firstError
+}

--- a/runtime/pubsub/internal/utils/workers_test.go
+++ b/runtime/pubsub/internal/utils/workers_test.go
@@ -1,0 +1,210 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestWorkConcurrently(t *testing.T) {
+	t.Parallel()
+
+	params := []struct {
+		concurrency  int
+		maxBatchSize int
+		fetchErr     error
+		processErr   error
+	}{
+		// Simple concurrency tests
+		{1, 10, nil, nil},
+		{10, 10, nil, nil},
+		{50, 50, nil, nil},
+
+		// Test batch sizes
+		{50, 0, nil, nil}, // Unlimited batch size
+		{50, 1, nil, nil},
+		{50, 10, nil, nil},
+
+		// Unlimited concurrency
+		{-1, 0, nil, nil},  // No batch size and unlimited concurrency
+		{-1, 10, nil, nil}, // Unlimited concurrency, but a batch size
+
+		// Test errors
+		{50, 10, fmt.Errorf("fetch error"), nil},
+		{50, 10, nil, fmt.Errorf("process error")},
+	}
+
+	for _, tt := range params {
+		tt := tt
+		t.Run(fmt.Sprintf("c%d_b%d", tt.concurrency, tt.maxBatchSize), func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			// Create a context which will timeout the test
+			timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer timeoutCancel()
+
+			// Then create a context which will cancel the work generator off that
+			// (which we use to break out of the work generator loop)
+			ctx, cancel := context.WithCancel(timeoutCtx)
+			defer cancel()
+
+			// The number of items we've generated
+			toGenerate := tt.concurrency * 3 // We want to generate enough work to fill the workers plus test other outcomes
+			if toGenerate <= 0 {
+				toGenerate = 2_000 // If we have unlimited concurrency, we need to generate a lot of work
+			}
+			var nextWork int
+			type fetchReq struct {
+				toFetch     int
+				numReturned int
+			}
+			var fetchRequests []*fetchReq // We want to test that the fetcher is called the correct number of times
+
+			// We want to test that the concurrency is respected and the max concurrency is reached
+			// so this section setups a counter and max counter to track the number of active workers
+			var counterMu sync.Mutex
+			var activeWorkers int
+			var maxActiveWorkers int
+			incActiveWorkers := func() {
+				counterMu.Lock()
+				defer counterMu.Unlock()
+				activeWorkers++
+				if activeWorkers > maxActiveWorkers {
+					maxActiveWorkers = activeWorkers
+				}
+			}
+			decActiveWorkers := func() {
+				counterMu.Lock()
+				defer counterMu.Unlock()
+				activeWorkers--
+			}
+
+			// We want to test that all the work was received by the processor
+			// so we'll track the work received in a slice protected by a mutex
+			var workMu sync.Mutex
+			var receivedWork []int
+
+			// Create the fetcher function
+			fetcher := func(ctx context.Context, toFetch int) ([]int, error) {
+				// No work to fetch return nothing
+				if nextWork >= toGenerate {
+					return nil, nil
+				}
+
+				// record this fetch request
+				req := &fetchReq{
+					toFetch: toFetch,
+				}
+				fetchRequests = append(fetchRequests, req)
+
+				// One of the fetches should return no data
+				switch len(fetchRequests) {
+				case 2:
+					// simulate only one piece of data on fetch 1
+					toFetch = 1
+				case 3:
+					// simulate no data on fetch 2
+					time.Sleep(500 * time.Millisecond)
+					return nil, nil
+				case 4:
+					// simulate only half the data is available on fetch 3
+					toFetch = toFetch / 2
+				case 5:
+					// If we have a fetch error, return it on fetch 4
+					if tt.fetchErr != nil {
+						return nil, tt.fetchErr
+					}
+				}
+
+				rtn := make([]int, 0, toFetch)
+				for i := 0; i < toFetch; i++ {
+					rtn = append(rtn, nextWork)
+					nextWork++
+				}
+
+				// If we've generated enough work to fill the workers, cancel the context in a little bit
+				// giving time for the workers to process the work
+				if nextWork >= toGenerate {
+					go func() {
+						time.Sleep(50 * time.Millisecond)
+						cancel()
+					}()
+				}
+
+				req.numReturned = len(rtn)
+				return rtn, nil
+			}
+
+			// Create the processor function
+			processor := func(ctx context.Context, work int) error {
+				incActiveWorkers()
+				defer decActiveWorkers()
+
+				// simulate some work
+				time.Sleep(10 * time.Millisecond)
+
+				workMu.Lock()
+				defer workMu.Unlock()
+				receivedWork = append(receivedWork, work)
+
+				// If we have a process error, return it around half way through the work
+				if tt.processErr != nil && len(receivedWork) > (toGenerate/2) {
+					return tt.processErr
+				}
+
+				return nil
+			}
+
+			err := WorkConcurrently(ctx, tt.concurrency, tt.maxBatchSize, fetcher, processor)
+
+			// Run assertions on the exit conditions
+			c.Assert(timeoutCtx.Err(), qt.IsNil, qt.Commentf("test timed out - not all work was fetched within the timeout"))
+			switch {
+			case tt.fetchErr != nil:
+				c.Assert(err, qt.ErrorIs, tt.fetchErr, qt.Commentf("unexpected error from work concurrently"))
+				c.Assert(len(receivedWork) < toGenerate, qt.IsTrue, qt.Commentf("all the work was fetched even though there was a fetch error"))
+				return
+			case tt.processErr != nil:
+				c.Assert(err, qt.ErrorIs, tt.processErr, qt.Commentf("unexpected error from work concurrently"))
+				c.Assert(len(receivedWork) < toGenerate, qt.IsTrue, qt.Commentf("all the work was fetched even though there was a process error"))
+				return
+			default:
+				c.Assert(err, qt.IsNil, qt.Commentf("unexpected error from work concurrently"))
+			}
+
+			// Run assertions on the processed data
+			c.Assert(receivedWork, qt.HasLen, nextWork, qt.Commentf("not all work was received/processed"))
+			if tt.concurrency > 0 {
+				c.Assert(maxActiveWorkers <= tt.concurrency, qt.IsTrue, qt.Commentf("max concurrency was not respected; reached %d workers", maxActiveWorkers))
+				c.Assert(maxActiveWorkers == tt.concurrency, qt.IsTrue, qt.Commentf("max concurrency was not reached; only got %d workers at one time", maxActiveWorkers))
+			}
+			sort.Ints(receivedWork)
+			for i, work := range receivedWork {
+				c.Assert(work, qt.Equals, i, qt.Commentf("unexpected work received (once sorted); expected %d, got %d", i, work))
+			}
+
+			// Run assertions on the fetch requests
+			maxBatchSize := tt.maxBatchSize
+			if maxBatchSize <= 0 || (maxBatchSize > tt.concurrency && tt.concurrency > 0) {
+				if tt.concurrency > 0 {
+					maxBatchSize = tt.concurrency
+				} else {
+					maxBatchSize = 100
+				}
+			}
+			c.Assert(fetchRequests[0].toFetch, qt.Equals, maxBatchSize, qt.Commentf("first fetch request was not the max batch size"))
+			c.Assert(fetchRequests[0].numReturned, qt.Equals, maxBatchSize, qt.Commentf("first fetch request did not return a full batch"))
+			for i, req := range fetchRequests {
+				c.Assert(req.toFetch, qt.Not(qt.Equals), 0, qt.Commentf("fetch request %d was 0", i))
+				c.Assert(req.toFetch <= maxBatchSize, qt.IsTrue, qt.Commentf("max batch size was not respected; requested %d items on fetch %d", req, i))
+				c.Assert(req.toFetch >= req.numReturned, qt.IsTrue, qt.Commentf("test function returned too many items"))
+			}
+		})
+	}
+}

--- a/runtime/pubsub/subscription.go
+++ b/runtime/pubsub/subscription.go
@@ -96,11 +96,6 @@ func NewSubscription[T any](topic *Topic[T], name string, cfg SubscriptionConfig
 		return cfg.Handler(ctx, msg)
 	}
 
-	// Configure the max concurrency
-	if cfg.MaxConcurrency == 0 {
-		cfg.MaxConcurrency = 100
-	}
-
 	log := mgr.rootLogger.With().
 		Str("service", staticCfg.Service).
 		Str("topic", topic.runtimeCfg.EncoreName).

--- a/runtime/pubsub/types.go
+++ b/runtime/pubsub/types.go
@@ -45,6 +45,28 @@ type SubscriptionConfig[T any] struct {
 	// [Encore service struct]: https://encore.dev/docs/primitives/services-and-apis#service-structs
 	Handler func(ctx context.Context, msg T) error
 
+	// MaxConcurrency is the maximum number of messages which will be processed
+	// simultaneously per instance of the service for this subscription.
+	//
+	// Note that this is per instance of the service, so if your service has
+	// scaled to 10 instances and this is set to 10, then 100 messages could be
+	// processed simultaneously.
+	//
+	// If the value is negative, then there will be no limit on the number
+	// of messages processed simultaneously.
+	//
+	// Note: This is not supported by all cloud providers; specifically on GCP
+	// when using Cloud Run instances on an unordered topic the subscription will
+	// be configured as a Push Subscription and will have an adaptive concurrency
+	// See [GCP Push Delivery Rate].
+	//
+	// This setting also has no effect on Encore Cloud environments.
+	//
+	// If not set, it uses a reasonable default based on the cloud provider.
+	//
+	// [GCP Push Delivery Rate]: https://cloud.google.com/pubsub/docs/push#push_delivery_rate
+	MaxConcurrency int
+
 	// Filter is a boolean expression using =, !=, IN, &&
 	// It is used to filter which messages are forwarded from the
 	// topic to a subscription

--- a/v2/app/testdata/pubsub.txt
+++ b/v2/app/testdata/pubsub.txt
@@ -41,6 +41,7 @@ var (
     _ = pubsub.NewSubscription(shared.BasicTopic, "basic-subscription",
         pubsub.SubscriptionConfig {
             Handler: Subscriber1,
+            MaxConcurrency: 25,
             AckDeadline: 45 * time.Second,
             MessageRetention: 5 * time.Hour * 24 + -10 * time.Hour,
             RetryPolicy: &pubsub.RetryPolicy{

--- a/v2/parser/infra/pubsub/subscription.go
+++ b/v2/parser/infra/pubsub/subscription.go
@@ -121,11 +121,13 @@ func parsePubSubSubscription(d parseutil.ReferenceInfo) {
 		Handler ast.Expr `literal:",dynamic,required"`
 
 		// Optional configuration
+		MaxConcurrency   int           `literal:",optional,default"`
 		AckDeadline      time.Duration `literal:",optional,default"`
 		MessageRetention time.Duration `literal:",optional,default"`
 		RetryPolicy      retryConfig   `literal:",optional,default"`
 	}
 	defaults := decodedConfig{
+		MaxConcurrency:   100,
 		AckDeadline:      30 * time.Second,
 		MessageRetention: 7 * 24 * time.Hour,
 		RetryPolicy: retryConfig{


### PR DESCRIPTION
This commit adds a new `MaxConcurrency` configuration parameter to PubSub subscriptions, allowing the end user to control how parallelizable their subscriptions are.

It  respects batch sizes enforced by the cloud providers, and uses a new `WorkConcurrently` to control fetching of work and processing of work in a way that it respects the `MaxConcurrency` field and will never go _above_ it.