### PR TITLE
Introduce no-op infrastructure

### DIFF
--- a/runtime/config/manager_internal.go
+++ b/runtime/config/manager_internal.go
@@ -49,21 +49,21 @@ func NewManager(rt *reqtrack.RequestTracker, json jsoniter.API) *Manager {
 	}
 }
 
-func (m *Manager) getComputedCUE(serviceName string) ([]byte, error) {
+func (m *Manager) getComputedCUE(serviceName string) (jsonBytes []byte, found bool, err error) {
 	if m == nil {
-		return nil, fmt.Errorf("config subsystem has not been initialized")
+		return nil, true, fmt.Errorf("config subsystem has not been initialized")
 	}
 
 	// Fetch the raw JSON config for this service
 	envVar := encoreenv.Get(envName(serviceName))
 	if envVar == "" {
-		return nil, fmt.Errorf("configuration for service `%s` not found, expected it in environmental variable %s", serviceName, envName(serviceName))
+		return nil, false, fmt.Errorf("configuration for service `%s` not found, expected it in environmental variable %s", serviceName, envName(serviceName))
 	}
 	cfgBytes, err := base64.RawURLEncoding.DecodeString(envVar)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode configuration for service `%s`: %v", serviceName, err)
+		return nil, true, fmt.Errorf("failed to decode configuration for service `%s`: %v", serviceName, err)
 	}
-	return cfgBytes, nil
+	return cfgBytes, true, nil
 }
 
 // nextID returns the next unique ID for a config value to use to be tracked

--- a/runtime/config/pkgfn.go
+++ b/runtime/config/pkgfn.go
@@ -31,8 +31,14 @@ var Singleton = NewManager(reqtrack.Singleton, jsonapi.Default)
 // referenced from other services.
 func Load[T any](__serviceName string, __unmarshaler Unmarshaler[T]) T {
 	// Get the computed cfg
-	cfgBytes, err := Singleton.getComputedCUE(__serviceName)
+	cfgBytes, found, err := Singleton.getComputedCUE(__serviceName)
 	if err != nil {
+		// If the config is not found, return a zero value
+		if !found {
+			var zero T
+			return zero
+		}
+
 		panic(err.Error())
 	}
 

--- a/runtime/pubsub/internal/noop/topic.go
+++ b/runtime/pubsub/internal/noop/topic.go
@@ -1,0 +1,29 @@
+package noop
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"encore.dev/appruntime/exported/config"
+	"encore.dev/pubsub/internal/types"
+)
+
+type Topic struct{}
+
+var _ types.TopicImplementation = (*Topic)(nil)
+
+var ErrNoop = errors.New(
+	"pubsub: this service is not configured to use this topic. " +
+		"Use pubsub.TopicRef in the service to get a reference and access to the topic from this service",
+)
+
+func (t *Topic) PublishMessage(ctx context.Context, orderingKey string, attrs map[string]string, data []byte) (id string, err error) {
+	return "", ErrNoop
+}
+
+func (t *Topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, _ time.Duration, _ *types.RetryPolicy, subCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {
+	// no-op
+}

--- a/runtime/storage/cache/manager_internal.go
+++ b/runtime/storage/cache/manager_internal.go
@@ -89,7 +89,7 @@ func (mgr *Manager) getClient(clusterName string) *redis.Client {
 		}
 	}
 
