### PR TITLE
cli: add device auth login flow

### DIFF
--- a/cli/cmd/encore/app/create.go
+++ b/cli/cmd/encore/app/create.go
@@ -58,7 +58,7 @@ func createApp(ctx context.Context, name, template string) (err error) {
 	if _, err := conf.CurrentUser(); errors.Is(err, fs.ErrNotExist) {
 		cyan.Fprint(os.Stderr, "Log in to create your app [press enter to continue]: ")
 		fmt.Scanln()
-		if err := auth.DoLogin(); err != nil {
+		if err := auth.DoLogin(auth.AutoFlow); err != nil {
 			cmdutil.Fatal(err)
 		}
 	}

--- a/cli/internal/browser/browser.go
+++ b/cli/internal/browser/browser.go
@@ -42,6 +42,17 @@ func Commands() [][]string {
 	return cmds
 }
 
+// CanOpen reports whether it's likely that Open will succeed.
+func CanOpen() bool {
+	cmds := Commands()
+	for _, cmd := range cmds {
+		if _, err := exec.LookPath(cmd[0]); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // Open tries to open url in a browser and reports whether it succeeded.
 func Open(url string) bool {
 	for _, args := range Commands() {

--- a/cli/internal/login/deviceauth.go
+++ b/cli/internal/login/deviceauth.go
@@ -1,0 +1,182 @@
+package login
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
+
+	"encr.dev/cli/cmd/encore/cmdutil"
+	"encr.dev/cli/internal/browser"
+	"encr.dev/cli/internal/platform"
+	"encr.dev/internal/conf"
+	"encr.dev/internal/env"
+)
+
+// DeviceAuth logs in the suser with the device auth flow.
+func DeviceAuth() (*conf.Config, error) {
+	// Generate PKCE challenge.
+	randData, err := genRandData()
+	if err != nil {
+		return nil, fmt.Errorf("could not generate random data: %v", err)
+	}
+	codeVerifier := base64.RawURLEncoding.EncodeToString([]byte(randData))
+	challengeHash := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(challengeHash[:])
+
+	resp, err := platform.BeginDeviceAuthFlow(context.Background(), platform.BeginAuthorizationFlowParams{
+		CodeChallenge: codeChallenge,
+		ClientID:      "encore_cli",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		bold  = color.New(color.Bold)
+		faint = color.New(color.Faint)
+	)
+
+	fmt.Printf("Your pairing code is %s\n", bold.Sprint(resp.UserCode))
+	faint.Println("This pairing code verifies your authentication with Encore.")
+
+	inputCh := make(chan struct{}, 1)
+
+	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	spin.Prefix = "Waiting for login confirmation..."
+
+	if !env.IsSSH() && browser.CanOpen() {
+		fmt.Fprintf(os.Stdout, "Press Enter to open the browser or visit %s (^C to quit)\n",
+			resp.VerificationURI)
+
+		// Asynchronously wait for input.
+		w := waitForEnterPress()
+		defer w.Stop()
+		go func() {
+			select {
+			case <-w.pressed:
+				inputCh <- struct{}{}
+			case <-w.quit:
+			}
+		}()
+
+	} else {
+		// On Windows we need a proper \r\n newline to ensure the URL detection doesn't extend to the next line.
+		// fmt.Fprintln and family prints just a simple \n, so don't use that.
+		fmt.Fprintf(os.Stdout, "To authenticate with Encore, please go to: %s%s", resp.VerificationURI, cmdutil.Newline)
+		spin.Start()
+	}
+
+	resultCh := make(chan deviceAuthResult, 1)
+	go pollForDeviceAuthResult(codeVerifier, resp, resultCh)
+
+	for {
+		select {
+		case <-inputCh:
+			// The user hit Enter; show a spinner and try to open the browser.
+			spin.Start()
+			if !browser.Open(resp.VerificationURI) {
+				spin.FinalMSG = fmt.Sprintf("Failed to open browser, please go to %s manually.", resp.VerificationURI)
+				spin.Stop()
+
+				// Create a new spinner so the message above stays around.
+				spin = spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+				spin.Prefix = "Waiting for login confirmation..."
+				spin.Start()
+			}
+
+		case res := <-resultCh:
+			if res.err != nil {
+				spin.FinalMSG = fmt.Sprintf("Failed to log in: %v", res.err)
+				spin.Stop()
+				return nil, res.err
+			}
+
+			spin.Stop()
+			return res.cfg, nil
+		}
+	}
+}
+
+type deviceAuthResult struct {
+	cfg *conf.Config
+	err error
+}
+
+func pollForDeviceAuthResult(codeVerifier string, data *platform.BeginAuthorizationFlowResponse, resultCh chan<- deviceAuthResult) {
+PollLoop:
+	for {
+		interval := data.Interval
+		if interval <= 0 {
+			interval = 5
+		}
+		time.Sleep(time.Duration(interval) * time.Second)
+
+		resp, err := platform.PollDeviceAuthFlow(context.Background(), platform.PollDeviceAuthFlowParams{
+			DeviceCode:   data.DeviceCode,
+			CodeVerifier: codeVerifier,
+		})
+		if err != nil {
+			if e, ok := err.(platform.Error); ok {
+				switch e.Code {
+				case "auth_pending":
+					// Not yet authorized, continue polling.
+					continue PollLoop
+
+				case "rate_limited":
+					// Spurious error; sleep a bit extra before retrying to be safe.
+					time.Sleep(5 * time.Second)
+					continue PollLoop
+				}
+			}
+			resultCh <- deviceAuthResult{err: err}
+			return
+		}
+
+		cfg := &conf.Config{Token: *resp.Token, Actor: resp.Actor, Email: resp.Email, AppSlug: resp.AppSlug}
+		resultCh <- deviceAuthResult{cfg: cfg}
+		return
+	}
+}
+
+type enterPressWaiter struct {
+	quit    chan struct{} // close to abort the waiter
+	pressed chan struct{} // closed when enter has been pressed
+	runDone chan struct{} // closed when the run goroutine has exited
+}
+
+func waitForEnterPress() *enterPressWaiter {
+	w := &enterPressWaiter{
+		quit:    make(chan struct{}),
+		pressed: make(chan struct{}, 1),
+		runDone: make(chan struct{}),
+	}
+	go w.run()
+	return w
+}
+
+func (w *enterPressWaiter) run() {
+	defer close(w.runDone)
+	fmt.Fscanln(os.Stdin)
+	select {
+	case w.pressed <- struct{}{}:
+	case <-w.quit:
+	}
+}
+
+func (w *enterPressWaiter) Stop() {
+	close(w.quit)
+	os.Stdin.SetReadDeadline(time.Now()) // interrupt the pending read
+
+	// Asynchronously wait for the run goroutine to exit before
+	// we reset the read deadline.
+	go func() {
+		<-w.runDone
+		os.Stdin.SetReadDeadline(time.Time{}) // reset read deadline
+	}()
+}

--- a/cli/internal/login/interactive.go
+++ b/cli/internal/login/interactive.go
@@ -1,0 +1,125 @@
+package login
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+
+	"encr.dev/cli/cmd/encore/cmdutil"
+	"encr.dev/cli/internal/browser"
+	"encr.dev/cli/internal/platform"
+	"encr.dev/internal/conf"
+	"encr.dev/internal/env"
+)
+
+// interactive keeps the state of an ongoing login flow.
+type interactive struct {
+	result chan *conf.Config // Successful logins are sent on this
+
+	state           string
+	challenge       string
+	pubKey, privKey string
+	srv             *http.Server
+	ln              net.Listener
+}
+
+// Interactive begins an interactive login attempt.
+func Interactive() (*conf.Config, error) {
+	// Generate initial request state
+	state, err1 := genRandData()
+	challenge, err2 := genRandData()
+	if err1 != nil || err2 != nil {
+		return nil, fmt.Errorf("could not generate random data: %v/%v", err1, err2)
+	}
+
+	challengeHash := sha256.Sum256([]byte(challenge))
+	encodedChallenge := base64.RawURLEncoding.EncodeToString(challengeHash[:])
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	defer ln.Close()
+	addr := ln.Addr().(*net.TCPAddr)
+	url := fmt.Sprintf("http://localhost:%d/oauth", addr.Port)
+
+	req := &platform.CreateOAuthSessionParams{
+		Challenge:   encodedChallenge,
+		State:       state,
+		RedirectURL: url,
+	}
+	authURL, err := platform.CreateOAuthSession(context.Background(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	flow := &interactive{
+		result: make(chan *conf.Config),
+
+		state:     state,
+		challenge: challenge,
+	}
+	flow.srv = &http.Server{Handler: http.HandlerFunc(flow.oauthHandler)}
+	go flow.srv.Serve(ln)
+
+	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+
+	if env.IsSSH() || !browser.Open(authURL) {
+		// On Windows we need a proper \r\n newline to ensure the URL detection doesn't extend to the next line.
+		// fmt.Fprintln and family prints just a simple \n, so don't use that.
+		fmt.Fprint(os.Stdout, "Log in to Encore using your browser here: ", authURL, cmdutil.Newline)
+	} else {
+		spin.Prefix = "Waiting for login to complete "
+		spin.Start()
+		defer spin.Stop()
+	}
+
+	select {
+	case res := <-flow.result:
+		return res, nil
+	case <-time.After(10 * time.Minute):
+		return nil, errors.New("Timed out waiting for login confirmation")
+	}
+}
+
+func (f *interactive) oauthHandler(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != "/oauth" {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	code := req.FormValue("code")
+	reqState := req.FormValue("state")
+	if code == "" || reqState != f.state {
+		http.Error(w, "Bad Request (bad code or state)", http.StatusBadRequest)
+		return
+	}
+
+	params := &platform.ExchangeOAuthTokenParams{
+		Challenge: f.challenge,
+		Code:      code,
+	}
+	resp, err := platform.ExchangeOAuthToken(req.Context(), params)
+	if err != nil {
+		http.Error(w, "Could not exchange token: "+err.Error(), http.StatusBadGateway)
+		return
+	} else if resp.Token == nil {
+		http.Error(w, "Invalid response: missing token", http.StatusBadGateway)
+		return
+	}
+
+	conf := &conf.Config{Token: *resp.Token, Actor: resp.Actor, Email: resp.Email, AppSlug: resp.AppSlug}
+	select {
+	case f.result <- conf:
+		http.Redirect(w, req, "https://www.encore.dev/auth/success", http.StatusFound)
+	default:
+		http.Error(w, "Unexpected request", http.StatusBadRequest)
+	}
+}

--- a/cli/internal/login/login.go
+++ b/cli/internal/login/login.go
@@ -4,111 +4,20 @@ package login
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"net"
-	"net/http"
 
+	"encr.dev/cli/internal/browser"
 	"encr.dev/cli/internal/platform"
 	"encr.dev/internal/conf"
+	"encr.dev/internal/env"
 )
 
-// Flow keeps the state of an ongoing login flow.
-type Flow struct {
-	URL     string            // Local URL the flow is listening on
-	LoginCh chan *conf.Config // Successful logins are sent on this
-
-	state           string
-	challenge       string
-	pubKey, privKey string
-	srv             *http.Server
-	ln              net.Listener
-}
-
-// Begin begins a new login attempt.
-func Begin() (f *Flow, err error) {
-	// Generate initial request state
-	state, err1 := genRandData()
-	challenge, err2 := genRandData()
-	if err1 != nil || err2 != nil {
-		return nil, fmt.Errorf("could not generate random data: %v/%v", err1, err2)
+func DecideFlow() (*conf.Config, error) {
+	if env.IsSSH() || !browser.CanOpen() {
+		return DeviceAuth()
 	}
-
-	challengeHash := sha256.Sum256([]byte(challenge))
-	encodedChallenge := base64.RawURLEncoding.EncodeToString(challengeHash[:])
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err != nil {
-			ln.Close()
-		}
-	}()
-	addr := ln.Addr().(*net.TCPAddr)
-	url := fmt.Sprintf("http://localhost:%d/oauth", addr.Port)
-
-	req := &platform.CreateOAuthSessionParams{
-		Challenge:   encodedChallenge,
-		State:       state,
-		RedirectURL: url,
-	}
-	authURL, err := platform.CreateOAuthSession(context.Background(), req)
-	if err != nil {
-		return nil, err
-	}
-
-	flow := &Flow{
-		URL:     authURL,
-		LoginCh: make(chan *conf.Config),
-
-		state:     state,
-		challenge: challenge,
-	}
-	flow.srv = &http.Server{Handler: http.HandlerFunc(flow.oauthHandler)}
-	go flow.srv.Serve(ln)
-	return flow, nil
-}
-
-// Close closes the login flow.
-func (f *Flow) Close() {
-	f.srv.Close()
-}
-
-func (f *Flow) oauthHandler(w http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != "/oauth" {
-		http.Error(w, "Not Found", http.StatusNotFound)
-		return
-	}
-	code := req.FormValue("code")
-	reqState := req.FormValue("state")
-	if code == "" || reqState != f.state {
-		http.Error(w, "Bad Request (bad code or state)", http.StatusBadRequest)
-		return
-	}
-
-	params := &platform.ExchangeOAuthTokenParams{
-		Challenge: f.challenge,
-		Code:      code,
-	}
-	resp, err := platform.ExchangeOAuthToken(req.Context(), params)
-	if err != nil {
-		http.Error(w, "Could not exchange token: "+err.Error(), http.StatusBadGateway)
-		return
-	} else if resp.Token == nil {
-		http.Error(w, "Invalid response: missing token", http.StatusBadGateway)
-		return
-	}
-
-	conf := &conf.Config{Token: *resp.Token, Actor: resp.Actor, Email: resp.Email, AppSlug: resp.AppSlug}
-	select {
-	case f.LoginCh <- conf:
-		http.Redirect(w, req, "https://www.encore.dev/auth/success", http.StatusFound)
-	default:
-		http.Error(w, "Unexpected request", http.StatusBadRequest)
-	}
+	return Interactive()
 }
 
 func WithAuthKey(authKey string) (*conf.Config, error) {

--- a/cli/internal/platform/api.go
+++ b/cli/internal/platform/api.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/gorilla/websocket"
-	"golang.org/x/oauth2"
 
 	metav1 "encr.dev/proto/encore/parser/meta/v1"
 )
@@ -58,48 +57,6 @@ func ListEnvs(ctx context.Context, appSlug string) ([]*Env, error) {
 	var resp []*Env
 	err := call(ctx, "GET", "/apps/"+url.PathEscape(appSlug)+"/envs", nil, &resp, true)
 	return resp, err
-}
-
-type CreateOAuthSessionParams struct {
-	Challenge   string `json:"challenge"`
-	State       string `json:"state"`
-	RedirectURL string `json:"redirect_url"`
-}
-
-func CreateOAuthSession(ctx context.Context, p *CreateOAuthSessionParams) (authURL string, err error) {
-	var resp struct {
-		AuthURL string `json:"auth_url"`
-	}
-	err = call(ctx, "POST", "/login/oauth:create-session", p, &resp, false)
-	return resp.AuthURL, err
-}
-
-type ExchangeOAuthTokenParams struct {
-	Challenge string `json:"challenge"`
-	Code      string `json:"code"`
-}
-
-type OAuthData struct {
-	Token   *oauth2.Token `json:"token"`
-	Actor   string        `json:"actor,omitempty"` // The ID of the user or app that authorized the token.
-	Email   string        `json:"email"`           // empty if logging in as an app
-	AppSlug string        `json:"app_slug"`        // empty if logging in as a user
-}
-
-func ExchangeOAuthToken(ctx context.Context, p *ExchangeOAuthTokenParams) (*OAuthData, error) {
-	var resp OAuthData
-	err := call(ctx, "POST", "/login/oauth:exchange-token", p, &resp, false)
-	return &resp, err
-}
-
-type ExchangeAuthKeyParams struct {
-	AuthKey string `json:"auth_key"`
-}
-
-func ExchangeAuthKey(ctx context.Context, p *ExchangeAuthKeyParams) (*OAuthData, error) {
-	var resp OAuthData
-	err := call(ctx, "POST", "/login/auth-key", p, &resp, false)
-	return &resp, err
 }
 
 type SecretKind string

--- a/cli/internal/platform/login.go
+++ b/cli/internal/platform/login.go
@@ -1,0 +1,151 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"encr.dev/internal/conf"
+)
+
+type CreateOAuthSessionParams struct {
+	Challenge   string `json:"challenge"`
+	State       string `json:"state"`
+	RedirectURL string `json:"redirect_url"`
+}
+
+func CreateOAuthSession(ctx context.Context, p *CreateOAuthSessionParams) (authURL string, err error) {
+	var resp struct {
+		AuthURL string `json:"auth_url"`
+	}
+	err = call(ctx, "POST", "/login/oauth:create-session", p, &resp, false)
+	return resp.AuthURL, err
+}
+
+type BeginAuthorizationFlowParams struct {
+	CodeChallenge string
+	ClientID      string
+}
+
+type BeginAuthorizationFlowResponse struct {
+	// DeviceCode is the device verification code.
+	DeviceCode string `json:"device_code"`
+
+	// UserCode is the end-user verification code.
+	UserCode string `json:"user_code"`
+
+	// VerificationURI is the end-user URL to use to login.
+	VerificationURI string `json:"verification_uri"`
+
+	// ExpiresIn is the lifetime in seconds of the device code and user code.
+	ExpiresIn int `json:"expires_in"`
+
+	// Interval is the number of seconds to wait between polling requests.
+	// If not provided, defaults to 5.
+	Interval int `json:"interval,omitempty"`
+}
+
+func BeginDeviceAuthFlow(ctx context.Context, p BeginAuthorizationFlowParams) (*BeginAuthorizationFlowResponse, error) {
+	vals := url.Values{}
+	vals.Set("code_challenge", p.CodeChallenge)
+	vals.Set("client_id", p.ClientID)
+	body := strings.NewReader(vals.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, "POST", conf.APIBaseURL+"/oauth/device-auth", body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := doPlatformReq(req, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, decodeErrorResponse(resp)
+	}
+	var respData BeginAuthorizationFlowResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+		return nil, fmt.Errorf("decoding response body: %w", err)
+	}
+	return &respData, nil
+}
+
+type PollDeviceAuthFlowParams struct {
+	DeviceCode   string
+	CodeVerifier string
+}
+
+type OAuthToken struct {
+	*oauth2.Token
+	Actor   string `json:"actor,omitempty"` // The ID of the user or app that authorized the token.
+	Email   string `json:"email"`           // empty if logging in as an app
+	AppSlug string `json:"app_slug"`        // empty if logging in as a user
+}
+
+func PollDeviceAuthFlow(ctx context.Context, p PollDeviceAuthFlowParams) (*OAuthToken, error) {
+	vals := url.Values{}
+	vals.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	vals.Set("device_code", p.DeviceCode)
+	vals.Set("code_verifier", p.CodeVerifier)
+	body := strings.NewReader(vals.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, "POST", conf.APIBaseURL+"/oauth/token", body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := doPlatformReq(req, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, decodeErrorResponse(resp)
+	}
+
+	var tok OAuthToken
+	if err := json.NewDecoder(resp.Body).Decode(&tok); err != nil {
+		return nil, fmt.Errorf("decoding response body: %w", err)
+	}
+	return &tok, nil
+}
+
+type ExchangeOAuthTokenParams struct {
+	Challenge string `json:"challenge"`
+	Code      string `json:"code"`
+}
+
+type OAuthData struct {
+	Token   *oauth2.Token `json:"token"`
+	Actor   string        `json:"actor,omitempty"` // The ID of the user or app that authorized the token.
+	Email   string        `json:"email"`           // empty if logging in as an app
+	AppSlug string        `json:"app_slug"`        // empty if logging in as a user
+}
+
+func ExchangeOAuthToken(ctx context.Context, p *ExchangeOAuthTokenParams) (*OAuthData, error) {
+	var resp OAuthData
+	err := call(ctx, "POST", "/login/oauth:exchange-token", p, &resp, false)
+	return &resp, err
+}
+
+type ExchangeAuthKeyParams struct {
+	AuthKey string `json:"auth_key"`
+}
+
+func ExchangeAuthKey(ctx context.Context, p *ExchangeAuthKeyParams) (*OAuthData, error) {
+	var resp OAuthData
+	err := call(ctx, "POST", "/login/auth-key", p, &resp, false)
+	return &resp, err
+}

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -90,3 +90,11 @@ func determineRoot() (root string, ok bool) {
 	}
 	return "", false
 }
+
+// IsSSH reports whether the current session is an SSH session.
+func IsSSH() bool {
+	if os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_CLIENT") != "" {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This adds support for the OAuth2 device authorization login flow. The flow supports logging in with a different device from where the browser runs, allowing use of the Encore CLI in environments that don't run browsers, like developing over SSH or using GitHub Codespaces/Gitpod.

Thanks Peter Stewart for the suggestion.