### PR TITLE
Get gateway instances running without Auth

### DIFF
--- a/runtime/appruntime/apisdk/api/gateway.go
+++ b/runtime/appruntime/apisdk/api/gateway.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog"
+
+	"encore.dev/beta/errs"
+)
+
+// IsGateway returns true if this instance of the container is acting as an API
+// gateway
+func (s *Server) IsGateway() bool {
+	return len(s.runtime.Gateways) > 0
+}
+
+// createGatewayHandlerAdapter creates a httprouter.Handle that proxies requests
+// ontop of the given handler to the service that is hosting the handler.
+func (s *Server) createGatewayHandlerAdapter(h Handler) httprouter.Handle {
+	service, found := s.runtime.ServiceDiscovery[h.ServiceName()]
+	if !found {
+		panic(fmt.Sprintf("service %q not found in service discovery when hosted in gateway", h.ServiceName()))
+	}
+
+	serviceBaseURL, err := url.Parse(service.URL)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse service URL %q: %v", service.URL, err))
+	}
+
+	// On cloud environments, we want to log the proxying of requests to services
+	// but locally we don't want the overhead of logging every request.
+	logger := s.rootLogger.With().Str("service", service.Name).Str("endpoint", h.EndpointName()).Logger()
+
+	proxy := httputil.NewSingleHostReverseProxy(serviceBaseURL)
+	proxy.ErrorLog = newZeroLogAdapter(logger, zerolog.ErrorLevel)
+	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		logger.Err(err).Msg("error proxying request to service")
+		errs.HTTPError(w, errs.B().Cause(err).Code(errs.Unavailable).Err())
+	}
+
+	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		if s.runtime.EnvCloud != "local" {
+			logger.Trace().Msg("proxying request to service")
+		}
+		proxy.ServeHTTP(w, req)
+	}
+}
+
+type zeroLogWriter struct {
+	logger zerolog.Logger
+	level  zerolog.Level
+}
+
+func (z *zeroLogWriter) Write(p []byte) (n int, err error) {
+	z.logger.WithLevel(z.level).CallerSkipFrame(3).Msg(string(p))
+	return len(p), nil
+}
+
+// NewZeroLogAdapter returns a new log.Logger that writes to the given zerolog.Logger at the given level.
+func newZeroLogAdapter(logger zerolog.Logger, level zerolog.Level) *log.Logger {
+	zlw := &zeroLogWriter{logger, level}
+	return log.New(zlw, "", 0)
+}

--- a/runtime/appruntime/apisdk/api/services.go
+++ b/runtime/appruntime/apisdk/api/services.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+
+	"encore.dev/appruntime/exported/model"
+	"encore.dev/appruntime/shared/cloudtrace"
+)
+
+// IsHostedService returns true if the given service is hosted by this instance
+// of the Encore application, false otherwise.
+func (s *Server) IsHostedService(serviceName string) bool {
+	// No runtime configured services or gateways means all services are running here
+	if len(s.runtime.HostedServices) == 0 && len(s.runtime.Gateways) == 0 {
+		return true
+	}
+
+	for _, service := range s.runtime.HostedServices {
+		if service == serviceName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *Server) createServiceHandlerAdapter(h Handler) httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		params := toUnnamedParams(ps)
+
+		// Extract metadata from the request.
+		meta := req.Context().Value(metaContextKeyAuthInfo).(CallMeta)
+
+		// Extract any cloud generated Trace identifiers from the request.
+		// and use them if we don't have any trace information in the metadata already
+		cloudGeneratedTraceIDs := cloudtrace.ExtractCloudTraceIDs(s.rootLogger, req)
+		if meta.TraceID.IsZero() {
+			meta.TraceID = cloudGeneratedTraceIDs.TraceID
+		}
+
+		// SpanID will be zero already, so if our Cloud generated one for us, we should
+		// use it as the SpanID for this request
+		meta.SpanID = cloudGeneratedTraceIDs.SpanID
+
+		// If we still don't have a trace id, generate one.
+		if meta.TraceID.IsZero() {
+			meta.TraceID, _ = model.GenTraceID()
+			meta.ParentSpanID = model.SpanID{} // no parent span if we have no trace id
+		}
+		traceIDStr := meta.TraceID.String()
+
+		// Echo the X-Request-ID back to the caller if present,
+		// otherwise send back the trace id.
+		reqID := req.Header.Get("X-Request-ID")
+		if reqID == "" {
+			reqID = traceIDStr
+		} else if len(reqID) > 64 {
+			// Don't allow arbitrarily long request IDs.
+			s.rootLogger.Warn().Int("length", len(reqID)).Msg("X-Request-ID was too long and is being truncated to 64 characters")
+			reqID = reqID[:64]
+		}
+		w.Header().Set("X-Request-ID", reqID)
+
+		// Read the correlation ID from the request.
+		if meta.CorrelationID != "" {
+			w.Header().Set("X-Correlation-ID", meta.CorrelationID)
+		}
+
+		// Always send the trace id back.
+		w.Header().Set("X-Encore-Trace-ID", traceIDStr)
+
+		s.processRequest(h, s.NewIncomingContext(w, req, params, meta))
+	}
+}