-	panic(fmt.Sprintf("cache: unknown cluster %q", clusterName))
+	return newNoopClient()
 }
 
 func (mgr *Manager) runningInEncoreCloud() bool {

--- a/runtime/storage/cache/noop_internal.go
+++ b/runtime/storage/cache/noop_internal.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/go-redis/redis/v8"
+)
+
+var ErrNoopClient = errors.New(
+	"cache: this service is not configured to use this cache",
+)
+
+func newNoopClient() *redis.Client {
+	client := redis.NewClient(&redis.Options{
+		MinIdleConns: 0,
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return nil, ErrNoopClient
+		},
+		OnConnect: func(ctx context.Context, cn *redis.Conn) error {
+			return ErrNoopClient
+		},
+	})
+
+	client.AddHook(&noopHook{})
+
+	return client
+}
+
+type noopHook struct{}
+
+func (n *noopHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	return nil, ErrNoopClient
+}
+
+func (n *noopHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
+	return ErrNoopClient
+}
+
+func (n *noopHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+	return nil, ErrNoopClient
+}
+
+func (n *noopHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
+	return ErrNoopClient
+}

--- a/runtime/storage/sqldb/stdlib_noop_internal.go
+++ b/runtime/storage/sqldb/stdlib_noop_internal.go
@@ -1,0 +1,105 @@
+package sqldb
+
+import (
+	"context"
+	"database/sql/driver"
+	"sync"
+)
+
+var (
+	registerNoopDriverOnce sync.Once
+)
+
+const noopDriverName = "__encore_noop"
+
+// noopDriver is a driver.Driver that returns will "connect" and manage
+// a connection to a database without an error, however whenever you try and use
+// the database, it will return a noop error.
+//
+// This is because we expect people to use drivers as package level variables,
+// but some services may not be running
+type noopDriver struct{}
+
+var (
+	_ driver.Driver        = noopDriver{}
+	_ driver.DriverContext = noopDriver{}
+)
+
+func (n noopDriver) Open(name string) (driver.Conn, error) {
+	return noopConn{}, nil
+}
+
+func (n noopDriver) OpenConnector(name string) (driver.Connector, error) {
+	return noopConnector{}, nil
+}
+
+// noopConnector is a driver.Connector that returns will "connect" and
+// manage a connection to a database without an error using the noopConn
+type noopConnector struct{}
+
+var (
+	_ driver.Connector = noopConnector{}
+)
+
+func (n noopConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	return noopConn{}, nil
+}
+
+func (n noopConnector) Driver() driver.Driver {
+	return noopDriver{}
+}
+
+// noopConn is a driver.Conn that will error on any operation not
+// related to managing the connection
+type noopConn struct{}
+
+var (
+	_ driver.Conn               = noopConn{}
+	_ driver.ConnBeginTx        = noopConn{}
+	_ driver.ConnPrepareContext = noopConn{}
+	_ driver.ExecerContext      = noopConn{}
+	_ driver.Pinger             = noopConn{}
+	_ driver.QueryerContext     = noopConn{}
+	_ driver.SessionResetter    = noopConn{}
+	_ driver.NamedValueChecker  = noopConn{}
+)
+
+func (n noopConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errNoopDB
+}
+
+func (n noopConn) Close() error {
+	return nil // Don't return an error here as we want "connections" to act normal until they are used
+}
+
+func (n noopConn) Begin() (driver.Tx, error) {
+	return nil, errNoopDB
+}
+
+func (n noopConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return nil, errNoopDB
+}
+
+func (n noopConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return nil, errNoopDB
+}
+
+func (n noopConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return nil, errNoopDB
+}
+
+func (n noopConn) Ping(ctx context.Context) error {
+	return nil // Don't return an error here as we want "connections" to act normal until they are used
+}
+
+func (n noopConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return nil, errNoopDB
+}
+
+func (n noopConn) ResetSession(ctx context.Context) error {
+	return nil // Don't return an error here as we want "connections" to act normal until they are used
+}
+
+func (n noopConn) CheckNamedValue(value *driver.NamedValue) error {
+	return errNoopDB
+}


### PR DESCRIPTION
This commit introduces the concept of no-op infrastructure. This is required so that Encore can build a single binary containing all the services, however deploy a container with just a single service running inside it - all infrastructure used by other services which are not running will not work as the container will not be provisioned permissions to that infrastructure. Instead any operations on that infrastructure should result in an error.