### PR TITLE
Re-add schema validation for Header & Query String fields

### DIFF
--- a/cli/daemon/run/errors.go
+++ b/cli/daemon/run/errors.go
@@ -7,7 +7,7 @@ import (
 	"encr.dev/v2/internals/perr"
 )
 
-func asErrorList(err error) *errlist.List {
+func AsErrorList(err error) *errlist.List {
 	if errList := errlist.Convert(err); errList != nil {
 		return errList
 	}

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -120,7 +120,7 @@ func (mgr *Manager) Start(ctx context.Context, params StartParams) (run *Run, er
 	mgr.mu.Unlock()
 
 	if err := run.start(params.Listener, params.OpsTracker); err != nil {
-		if errList := asErrorList(err); errList != nil {
+		if errList := AsErrorList(err); errList != nil {
 			return nil, errList
 		}
 		return nil, err

--- a/cli/daemon/run/watch.go
+++ b/cli/daemon/run/watch.go
@@ -18,7 +18,7 @@ func (mgr *Manager) watch(run *Run) error {
 
 		mgr.RunStdout(run, []byte("Changes detected, recompiling...\n"))
 		if err := run.Reload(); err != nil {
-			if errList := asErrorList(err); errList != nil {
+			if errList := AsErrorList(err); errList != nil {
 				mgr.RunError(run, errList)
 			} else {
 				errStr := err.Error()

--- a/internal/optracker/optracker.go
+++ b/internal/optracker/optracker.go
@@ -161,7 +161,6 @@ func (t *OpTracker) refresh() {
 		return ops[i].start.Before(ops[j].start)
 	})
 
-	// var errlistToSend *errlist.List
 	for _, o := range ops {
 		started := o.start.Before(now)
 		done := !o.done.IsZero() && o.done.Before(now)
@@ -177,7 +176,6 @@ func (t *OpTracker) refresh() {
 				msg = aurora.Yellow(fmt.Sprintf(format+"Canceled", canceled, o.msg))
 			} else {
 				if errlist := errlist.Convert(o.err); errlist != nil {
-					// errlistToSend = errlist
 					if len(errlist.List) > 0 {
 						msg = aurora.Red(fmt.Sprintf(format+"Failed: %v", fail, o.msg, errlist.List[0].Title()))
 					} else {
@@ -200,15 +198,6 @@ func (t *OpTracker) refresh() {
 			str,
 		)
 	}
-
-	// For now we don't send the error list to the stream
-	// as the OpTracker is only used for the initial build
-	// and we don't want to send the error list to the stream
-	// because the Run command will send the error list to the stream
-	// if errlistToSend != nil {
-	// 	// We sent this after we clear and repaint the screen
-	// 	errlistToSend.SendToStream(t.stream)
-	// }
 }
 
 func (t *OpTracker) spin() {

--- a/v2/app/testdata/cron_job_definition_init.txt
+++ b/v2/app/testdata/cron_job_definition_init.txt
@@ -73,4 +73,4 @@ PubSub subscription handler.
  22 │     return &Response{Message: msg}, nil
 ────╯
 
-For more information on how to use raw APIs see https://encore.dev/docs/primitives/services-and-apis
+For more information on how to use APIs see https://encore.dev/docs/primitives/services-and-apis

--- a/v2/app/testdata/cron_job_definition_rpc.txt
+++ b/v2/app/testdata/cron_job_definition_rpc.txt
@@ -70,4 +70,4 @@ PubSub subscription handler.
  19 │     return &Response{Message: msg}, nil
 ────╯
 
-For more information on how to use raw APIs see https://encore.dev/docs/primitives/services-and-apis
+For more information on how to use APIs see https://encore.dev/docs/primitives/services-and-apis

--- a/v2/app/testdata/missing_generic_param.txt
+++ b/v2/app/testdata/missing_generic_param.txt
@@ -40,3 +40,28 @@ Missing type argument
 ────╯
 
 For more information, see https://encore.dev/docs/develop/api-schemas
+
+
+
+
+── Missing type argument ──────────────────────────────────────────────────────────────────[E9999]──
+
+Missing type argument
+
+    ╭─[ foo.go:6:7 ]
+    │
+  4 │
+  5 │ type Params struct {
+  6 │     C *Generic
+    ⋮       ───┬────
+    ⋮          ╰─ missing from here
+  7 │ }
+  8 │
+  9 │ type Generic[T any] struct {
+    ⋮              ──┬──
+    ⋮                ╰─ missing type parameter defined here
+ 10 │     Val *T
+ 11 │ }
+────╯
+
+For more information, see https://encore.dev/docs/develop/api-schemas

--- a/v2/app/testdata/rpc_invalid_header_type.txt
+++ b/v2/app/testdata/rpc_invalid_header_type.txt
@@ -1,0 +1,47 @@
+! parse
+
+-- svc/svc.go --
+package svc
+
+import (
+	"context"
+	"encore.dev/types/uuid"
+)
+
+type Nested struct {
+    Baz string
+}
+
+type Params struct {
+    Foo uuid.UUID
+    Bar *Nested `header:"X-Bar"`
+}
+
+//encore:api public method=POST
+func Str(ctx context.Context, p *Params) error { return nil }
+
+-- want: errors --
+
+── Invalid request type ───────────────────────────────────────────────────────────────────[E9999]──
+
+API request parameters of type *Nested are not supported in headers. You can only use built-in
+types types such as strings, booleans, int, time.Time.
+
+    ╭─[ svc/svc.go:14:9 ]
+    │
+ 12 │ type Params struct {
+ 13 │     Foo uuid.UUID
+ 14 │     Bar *Nested `header:"X-Bar"`
+    ⋮         ───┬───
+    ⋮            ╰─ unsupported type
+    ·
+    ·
+ 16 │
+ 17 │ //encore:api public method=POST
+ 18 │ func Str(ctx context.Context, p *Params) error { return nil }
+    ⋮                               ────┬────
+    ⋮                                   ╰─ used here
+ 19 │
+────╯
+
+See https://encore.dev/docs/develop/api-schemas#supported-types for more information.

--- a/v2/app/testdata/rpc_invalid_query_type.txt
+++ b/v2/app/testdata/rpc_invalid_query_type.txt
@@ -1,0 +1,50 @@
+! parse
+
+-- svc/svc.go --
+package svc
+
+import (
+	"context"
+	"encore.dev/types/uuid"
+)
+
+type Nested struct {
+    Baz string
+}
+
+type Params struct {
+    Foo uuid.UUID
+    Bar *Nested
+}
+
+//encore:api public method=GET
+func Str(ctx context.Context, p *Params) error { return nil }
+
+-- want: errors --
+
+── Invalid request type ───────────────────────────────────────────────────────────────────[E9999]──
+
+API request parameters of type *Nested are not supported in query strings. You can only use
+built-in types, or slices of built-in types such as strings, booleans, int, time.Time.
+
+    ╭─[ svc/svc.go:14:9 ]
+    │
+ 12 │ type Params struct {
+ 13 │     Foo uuid.UUID
+ 14 │     Bar *Nested
+    ⋮         ───┬───
+    ⋮            ╰─ unsupported type
+ 15 │ }
+ 16 │
+ 17 │ //encore:api public method=GET
+    ⋮                     ────┬─────
+    ⋮                         ╰─ you could change this to a POST or PUT request
+ 18 │ func Str(ctx context.Context, p *Params) error { return nil }
+    ⋮                               ────┬────
+    ⋮                                   ╰─ used here
+ 19 │
+────╯
+
+APIs which are sent as GET, HEAD or DELETE requests are unable to contain JSON bodies, thus all
+parameters must be sent as query strings or headers. See
+https://encore.dev/docs/develop/api-schemas#supported-types for more information.

--- a/v2/app/testdata/rpc_outside_service.txt
+++ b/v2/app/testdata/rpc_outside_service.txt
@@ -55,4 +55,4 @@ the application.
  10 │ }
 ────╯
 
-For more information on how to use raw APIs see https://encore.dev/docs/primitives/services-and-apis
+For more information on how to use APIs see https://encore.dev/docs/primitives/services-and-apis

--- a/v2/app/testdata/rpc_without_calling.txt
+++ b/v2/app/testdata/rpc_without_calling.txt
@@ -59,4 +59,4 @@ PubSub subscription handler.
  10 │ }
 ────╯
 
-For more information on how to use raw APIs see https://encore.dev/docs/primitives/services-and-apis
+For more information on how to use APIs see https://encore.dev/docs/primitives/services-and-apis

--- a/v2/codegen/apigen/endpointgen/request.go
+++ b/v2/codegen/apigen/endpointgen/request.go
@@ -220,7 +220,10 @@ func (d *requestDesc) renderRequestDecoding(g *Group, dec *genutil.TypeUnmarshal
 	// Parsing requests for HTTP methods without a body (GET, HEAD, DELETE) are handled by parsing the query string,
 	// while other methods are parsed by reading the body and unmarshalling it as JSON.
 	// If the same endpoint supports both, handle it with a switch.
-	reqs := apienc.DescribeRequest(d.gu.Errs, d.ep.Request, d.ep.HTTPMethods...)
+	reqs := d.ep.RequestEncoding()
+	if d.gu.Errs.Len() > 0 {
+		return
+	}
 	g.Add(Switch(Id("m").Op(":=").Add(d.httpReqExpr()).Dot("Method"), Id("m")).BlockFunc(
 		func(g *Group) {
 			for _, r := range reqs {

--- a/v2/internals/schema/schemautil/schemautil.go
+++ b/v2/internals/schema/schemautil/schemautil.go
@@ -36,8 +36,14 @@ func IsPointer(t schema.Type) bool {
 
 // IsBuiltinKind reports whether the given type is a builtin
 // of one of the given kinds.
+//
+// If no kinds are passed in, it returns true for any builtin.
 func IsBuiltinKind(t schema.Type, kinds ...schema.BuiltinKind) bool {
 	if b, ok := t.(schema.BuiltinType); ok {
+		if len(kinds) == 0 {
+			return true
+		}
+
 		for _, k := range kinds {
 			if b.Kind == k {
 				return true

--- a/v2/internals/schema/schemautil/schemautil.go
+++ b/v2/internals/schema/schemautil/schemautil.go
@@ -36,14 +36,8 @@ func IsPointer(t schema.Type) bool {
 
 // IsBuiltinKind reports whether the given type is a builtin
 // of one of the given kinds.
-//
-// If no kinds are passed in, it returns true for any builtin.
 func IsBuiltinKind(t schema.Type, kinds ...schema.BuiltinKind) bool {
 	if b, ok := t.(schema.BuiltinType); ok {
-		if len(kinds) == 0 {
-			return true
-		}
-
 		for _, k := range kinds {
 			if b.Kind == k {
 				return true

--- a/v2/parser/apis/api/api.go
+++ b/v2/parser/apis/api/api.go
@@ -154,6 +154,12 @@ func Parse(d ParseData) *Endpoint {
 		}
 	}
 
+	// RequestEncoding will validate the request payload.
+	rpc.RequestEncoding()
+
+	// ResponseEncoding will validate the response payload.
+	rpc.ResponseEncoding()
+
 	return rpc
 }
 

--- a/v2/parser/apis/api/api.go
+++ b/v2/parser/apis/api/api.go
@@ -34,19 +34,20 @@ const (
 type Endpoint struct {
 	errs *perr.List
 
-	Name        string
-	Doc         string
-	File        *pkginfo.File
-	Decl        *schema.FuncDecl
-	Access      AccessType
-	AccessField option.Option[directive.Field]
-	Raw         bool
-	Path        *resourcepaths.Path
-	HTTPMethods []string
-	Request     schema.Type // request data; nil for Raw Endpoints
-	Response    schema.Type // response data; nil for Raw Endpoints
-	Tags        selector.Set
-	Recv        option.Option[*schema.Receiver] // None if not a method
+	Name             string
+	Doc              string
+	File             *pkginfo.File
+	Decl             *schema.FuncDecl
+	Access           AccessType
+	AccessField      option.Option[directive.Field]
+	Raw              bool
+	Path             *resourcepaths.Path
+	HTTPMethods      []string
+	HTTPMethodsField option.Option[directive.Field]
+	Request          schema.Type // request data; nil for Raw Endpoints
+	Response         schema.Type // response data; nil for Raw Endpoints
+	Tags             selector.Set
+	Recv             option.Option[*schema.Receiver] // None if not a method
 
 	reqEncOnce  sync.Once
 	reqEncoding []*apienc.RequestEncoding
@@ -69,8 +70,13 @@ func (ep *Endpoint) End() token.Pos            { return ep.Decl.AST.End() }
 func (ep *Endpoint) SortKey() string           { return ep.File.Pkg.ImportPath.String() + "." + ep.Name }
 
 func (ep *Endpoint) RequestEncoding() []*apienc.RequestEncoding {
+	if ep.Request == nil {
+		return nil
+	}
+
 	ep.reqEncOnce.Do(func() {
-		ep.reqEncoding = apienc.DescribeRequest(ep.errs, ep.Request, ep.HTTPMethods...)
+		requestParam := ep.Decl.Type.Params[len(ep.Decl.Type.Params)-1]
+		ep.reqEncoding = apienc.DescribeRequest(ep.errs, requestParam, ep.Request, ep.HTTPMethodsField, ep.HTTPMethods...)
 	})
 	return ep.reqEncoding
 }
@@ -334,6 +340,7 @@ func validateDirective(errs *perr.List, dir *directive.Directive) (*Endpoint, bo
 
 			case "method":
 				endpoint.HTTPMethods = f.List()
+				endpoint.HTTPMethodsField = option.Some(f)
 				for _, m := range endpoint.HTTPMethods {
 					for _, c := range m {
 						if !(c >= 'A' && c <= 'Z') && !(c >= 'a' && c <= 'z') {

--- a/v2/parser/apis/api/apienc/encoding.go
+++ b/v2/parser/apis/api/apienc/encoding.go
@@ -266,7 +266,7 @@ func DescribeRequest(errs *perr.List, requestAST schema.Param, requestSchema sch
 				errs.Add(errReservedHeaderPrefix.AtGoNode(field.Type.ASTExpr()))
 			}
 
-			if !schemautil.IsBuiltinKind(field.Type) {
+			if _, _, ok := schemautil.IsBuiltinOrList(field.Type); !ok {
 				errs.Add(
 					errInvalidHeaderType(field.Type.String()).
 						AtGoNode(field.Type.ASTExpr(), errors.AsError("unsupported type")).

--- a/v2/parser/apis/api/apienc/encoding.go
+++ b/v2/parser/apis/api/apienc/encoding.go
@@ -9,10 +9,12 @@ import (
 
 	"encr.dev/pkg/errors"
 	"encr.dev/pkg/idents"
+	"encr.dev/pkg/option"
 	"encr.dev/v2/internals/perr"
 	"encr.dev/v2/internals/schema"
 	"encr.dev/v2/internals/schema/schemautil"
 	"encr.dev/v2/parser/apis/authhandler"
+	"encr.dev/v2/parser/apis/internal/directive"
 )
 
 // WireLoc is the location of a parameter in the HTTP request/response.
@@ -216,7 +218,7 @@ func keyDiff[T comparable, V any](src map[T]V, keys ...T) (diff []T) {
 
 // DescribeRequest groups the provided httpMethods by default WireLoc and returns a RequestEncoding
 // per WireLoc
-func DescribeRequest(errs *perr.List, requestSchema schema.Type, httpMethods ...string) []*RequestEncoding {
+func DescribeRequest(errs *perr.List, requestAST schema.Param, requestSchema schema.Type, methodsField option.Option[directive.Field], httpMethods ...string) []*RequestEncoding {
 	methodsByDefaultLocation := make(map[WireLoc][]string)
 	for _, m := range httpMethods {
 		switch m {
@@ -258,11 +260,42 @@ func DescribeRequest(errs *perr.List, requestSchema schema.Type, httpMethods ...
 			return nil
 		}
 
-		// Check for reserved header prefixes
+		// Check for reserved header prefixes or invalid data types
 		for _, field := range fields[Header] {
 			if strings.HasPrefix(strings.ToLower(field.WireName), "x-encore-") {
 				errs.Add(errReservedHeaderPrefix.AtGoNode(field.Type.ASTExpr()))
 			}
+
+			if !schemautil.IsBuiltinKind(field.Type) {
+				errs.Add(
+					errInvalidHeaderType(field.Type.String()).
+						AtGoNode(field.Type.ASTExpr(), errors.AsError("unsupported type")).
+						AtGoNode(requestAST.AST, errors.AsHelp("used here")),
+				)
+			}
+		}
+
+		// Check for invalid datatype in query parameters
+		for _, field := range fields[Query] {
+			if _, _, ok := schemautil.IsBuiltinOrList(field.Type); !ok {
+				err := errInvalidQueryStringType(field.Type.String()).
+					AtGoNode(field.Type.ASTExpr(), errors.AsError("unsupported type")).
+					AtGoNode(requestAST.AST, errors.AsHelp("used here"))
+
+				if field, ok := methodsField.Get(); ok {
+					httpMethod := strings.ToUpper(field.Value)
+					switch httpMethod {
+					case "GET", "HEAD", "DELETE":
+						err = err.AtGoNode(field, errors.AsHelp("you could change this to a POST or PUT request"))
+					}
+				}
+
+				errs.Add(err)
+			}
+		}
+
+		if errs.Len() > 0 {
+			return nil
 		}
 
 		if keys := keyDiff(fields, Query, Header, Body); len(keys) > 0 {

--- a/v2/parser/apis/api/apienc/errors.go
+++ b/v2/parser/apis/api/apienc/errors.go
@@ -13,7 +13,7 @@ var (
 
 	errAnonymousFields = errRange.New(
 		"Invalid API schema",
-		"Anonymous fields in top-leve request/response types are not support.",
+		"Anonymous fields in top-level request/response types are not support.",
 	)
 
 	errTagConflict = errRange.Newf(
@@ -59,5 +59,23 @@ var (
 	ErrAnonymousFieldsNotSupported = errRange.New(
 		"Invalid API schema",
 		"Anonymous fields are not supported in API schemas.",
+	)
+
+	errInvalidHeaderType = errRange.Newf(
+		"Invalid request type",
+		"API request parameters of type %s are not supported in headers. You can only "+
+			"use built-in types types such as strings, booleans, int, time.Time.",
+
+		errors.WithDetails("See https://encore.dev/docs/develop/api-schemas#supported-types for more information."),
+	)
+
+	errInvalidQueryStringType = errRange.Newf(
+		"Invalid request type",
+		"API request parameters of type %s are not supported in query strings. You can only "+
+			"use built-in types, or slices of built-in types such as strings, booleans, int, time.Time.",
+
+		errors.WithDetails("APIs which are sent as GET, HEAD or DELETE requests are unable to contain JSON bodies, "+
+			"thus all parameters must be sent as query strings or headers. "+
+			"See https://encore.dev/docs/develop/api-schemas#supported-types for more information."),
 	)
 )

--- a/v2/parser/apis/api/apienc/errors.go
+++ b/v2/parser/apis/api/apienc/errors.go
@@ -13,7 +13,7 @@ var (
 
 	errAnonymousFields = errRange.New(
 		"Invalid API schema",
-		"Anonymous fields in top-level request/response types are not support.",
+		"Anonymous fields in top-level request/response types are not supported.",
 	)
 
 	errTagConflict = errRange.Newf(

--- a/v2/parser/apis/api/errors.go
+++ b/v2/parser/apis/api/errors.go
@@ -8,7 +8,7 @@ const rawHint = `hint: signature must be func(http.ResponseWriter, *http.Request
 
 For more information on how to use raw APIs see https://encore.dev/docs/primitives/services-and-apis#raw-endpoints`
 
-const baseHint = "For more information on how to use raw APIs see https://encore.dev/docs/primitives/services-and-apis"
+const baseHint = "For more information on how to use APIs see https://encore.dev/docs/primitives/services-and-apis"
 
 var (
 	errRange = errors.Range(


### PR DESCRIPTION
This PR re-adds schema validation for header and query string fields, which in the v1 parser we had, but lost during the v2 rewrite.

It also fixes an issue where we where double sending compiler errors to the CLI.