--- a/runtime/appruntime/apisdk/service/service.go
+++ b/runtime/appruntime/apisdk/service/service.go
@@ -114,11 +114,11 @@ type Manager struct {
 }
 
 func (mgr *Manager) RegisterService(i Initializer) {
-	if !mgr.IsHosting(i) {
+	name := i.ServiceName()
+	if !mgr.IsHosting(name) {
 		return
 	}
 
-	name := i.ServiceName()
 	if _, ok := mgr.svcMap[name]; ok {
 		panic(fmt.Sprintf("service %s: already registered", name))
 	}
@@ -126,7 +126,7 @@ func (mgr *Manager) RegisterService(i Initializer) {
 	mgr.svcInit = append(mgr.svcInit, i)
 }
 
-func (mgr *Manager) IsHosting(i Initializer) bool {
+func (mgr *Manager) IsHosting(serviceName string) bool {
 	// If we're an all-in-one server, we're hosting everything.
 	if len(mgr.runtime.Gateways) == 0 && len(mgr.runtime.HostedServices) == 0 {
 		return true
@@ -134,7 +134,7 @@ func (mgr *Manager) IsHosting(i Initializer) bool {
 
 	// Otherwise check if we're hosting this
 	for _, svc := range mgr.runtime.HostedServices {
-		if svc == i.ServiceName() {
+		if svc == serviceName {
 			return true
 		}
 	}

--- a/runtime/appruntime/apisdk/service/service.go
+++ b/runtime/appruntime/apisdk/service/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/exported/trace2"
 	"encore.dev/appruntime/shared/health"
 	"encore.dev/appruntime/shared/reqtrack"
@@ -89,8 +90,8 @@ type shutdowner interface {
 	Shutdown(force context.Context)
 }
 
-func NewManager(rt *reqtrack.RequestTracker, healthChecks *health.CheckRegistry, rootLogger zerolog.Logger) *Manager {
-	mgr := &Manager{rt: rt, rootLogger: rootLogger, svcMap: make(map[string]Initializer), initialisedServices: make(map[string]struct{})}
+func NewManager(runtime *config.Runtime, rt *reqtrack.RequestTracker, healthChecks *health.CheckRegistry, rootLogger zerolog.Logger) *Manager {
+	mgr := &Manager{rt: rt, runtime: runtime, rootLogger: rootLogger, svcMap: make(map[string]Initializer), initialisedServices: make(map[string]struct{})}
 
 	// Register with the health check service.
 	healthChecks.Register(mgr)
@@ -99,6 +100,7 @@ func NewManager(rt *reqtrack.RequestTracker, healthChecks *health.CheckRegistry,
 }
 
 type Manager struct {
+	runtime    *config.Runtime
 	rt         *reqtrack.RequestTracker
 	rootLogger zerolog.Logger
 	svcInit    []Initializer
@@ -112,12 +114,31 @@ type Manager struct {
 }
 
 func (mgr *Manager) RegisterService(i Initializer) {
+	if !mgr.IsHosting(i) {
+		return
+	}
+
 	name := i.ServiceName()
 	if _, ok := mgr.svcMap[name]; ok {
 		panic(fmt.Sprintf("service %s: already registered", name))
 	}
 	mgr.svcMap[name] = i
 	mgr.svcInit = append(mgr.svcInit, i)
+}
+
+func (mgr *Manager) IsHosting(i Initializer) bool {
+	// If we're an all-in-one server, we're hosting everything.
+	if len(mgr.runtime.Gateways) == 0 && len(mgr.runtime.HostedServices) == 0 {
+		return true
+	}
+
+	// Otherwise check if we're hosting this
+	for _, svc := range mgr.runtime.HostedServices {
+		if svc == i.ServiceName() {
+			return true
+		}
+	}
+	return false
 }
 
 func (mgr *Manager) InitializeServices() error {

--- a/runtime/appruntime/apisdk/service/singleton.go
+++ b/runtime/appruntime/apisdk/service/singleton.go
@@ -5,12 +5,13 @@ package service
 import (
 	"fmt"
 
+	"encore.dev/appruntime/shared/appconf"
 	"encore.dev/appruntime/shared/health"
 	"encore.dev/appruntime/shared/logging"
 	"encore.dev/appruntime/shared/reqtrack"
 )
 
-var Singleton = NewManager(reqtrack.Singleton, health.Singleton, logging.RootLogger)
+var Singleton = NewManager(appconf.Runtime, reqtrack.Singleton, health.Singleton, logging.RootLogger)
 
 func Register(i Initializer) {
 	Singleton.RegisterService(i)

--- a/runtime/appruntime/exported/config/config.go
+++ b/runtime/appruntime/exported/config/config.go
@@ -51,8 +51,9 @@ type Runtime struct {
 	RedisServers     []*RedisServer          `json:"redis_servers,omitempty"`
 	RedisDatabases   []*RedisDatabase        `json:"redis_databases,omitempty"`
 	Metrics          *Metrics                `json:"metrics,omitempty"`
-	ServiceDiscovery map[string]Service      `json:"service_discovery,omitempty"`
-	Gateways         []Gateway               `json:"gateways,omitempty"` // Gateways defines the gateways which should be served by the container
+	Gateways         []Gateway               `json:"gateways,omitempty"`          // Gateways defines the gateways which should be served by the container
+	HostedServices   []string                `json:"hosted_services,omitempty"`   // List of services to be hosted within this container (zero length means all services, unless there's a gateway running)
+	ServiceDiscovery map[string]Service      `json:"service_discovery,omitempty"` // ServiceDiscovery lists where all the services are being hosted if not in this container
 
 	// ServiceAuth defines which authentication method can be used
 	// when talking to this runtime for internal service-to-service


### PR DESCRIPTION
This commit makes the following changes:

- Instances can be defined as gateways and brought up by themselves
- `initService` functions are not being called if the instance isn't hosting that service
- API endpoints are not registered if the instance isn't hosting that service
- Only the gateway logs when it is listening for HTTP requests and the registered endpoints locally - this is to reduce log spam on startup
- Missing secrets as a warning as been moved from the runtime to the daemon (again to reduce duplication)