### PR TITLE
clientgen: fix golang codegen for types outside svc

### DIFF
--- a/internal/clientgen/testdata/expected_golang.go
+++ b/internal/clientgen/testdata/expected_golang.go
@@ -231,6 +231,10 @@ type SvcTuple[A any, B any] struct {
 	B B
 }
 
+type SvcWithNested struct {
+	Nested *NestedType
+}
+
 type SvcWrappedRequest = SvcWrapper[SvcRequest]
 
 type SvcWrapper[T any] struct {
@@ -245,6 +249,7 @@ type SvcClient interface {
 	Get(ctx context.Context, params SvcGetRequest) error
 	GetRequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[int]) (SvcHeaderOnlyStruct, error)
 	HeaderOnlyRequest(ctx context.Context, params SvcHeaderOnlyStruct) error
+	Nested(ctx context.Context, params SvcWithNested) (SvcWithNested, error)
 	RESTPath(ctx context.Context, a string, b int) error
 	RequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[string]) (SvcAllInputTypes[float64], error)
 
@@ -377,6 +382,16 @@ func (c *svcClient) HeaderOnlyRequest(ctx context.Context, params SvcHeaderOnlyS
 	return err
 }
 
+func (c *svcClient) Nested(ctx context.Context, params SvcWithNested) (resp SvcWithNested, err error) {
+	// Now make the actual call to the API
+	_, err = callAPI(ctx, c.base, "POST", "/svc.Nested", nil, params, &resp)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 func (c *svcClient) RESTPath(ctx context.Context, a string, b int) error {
 	_, err := callAPI(ctx, c.base, "POST", fmt.Sprintf("/path/%s/%d", url.PathEscape(a), b), nil, nil, nil)
 	return err
@@ -471,6 +486,10 @@ func (c *svcClient) Webhook(ctx context.Context, a string, b []string, request *
 	}
 
 	return c.base.Do(request)
+}
+
+type NestedType struct {
+	Message string
 }
 
 // HTTPDoer is an interface which can be used to swap out the default

--- a/internal/clientgen/testdata/expected_javascript.js
+++ b/internal/clientgen/testdata/expected_javascript.js
@@ -159,6 +159,12 @@ class SvcServiceClient {
         await this.baseClient.callAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
     }
 
+    async Nested(params) {
+        // Now make the actual call to the API
+        const resp = await this.baseClient.callAPI("POST", `/svc.Nested`, JSON.stringify(params))
+        return await resp.json()
+    }
+
     async RESTPath(a, b) {
         await this.baseClient.callAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
     }

--- a/internal/clientgen/testdata/expected_openapi.json
+++ b/internal/clientgen/testdata/expected_openapi.json
@@ -47,6 +47,14 @@
         },
         "type": "object"
       },
+      "nested.Type": {
+        "properties": {
+          "Message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "products.Product": {
         "properties": {
           "created_at": {
@@ -691,6 +699,45 @@
         ],
         "responses": {
           "200": {
+            "description": "Success response"
+          },
+          "default": {
+            "$ref": "#/components/responses/APIError"
+          }
+        }
+      }
+    },
+    "/svc.Nested": {
+      "post": {
+        "operationId": "POST:svc.Nested",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "Nested": {
+                    "$ref": "#/components/schemas/nested.Type"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "Nested": {
+                      "$ref": "#/components/schemas/nested.Type"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
             "description": "Success response"
           },
           "default": {

--- a/internal/clientgen/testdata/expected_typescript.ts
+++ b/internal/clientgen/testdata/expected_typescript.ts
@@ -214,6 +214,10 @@ export namespace svc {
         B: B
     }
 
+    export interface WithNested {
+        Nested: nested.Type
+    }
+
     export type WrappedRequest = Wrapper<Request>
 
     export interface Wrapper<T> {
@@ -307,6 +311,12 @@ export namespace svc {
             await this.baseClient.callAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
         }
 
+        public async Nested(params: WithNested): Promise<WithNested> {
+            // Now make the actual call to the API
+            const resp = await this.baseClient.callAPI("POST", `/svc.Nested`, JSON.stringify(params))
+            return await resp.json() as WithNested
+        }
+
         public async RESTPath(a: string, b: number): Promise<void> {
             await this.baseClient.callAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
         }
@@ -349,6 +359,12 @@ export namespace svc {
         public async Webhook(method: string, a: string, b: string[], body?: BodyInit, options?: CallParameters): Promise<Response> {
             return this.baseClient.callAPI(method, `/webhook/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, body, options)
         }
+    }
+}
+
+export namespace nested {
+    export interface Type {
+        Message: string
     }
 }
 

--- a/internal/clientgen/testdata/input.go
+++ b/internal/clientgen/testdata/input.go
@@ -90,6 +90,7 @@ package svc
 import (
     "context"
     "net/http"
+    "app/svc/nested"
 )
 
 // DummyAPI is a dummy endpoint.
@@ -131,6 +132,21 @@ func GetRequestWithAllInputTypes(ctx context.Context, req *AllInputTypes[int]) (
 //encore:api public method=GET
 func HeaderOnlyRequest(ctx context.Context, req *HeaderOnlyStruct) error {
     return nil
+}
+
+type WithNested struct {
+    Nested *nested.Type
+}
+
+//encore:api public method=POST
+func Nested(ctx context.Context, req *WithNested) (*WithNested, error) {
+    return nil
+}
+-- svc/nested/nested.go --
+package nested
+
+type Type struct {
+    Message string
 }
 
 -- products/product.go --


### PR DESCRIPTION
Unlike other client generators we weren't properly tracking which namespaces had been emitted
and emitting the rest at the end.

Thanks Jamie MacLeod for the report.