### PR TITLE
Refactor proc into procgroup

### DIFF
--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -121,7 +121,7 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		if run == nil {
 			return reply(ctx, map[string]interface{}{"running": false}, nil)
 		}
-		proc := run.Proc()
+		proc := run.ProcGroup()
 		if proc == nil {
 			return reply(ctx, map[string]interface{}{"running": false}, nil)
 		}
@@ -192,7 +192,7 @@ func (h *handler) apiCall(ctx context.Context, reply jsonrpc2.Replier, p *apiCal
 		log.Error().Str("app_id", p.AppID).Msg("dash: cannot make api call: app not running")
 		return reply(ctx, nil, fmt.Errorf("app not running"))
 	}
-	proc := run.Proc()
+	proc := run.ProcGroup()
 	if proc == nil {
 		log.Error().Str("app_id", p.AppID).Msg("dash: cannot make api call: app not running")
 		return reply(ctx, nil, fmt.Errorf("app not running"))
@@ -272,7 +272,7 @@ var _ run.EventListener = (*Server)(nil)
 // OnStart notifies active websocket clients about the started run.
 func (s *Server) OnStart(r *run.Run) {
 	m := &jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
-	proc := r.Proc()
+	proc := r.ProcGroup()
 	str, err := m.MarshalToString(proc.Meta)
 	if err != nil {
 		log.Error().Err(err).Msg("dash: could not marshal app meta")
@@ -295,7 +295,7 @@ func (s *Server) OnStart(r *run.Run) {
 // OnReload notifies active websocket clients about the reloaded run.
 func (s *Server) OnReload(r *run.Run) {
 	m := &jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
-	proc := r.Proc()
+	proc := r.ProcGroup()
 	str, err := m.MarshalToString(proc.Meta)
 	if err != nil {
 		log.Error().Err(err).Msg("dash: could not marshal app meta")

--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -143,7 +143,7 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 	ops.AllDone()
 
 	stderr.Write([]byte("\n"))
-	pid := runInstance.Proc().Pid
+	pid := runInstance.ProcGroup().Pid
 	fmt.Fprintf(stderr, "  Encore development server running!\n\n")
 
 	fmt.Fprintf(stderr, "  Your API is running at:     %s\n", aurora.Cyan("http://"+runInstance.ListenAddr))
@@ -153,7 +153,7 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 		fmt.Fprintf(stderr, "  Process ID:                 %d\n", aurora.Cyan(pid))
 	}
 	// Log which experiments are enabled, if any
-	if exp := runInstance.Proc().Experiments.List(); len(exp) > 0 {
+	if exp := runInstance.ProcGroup().Experiments.List(); len(exp) > 0 {
 		strs := make([]string, len(exp))
 		for i, e := range exp {
 			strs[i] = string(e)
@@ -189,7 +189,7 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 		case <-runInstance.Done():
 			return
 		case <-time.After(5 * time.Second):
-			if proc := runInstance.Proc(); proc != nil {
+			if proc := runInstance.ProcGroup(); proc != nil {
 				showFirstRunExperience(runInstance, proc.Meta, stderr)
 			}
 		}

--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -143,7 +143,7 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 	ops.AllDone()
 
 	stderr.Write([]byte("\n"))
-	pid := runInstance.ProcGroup().Pid
+	pid := runInstance.ProcGroup().Gateway.Pid
 	fmt.Fprintf(stderr, "  Encore development server running!\n\n")
 
 	fmt.Fprintf(stderr, "  Your API is running at:     %s\n", aurora.Cyan("http://"+runInstance.ListenAddr))

--- a/cli/daemon/run/http.go
+++ b/cli/daemon/run/http.go
@@ -28,12 +28,12 @@ func (r *Run) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	proc := r.proc.Load().(*Proc)
+	proc := r.proc.Load().(*ProcGroup)
 	proc.forwardReq(endpoint, w, req)
 }
 
 // forwardReq forwards the request to the Encore app.
-func (p *Proc) forwardReq(endpoint string, w http.ResponseWriter, req *http.Request) {
+func (p *ProcGroup) forwardReq(endpoint string, w http.ResponseWriter, req *http.Request) {
 	// director is a simplified version from httputil.NewSingleHostReverseProxy.
 	director := func(r *http.Request) {
 		r.URL.Scheme = "http"

--- a/cli/daemon/run/http.go
+++ b/cli/daemon/run/http.go
@@ -33,11 +33,11 @@ func (r *Run) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 // forwardReq forwards the request to the Encore app.
-func (p *ProcGroup) forwardReq(endpoint string, w http.ResponseWriter, req *http.Request) {
+func (pg *ProcGroup) forwardReq(endpoint string, w http.ResponseWriter, req *http.Request) {
 	// director is a simplified version from httputil.NewSingleHostReverseProxy.
 	director := func(r *http.Request) {
 		r.URL.Scheme = "http"
-		r.URL.Host = p.Run.ListenAddr
+		r.URL.Host = pg.Run.ListenAddr
 		r.URL.Path = "/" + endpoint
 		r.URL.RawQuery = req.URL.RawQuery
 		if _, ok := r.Header["User-Agent"]; !ok {
@@ -47,7 +47,7 @@ func (p *ProcGroup) forwardReq(endpoint string, w http.ResponseWriter, req *http
 
 		// Add the auth key unless the test header is set.
 		if r.Header.Get(TestHeaderDisablePlatformAuth) == "" {
-			addAuthKeyToRequest(r, p.authKey)
+			addAuthKeyToRequest(r, pg.authKey)
 		}
 	}
 
@@ -57,7 +57,7 @@ func (p *ProcGroup) forwardReq(endpoint string, w http.ResponseWriter, req *http
 	transport := &http.Transport{
 		DisableKeepAlives: true,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return p.Client.Open()
+			return pg.Gateway.Client.Open()
 		},
 	}
 

--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -51,11 +51,11 @@ type EventListener interface {
 
 // FindProc finds the proc with the given id.
 // It reports nil if no such proc was found.
-func (mgr *Manager) FindProc(procID string) *Proc {
+func (mgr *Manager) FindProc(procID string) *ProcGroup {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 	for _, run := range mgr.runs {
-		if p := run.Proc(); p != nil && p.ID == procID {
+		if p := run.ProcGroup(); p != nil && p.ID == procID {
 			return p
 		}
 	}

--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -1,0 +1,107 @@
+package run
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	"github.com/rs/zerolog"
+
+	"encore.dev/appruntime/exported/config"
+	"encore.dev/appruntime/exported/experiments"
+	"encr.dev/cli/daemon/internal/sym"
+	meta "encr.dev/proto/encore/parser/meta/v1"
+)
+
+// ProcGroup represents a running Encore process.
+type ProcGroup struct {
+	ID          string           // unique process id
+	Run         *Run             // the run the process belongs to
+	Pid         int              // the OS process id
+	Meta        *meta.Data       // app metadata snapshot
+	Started     time.Time        // when the process started
+	Experiments *experiments.Set // enabled experiments
+
+	ctx      context.Context
+	log      zerolog.Logger
+	exit     chan struct{} // closed when the process has exited
+	cmd      *exec.Cmd
+	reqWr    *os.File
+	respRd   *os.File
+	buildDir string
+	Client   *yamux.Session
+	authKey  config.EncoreAuthKey
+
+	sym       *sym.Table
+	symErr    error
+	symParsed chan struct{} // closed when sym and symErr are set
+}
+
+// Done returns a channel that is closed when the process has exited.
+func (p *ProcGroup) Done() <-chan struct{} {
+	return p.exit
+}
+
+// Close closes the process and waits for it to shutdown.
+// It can safely be called multiple times.
+func (p *ProcGroup) Close() {
+	p.reqWr.Close()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-p.exit:
+	case <-timer.C:
+		// The process didn't exit after 10s
+		p.log.Error().Msg("timed out waiting for process to exit; killing")
+		p.cmd.Process.Kill()
+		<-p.exit
+	}
+}
+
+func (p *ProcGroup) waitForExit() {
+	defer close(p.exit)
+	defer closeAll(p.reqWr, p.respRd)
+
+	if err := p.cmd.Wait(); err != nil && p.ctx.Err() == nil {
+		p.log.Error().Err(err).Msg("process exited with error")
+	} else {
+		p.log.Info().Msg("process exited successfully")
+	}
+
+	// Flush the logs in case the output did not end in a newline.
+	for _, w := range [...]io.Writer{p.cmd.Stdout, p.cmd.Stderr} {
+		if w != nil {
+			w.(*logWriter).Flush()
+		}
+	}
+}
+
+// parseSymTable parses the symbol table of the binary at binPath
+// and stores the result in p.sym and p.symErr.
+func (p *ProcGroup) parseSymTable(binPath string) {
+	parse := func() (*sym.Table, error) {
+		f, err := os.Open(binPath)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		return sym.Load(f)
+	}
+
+	defer close(p.symParsed)
+	p.sym, p.symErr = parse()
+}
+
+// SymTable waits for the proc's symbol table to be parsed and then returns it.
+// ctx is used to cancel the wait.
+func (p *ProcGroup) SymTable(ctx context.Context) (*sym.Table, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-p.symParsed:
+		return p.sym, p.symErr
+	}
+}

--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -138,7 +138,7 @@ func (pg *ProcGroup) NewAllInOneProc(binPath string, environ []string, secrets m
 	}
 	runtimeJSON, _ := json.Marshal(runtimeCfg)
 
-	cmd := exec.Command(binPath)
+	cmd := exec.CommandContext(pg.ctx, binPath)
 	envs := append([]string{
 		"ENCORE_RUNTIME_CONFIG=" + base64.RawURLEncoding.EncodeToString(runtimeJSON),
 		"ENCORE_APP_SECRETS=" + encodeSecretsEnv(secrets),

--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -2,86 +2,93 @@ package run
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/yamux"
 	"github.com/rs/zerolog"
 
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/exported/experiments"
 	"encr.dev/cli/daemon/internal/sym"
+	"encr.dev/cli/internal/xos"
 	meta "encr.dev/proto/encore/parser/meta/v1"
 )
 
-// ProcGroup represents a running Encore process.
+// ProcGroup represents a running Encore application
+//
+// It is a collection of [Proc]'s that are all part of the same application,
+// where each [Proc] represents a one or more services or a API gateway.
 type ProcGroup struct {
 	ID          string           // unique process id
 	Run         *Run             // the run the process belongs to
-	Pid         int              // the OS process id
 	Meta        *meta.Data       // app metadata snapshot
-	Started     time.Time        // when the process started
 	Experiments *experiments.Set // enabled experiments
 
-	ctx      context.Context
-	log      zerolog.Logger
-	exit     chan struct{} // closed when the process has exited
-	cmd      *exec.Cmd
-	reqWr    *os.File
-	respRd   *os.File
-	buildDir string
-	Client   *yamux.Session
-	authKey  config.EncoreAuthKey
+	Gateway *Proc // the API gateway process
 
+	procMu       sync.Mutex // protects both AllProcesses and runningProcs
+	procCond     sync.Cond  // used to signal a change in runningProcs
+	AllProcesses []*Proc    // all processes in the group
+	runningProcs uint32     // number of running processes
+
+	ctx        context.Context
+	logger     RunLogger
+	log        zerolog.Logger
+	buildDir   string
+	workingDir string
+
+	authKey   config.EncoreAuthKey
 	sym       *sym.Table
 	symErr    error
 	symParsed chan struct{} // closed when sym and symErr are set
 }
 
 // Done returns a channel that is closed when the process has exited.
-func (p *ProcGroup) Done() <-chan struct{} {
-	return p.exit
+func (pg *ProcGroup) Done() <-chan struct{} {
+	c := make(chan struct{})
+	go func() {
+		pg.procMu.Lock()
+		defer pg.procMu.Unlock()
+
+		for pg.runningProcs > 0 {
+			// If we have more than one process, wait for one to exit
+			pg.procCond.Wait()
+		}
+
+		close(c)
+	}()
+
+	return c
 }
 
 // Close closes the process and waits for it to shutdown.
 // It can safely be called multiple times.
-func (p *ProcGroup) Close() {
-	p.reqWr.Close()
-	timer := time.NewTimer(10 * time.Second)
-	defer timer.Stop()
-	select {
-	case <-p.exit:
-	case <-timer.C:
-		// The process didn't exit after 10s
-		p.log.Error().Msg("timed out waiting for process to exit; killing")
-		p.cmd.Process.Kill()
-		<-p.exit
-	}
-}
-
-func (p *ProcGroup) waitForExit() {
-	defer close(p.exit)
-	defer closeAll(p.reqWr, p.respRd)
-
-	if err := p.cmd.Wait(); err != nil && p.ctx.Err() == nil {
-		p.log.Error().Err(err).Msg("process exited with error")
-	} else {
-		p.log.Info().Msg("process exited successfully")
+func (pg *ProcGroup) Close() {
+	var wg sync.WaitGroup
+	wg.Add(len(pg.AllProcesses))
+	for _, p := range pg.AllProcesses {
+		go func(p *Proc) {
+			p.Close()
+			wg.Done()
+		}(p)
 	}
 
-	// Flush the logs in case the output did not end in a newline.
-	for _, w := range [...]io.Writer{p.cmd.Stdout, p.cmd.Stderr} {
-		if w != nil {
-			w.(*logWriter).Flush()
-		}
-	}
+	wg.Wait()
 }
 
 // parseSymTable parses the symbol table of the binary at binPath
 // and stores the result in p.sym and p.symErr.
-func (p *ProcGroup) parseSymTable(binPath string) {
+func (pg *ProcGroup) parseSymTable(binPath string) {
 	parse := func() (*sym.Table, error) {
 		f, err := os.Open(binPath)
 		if err != nil {
@@ -91,17 +98,200 @@ func (p *ProcGroup) parseSymTable(binPath string) {
 		return sym.Load(f)
 	}
 
-	defer close(p.symParsed)
-	p.sym, p.symErr = parse()
+	defer close(pg.symParsed)
+	pg.sym, pg.symErr = parse()
 }
 
 // SymTable waits for the proc's symbol table to be parsed and then returns it.
 // ctx is used to cancel the wait.
-func (p *ProcGroup) SymTable(ctx context.Context) (*sym.Table, error) {
+func (pg *ProcGroup) SymTable(ctx context.Context) (*sym.Table, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-p.symParsed:
-		return p.sym, p.symErr
+	case <-pg.symParsed:
+		return pg.sym, pg.symErr
 	}
+}
+
+func (pg *ProcGroup) NewAllInOneProc(binPath string, environ []string, secrets map[string]string, configs map[string]string) error {
+	p := &Proc{
+		group: pg,
+		log:   pg.log.With().Str("proc", "all-in-one").Logger(),
+		exit:  make(chan struct{}),
+	}
+	pg.Gateway = p
+	pg.AllProcesses = append(pg.AllProcesses, p)
+
+	runtimeCfg, err := pg.Run.Mgr.generateConfig(generateConfigParams{
+		App:           pg.Run.App,
+		RM:            pg.Run.ResourceManager,
+		Meta:          pg.Meta,
+		ForTests:      false,
+		AuthKey:       pg.authKey,
+		APIBaseURL:    "http://" + pg.Run.ListenAddr,
+		ConfigAppID:   pg.Run.ID,
+		ConfigEnvID:   pg.ID,
+		ExternalCalls: experiments.ExternalCalls.Enabled(pg.Experiments),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to generate runtime config")
+	}
+	runtimeJSON, _ := json.Marshal(runtimeCfg)
+
+	cmd := exec.Command(binPath)
+	envs := append([]string{
+		"ENCORE_RUNTIME_CONFIG=" + base64.RawURLEncoding.EncodeToString(runtimeJSON),
+		"ENCORE_APP_SECRETS=" + encodeSecretsEnv(secrets),
+	},
+		environ...,
+	)
+	for serviceName, cfgString := range configs {
+		envs = append(envs, "ENCORE_CFG_"+strings.ToUpper(serviceName)+"="+base64.RawURLEncoding.EncodeToString([]byte(cfgString)))
+	}
+
+	cmd.Env = envs
+	cmd.Dir = filepath.Join(pg.Run.App.Root(), pg.workingDir)
+
+	// Proxy stdout and stderr to the given app logger, if any.
+	if l := pg.logger; l != nil {
+		cmd.Stdout = newLogWriter(pg.Run, l.RunStdout)
+		cmd.Stderr = newLogWriter(pg.Run, l.RunStderr)
+	}
+
+	p.cmd = cmd
+
+	// Set up extra file descriptors for communicating requests/responses:
+	// - reqRd is for reading incoming requests (handed over procchild)
+	// - reqWr is for writing incoming requests
+	// - respRd is for reading responses
+	// - respWr is for writing responses (handed over to proc)
+	reqRd, reqWr, err1 := os.Pipe()
+	respRd, respWr, err2 := os.Pipe()
+	defer func() {
+		// Close all the files if we return an error.
+		if err != nil {
+			closeAll(reqRd, reqWr, respRd, respWr)
+		}
+	}()
+	if err := firstErr(err1, err2); err != nil {
+		return errors.Wrap(err, "could not create request & response pipes")
+	} else if err := xos.ArrangeExtraFiles(cmd, reqRd, respWr); err != nil {
+		return errors.Wrap(err, "could not handle over request & response pipes")
+	}
+	p.reqWr = reqWr
+	p.respRd = respRd
+	p.closeOnStart = []io.Closer{reqRd, respWr}
+
+	rwc := &struct {
+		io.ReadCloser
+		io.Writer
+	}{
+		ReadCloser: io.NopCloser(respRd),
+		Writer:     reqWr,
+	}
+	p.Client, err = yamux.Client(rwc, yamux.DefaultConfig())
+	if err != nil {
+		return errors.Wrap(err, "could not initialize connection")
+	}
+
+	return nil
+}
+
+// Proc represents a single Encore process running within a [ProcGroup].
+type Proc struct {
+	group *ProcGroup     // The group this process belongs to
+	log   zerolog.Logger // The logger for this process
+	exit  chan struct{}  // closed when the process has exited
+	cmd   *exec.Cmd      // The command for this specific process
+
+	Started   atomic.Bool    // whether the process has started
+	StartedAt time.Time      // when the process started
+	Pid       int            // the OS process id
+	Client    *yamux.Session // the client connection to the process
+
+	reqWr        *os.File
+	respRd       *os.File
+	closeOnStart []io.Closer
+}
+
+// Start starts the process and returns immediately.
+//
+// If the process has already been started, this is a no-op.
+func (p *Proc) Start() error {
+	if !p.Started.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	p.group.procMu.Lock()
+	defer p.group.procMu.Unlock()
+
+	if err := p.cmd.Start(); err != nil {
+		return errors.Wrap(err, "could not start process")
+	}
+	p.group.runningProcs++
+
+	p.Pid = p.cmd.Process.Pid
+	p.StartedAt = time.Now()
+
+	// Close the files we handed over to the child.
+	closeAll(p.closeOnStart...)
+
+	// Start watching the process for when it quits.
+	go func() {
+		defer close(p.exit)
+		defer closeAll(p.reqWr, p.respRd)
+
+		// Wait for the process to exit.
+		err := p.cmd.Wait()
+		if err != nil && p.group.ctx.Err() == nil {
+			p.log.Error().Err(err).Msg("process exited with error")
+		} else {
+			p.log.Info().Msg("process exited successfully")
+		}
+
+		// Flush the logs in case the output did not end in a newline.
+		for _, w := range [...]io.Writer{p.cmd.Stdout, p.cmd.Stderr} {
+			if w != nil {
+				w.(*logWriter).Flush()
+			}
+		}
+	}()
+
+	// When the process exits, decrement the running count for the group
+	// and wake up any goroutines waiting for on the running count to shrink
+	go func() {
+		<-p.exit
+		p.group.procMu.Lock()
+		defer p.group.procMu.Unlock()
+		p.group.runningProcs--
+
+		p.group.procCond.Broadcast()
+	}()
+
+	return nil
+}
+
+// Close closes the process and waits for it to exit.
+// It is safe to call Close multiple times.
+func (p *Proc) Close() {
+	_ = p.reqWr.Close()
+
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-p.exit:
+		// already exited
+	case <-timer.C:
+		p.group.log.Error().Msg("timed out waiting for process to exit; killing")
+		p.Kill()
+		<-p.exit
+	}
+}
+
+// Kill causes the Process to exit immediately. Kill does not wait until
+// the Process has actually exited. This only kills the Process itself,
+// not any other processes it may have started.
+func (p *Proc) Kill() {
+	_ = p.cmd.Process.Kill()
 }

--- a/e2e-tests/app_test.go
+++ b/e2e-tests/app_test.go
@@ -86,7 +86,7 @@ func RunApp(c testing.TB, appRoot string, logger RunLogger, env []string) *RunAp
 	secretData, err := secrets.Load(app).Get(ctx, expSet)
 	assertNil(err)
 
-	p, err := run.StartProc(&StartProcParams{
+	p, err := run.StartProcGroup(&StartProcGroupParams{
 		Ctx:            ctx,
 		BuildDir:       build.Dir,
 		BinPath:        build.Exe,

--- a/e2e-tests/app_test.go
+++ b/e2e-tests/app_test.go
@@ -108,7 +108,7 @@ func RunApp(c testing.TB, appRoot string, logger RunLogger, env []string) *RunAp
 	}
 
 	// start proxying TCP requests to the running application
-	go proxyTcp(ctx, ln, p.Client)
+	go proxyTcp(ctx, ln, p.Gateway.Client)
 
 	return &RunAppData{
 		Addr:   ln.Addr().String(),

--- a/e2e-tests/echo_app_test.go
+++ b/e2e-tests/echo_app_test.go
@@ -123,7 +123,7 @@ func doTestEndToEndWithApp(t *testing.T, env []string) {
 
 			// Wait a bit to allow the message to be consumed.
 			time.Sleep(100 * time.Millisecond)
-		
+
 			stats, err := app.NSQ.Stats()
 			c.Assert(err, qt.IsNil)
 			c.Assert(len(stats.Producers), qt.Equals, 1)
@@ -558,7 +558,7 @@ func TestProcClosedOnCtxCancel(t *testing.T) {
 	defer cancel()
 
 	parse, build := testBuild(c, appRoot, append(os.Environ(), "ENCORE_EXPERIMENT=v2"))
-	p, err := run.StartProc(&StartProcParams{
+	p, err := run.StartProcGroup(&StartProcGroupParams{
 		Ctx:         ctx,
 		BuildDir:    build.Dir,
 		BinPath:     build.Exe,


### PR DESCRIPTION
This PR is prepping for when locally we run multiple processes of the Encore application, one for each microservice and one for each gateway.

This starts by refactoring our existing `Proc` struct into `ProcGroup` while keeping most of the API the same.

Then within a ProcGroup we introduce the concept of `Proc`'s which can be started independently of each other.