### PR TITLE
appfile: support configurable docker base image

### DIFF
--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -38,6 +38,10 @@ type File struct {
 
 	// CgoEnabled enables building with cgo.
 	CgoEnabled bool `json:"cgo_enabled,omitempty"`
+
+	// DockerBaseImage changes the docker base image used for building the application
+	// in Encore's CI/CD system. If unspecified it defaults to "scratch".
+	DockerBaseImage string `json:"docker_base_image,omitempty"`
 }
 
 type CORS struct {


### PR DESCRIPTION
This was previously supported via configuration
on the Encore Platform side. With this change it's configurable directly in the `encore.app` file,
making it easier to test as part of the normal PR workflow.