### PR TITLE
Remote Auth Handler calls implemented

### DIFF
--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -195,7 +195,7 @@ func (pg *ProcGroup) NewAllInOneProc(params *NewProcParams) error {
 	pg.Gateway = p
 
 	// Generate the environmental variables for the process
-	envs, err := pg.EnvGenerator.ForServices(ports.Gateway.ListenAddr, pg.Meta.Svcs...)
+	envs, err := pg.EnvGenerator.ForAllInOne(ports.Gateway.ListenAddr)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate environment variables")
 	}

--- a/runtime/appruntime/apisdk/api/auth_remote.go
+++ b/runtime/appruntime/apisdk/api/auth_remote.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog"
+
+	"encore.dev/appruntime/apisdk/api/transport"
+	"encore.dev/appruntime/exported/config"
+	"encore.dev/appruntime/exported/model"
+	"encore.dev/beta/errs"
+)
+
+// remoteAuthHandler is an AuthHandler that calls a remotely hosted auth handler.
+//
+// This is used when the auth handler is not being hosted in this container, but in
+// another container somewhere else in the cluster.
+type remoteAuthHandler struct {
+	server         *Server        // The server we're running in
+	hostingService config.Service // The service name of the remote auth handler
+	authURL        string         // The URL of the remote auth handler
+	original       AuthHandler
+	logger         zerolog.Logger
+	traceLogs      bool
+}
+
+var _ AuthHandler = (*remoteAuthHandler)(nil)
+
+func (r *remoteAuthHandler) Authenticate(c IncomingContext) (model.AuthInfo, error) {
+	// Quickly check if the auth data is parsable here, if it isn't we can return early
+	// without making a remote call.
+	if err := r.original.ParseAuthData(c); err != nil {
+		return model.AuthInfo{}, err
+	}
+
+	if r.traceLogs {
+		r.logger.Trace().Msg("calling auth handler")
+	}
+
+	// Create the auth request
+	authReq, err := http.NewRequestWithContext(c.ctx, http.MethodPost, r.authURL, nil)
+	if err != nil {
+		r.logger.Err(err).Msg("unable to create auth request")
+		return model.AuthInfo{}, errs.Wrap(err, "unable to create auth request")
+	}
+
+	// Copy over any data which might be needed by the auth handler (query string, headers and cookies)
+	authReq.URL.RawQuery = c.req.URL.RawQuery
+	for k, v := range c.req.Header {
+		// Don't copy the platform auth key across
+		if k == "X-Encore-Auth" {
+			continue
+		}
+
+		for _, vv := range v {
+			authReq.Header.Add(k, vv)
+		}
+	}
+
+	// Add call meta data to the request, so the receiving service can use to allow access to the auth handler
+	// This also passes a shared TraceID to the auth handler, so it and the microservice called after the gateway
+	// can both be traced as part of the same trace.
+	meta := CallMetaFromContext(c.ctx)
+	meta.Internal = &InternalCallMeta{
+		// Note we're acting as a ApiCaller here so we can access the __encore/auth_handler endpoint and
+		// also receive full marshalled errors back from the auth handler (as ApiCaller's are allowed PrivateAPIAccess)
+		Caller: &ApiCaller{ServiceName: "gateway", Endpoint: "__encore/auth_handler"},
+	}
+	if err := meta.AddToRequest(r.server, r.hostingService, transport.HTTPRequest(authReq)); err != nil {
+		r.logger.Err(err).Msg("unable to add call metadata to auth request")
+		return model.AuthInfo{}, errs.Wrap(err, "unable to add call metadata to auth request")
+	}
+
+	// Call the auth handler
+	resp, err := r.server.httpClient.Do(authReq)
+	if err != nil {
+		return model.AuthInfo{}, errs.Wrap(err, "unable to make auth request")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Handle the response
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// user was authenticated, let's decode it
+		t := transport.HTTPResponse(resp)
+		uid, found := t.ReadMeta("UserID")
+		if !found {
+			return model.AuthInfo{}, errs.B().Code(errs.Unauthenticated).Msg("no uid").Err()
+		}
+
+		authData := newAuthDataObj()
+		if err := authJSON.NewDecoder(resp.Body).Decode(authData); err != nil {
+			return model.AuthInfo{}, errs.Wrap(err, "unable to decode auth data")
+		}
+
+		return model.AuthInfo{
+			UID:      model.UID(uid),
+			UserData: authData,
+		}, nil
+
+	default:
+		// the user was not authenticated, let's return the error
+		err := unmarshalErrorResponse(resp)
+		if errs.Code(err) != errs.Unauthenticated && r.traceLogs {
+			r.logger.Trace().Err(err).Msg("auth handler returned error")
+		}
+
+		return model.AuthInfo{}, err
+	}
+}
+
+// handleRemoteAuthCall is the server side of remoteAuthHandler.Authenticate
+func (s *Server) handleRemoteAuthCall(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	// Parse the incoming call metadata
+	meta := CallMetaFromContext(req.Context())
+
+	// Check if the caller was the gateway, if not return an error
+	if meta.Internal == nil || meta.Internal.Caller == nil {
+		errs.HTTPErrorWithCode(w, errs.B().Code(errs.PermissionDenied).Msg("permission denied").Err(), 0)
+		return
+	}
+	caller, ok := meta.Internal.Caller.(*ApiCaller)
+	if !ok || caller.ServiceName != "gateway" || caller.Endpoint != "__encore/auth_handler" {
+		errs.HTTPErrorWithCode(w, errs.B().Code(errs.PermissionDenied).Msg("permission denied").Err(), 0)
+		return
+	}
+
+	// originalC captures the meta _before_ we removed the internal call metadata
+	// this is used for returnError to marshal the full error
+	originalC := s.NewIncomingContext(w, req, nil, meta)
+
+	// Remove the internal call metadata, so it doesn't get passed to the auth handler
+	meta.Internal = nil
+
+	// Create a new IncomingContext
+	c := s.NewIncomingContext(w, req, nil, meta)
+
+	// Call the original auth handler
+	authInfo, err := s.authHandler.Authenticate(c)
+	if err != nil {
+		returnError(originalC, err, 0)
+		return
+	}
+
+	// Add the user ID to the response metadata
+	t := transport.HTTPResponseWriter(w)
+	t.SetMeta("UserID", string(authInfo.UID))
+
+	// Write the auth info to the response
+	if err := authJSON.NewEncoder(w).Encode(authInfo.UserData); err != nil {
+		returnError(originalC, err, 0)
+		return
+	}
+}
+
+func (r *remoteAuthHandler) HostedByService() string {
+	return r.hostingService.Name
+}
+
+func (r *remoteAuthHandler) ParseAuthData(c IncomingContext) error {
+	return r.original.ParseAuthData(c)
+}

--- a/runtime/appruntime/apisdk/api/callers.go
+++ b/runtime/appruntime/apisdk/api/callers.go
@@ -9,7 +9,8 @@ import (
 // Caller is an interface which can be used to identify the caller of an RPC call.
 // if the caller is an authenticated source.
 type Caller interface {
-	CallerString() string
+	CallerString() string   // What is the caller wireformat?
+	PrivateAPIAccess() bool // Is this caller allowed to access private APIs?
 }
 
 // ApiCaller is a caller which represents an RPC which made a service-to-service API call
@@ -20,6 +21,10 @@ type ApiCaller struct {
 
 func (s ApiCaller) CallerString() string {
 	return fmt.Sprintf("api:%s.%s", s.ServiceName, s.Endpoint)
+}
+
+func (s ApiCaller) PrivateAPIAccess() bool {
+	return true
 }
 
 // PubSubCaller is a caller which represents a PubSub subscription which made a service-to-service API call
@@ -33,6 +38,10 @@ func (p PubSubCaller) CallerString() string {
 	return fmt.Sprintf("pubsub:%s:%s:%s", p.Topic, p.Subscription, p.MessageID)
 }
 
+func (p PubSubCaller) PrivateAPIAccess() bool {
+	return true
+}
+
 // AppCaller is a caller which represents the app itself made a service-to-service API call, but outside any traced process
 // - This most likely means the call was made from a background process or init function
 type AppCaller struct {
@@ -43,6 +52,26 @@ func (a AppCaller) CallerString() string {
 	return fmt.Sprintf("app:%s", a.DeployID)
 }
 
+func (a AppCaller) PrivateAPIAccess() bool {
+	return true
+}
+
+// GatewayCaller is a caller which represents an API gateway within the application made a service-to-service API call
+// This is used to identify the fact that the call was made from a gateway, and not from a background process or init function
+// and should not be allowed access to the private routes
+type GatewayCaller struct {
+	ServiceName string // The service name being called by the gateway
+	Endpoint    string // The endpoint being called by the gateway
+}
+
+func (g GatewayCaller) CallerString() string {
+	return fmt.Sprintf("gateway:%s.%s", g.ServiceName, g.Endpoint)
+}
+
+func (g GatewayCaller) PrivateAPIAccess() bool {
+	return false
+}
+
 // EncoreCaller represents an RPC call made from Encore's central systems (such as the Cloud dashboard)
 type EncoreCaller struct {
 	Principal string // The principal which made the call, could be an end user or a service
@@ -50,6 +79,10 @@ type EncoreCaller struct {
 
 func (e EncoreCaller) CallerString() string {
 	return fmt.Sprintf("encore:%s", e.Principal)
+}
+
+func (e EncoreCaller) PrivateAPIAccess() bool {
+	return true
 }
 
 // ParseCallerString parses a caller string into a Caller object
@@ -73,6 +106,12 @@ func ParseCallerString(callerStr string) (Caller, error) {
 		return &PubSubCaller{topic, subscription, msgId}, nil
 	case strings.HasPrefix(callerStr, "app:"):
 		return &AppCaller{callerStr[len("app:"):]}, nil
+	case strings.HasPrefix(callerStr, "gateway:"):
+		service, endpoint, found := strings.Cut(callerStr[len("gateway:"):], ".")
+		if !found {
+			return nil, errors.New("invalid gateway caller")
+		}
+		return &GatewayCaller{service, endpoint}, nil
 	case strings.HasPrefix(callerStr, "encore:"):
 		return &EncoreCaller{callerStr[len("encore:"):]}, nil
 	default:

--- a/runtime/appruntime/apisdk/api/encore_routes.go
+++ b/runtime/appruntime/apisdk/api/encore_routes.go
@@ -12,7 +12,7 @@ import (
 func (s *Server) registerEncoreRoutes() {
 	s.encore.HandlerFunc(wildcardMethod, "/healthz", s.handleHealthz)
 	s.encore.Handle("POST", "/pubsub/push/:subscription_id", s.handlePubsubPush)
-	s.encore.Handle("POST", "/auth_handler", s.handleRemoteAuthCall)
+	s.encore.Handle("POST", "/authhandler", s.handleRemoteAuthCall)
 }
 
 // handleHealthz returns the current health and deployment details of the running Encore application

--- a/runtime/appruntime/apisdk/api/encore_routes.go
+++ b/runtime/appruntime/apisdk/api/encore_routes.go
@@ -12,6 +12,7 @@ import (
 func (s *Server) registerEncoreRoutes() {
 	s.encore.HandlerFunc(wildcardMethod, "/healthz", s.handleHealthz)
 	s.encore.Handle("POST", "/pubsub/push/:subscription_id", s.handlePubsubPush)
+	s.encore.Handle("POST", "/auth_handler", s.handleRemoteAuthCall)
 }
 
 // handleHealthz returns the current health and deployment details of the running Encore application

--- a/runtime/appruntime/apisdk/api/server.go
+++ b/runtime/appruntime/apisdk/api/server.go
@@ -20,6 +20,7 @@ import (
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/exported/experiments"
 	"encore.dev/appruntime/exported/model"
+	"encore.dev/appruntime/shared/cfgutil"
 	"encore.dev/appruntime/shared/health"
 	"encore.dev/appruntime/shared/platform"
 	"encore.dev/appruntime/shared/reqtrack"
@@ -220,7 +221,7 @@ func (s *Server) registerEndpoint(h Handler) {
 	case s.IsGateway():
 		adapter = s.createGatewayHandlerAdapter(h)
 
-	case s.IsHostedService(h.ServiceName()):
+	case cfgutil.IsHostedService(s.runtime, h.ServiceName()):
 		adapter = s.createServiceHandlerAdapter(h)
 
 	default:

--- a/runtime/appruntime/apisdk/api/server.go
+++ b/runtime/appruntime/apisdk/api/server.go
@@ -21,6 +21,7 @@ import (
 	"encore.dev/appruntime/exported/experiments"
 	"encore.dev/appruntime/exported/model"
 	"encore.dev/appruntime/shared/cfgutil"
+	"encore.dev/appruntime/shared/cloudtrace"
 	"encore.dev/appruntime/shared/health"
 	"encore.dev/appruntime/shared/platform"
 	"encore.dev/appruntime/shared/reqtrack"
@@ -85,12 +86,6 @@ type requestsTotalLabels struct {
 	endpoint string // Endpoint name.
 	code     string // Human-readable HTTP status code.
 }
-
-type metaContextKey string
-
-var (
-	metaContextKeyAuthInfo metaContextKey = "requestMeta"
-)
 
 type Server struct {
 	static         *config.Static
@@ -196,7 +191,27 @@ func NewServer(static *config.Static, runtime *config.Runtime, rt *reqtrack.Requ
 // setAuthHandler sets the auth handler to use.
 // If h is nil it means no auth handler is used.
 func (s *Server) setAuthHandler(h AuthHandler) {
-	s.authHandler = h
+	authService := h.HostedByService()
+
+	if !cfgutil.IsHostedService(s.runtime, authService) {
+		service, found := s.runtime.ServiceDiscovery[authService]
+		if !found {
+			panic(fmt.Errorf("service %q not found in service discovery, but needed for the auth handler", authService))
+		}
+
+		authURL := fmt.Sprintf("%s/__encore/auth_handler", service.URL)
+
+		s.authHandler = &remoteAuthHandler{
+			server:         s,
+			hostingService: service,
+			authURL:        authURL,
+			original:       h,
+			logger:         s.rootLogger.With().Str("auth_url", authURL).Logger(),
+			traceLogs:      s.runtime.EnvCloud != "local", // log auth calls in prod containers only
+		}
+	} else {
+		s.authHandler = h
+	}
 }
 
 func (s *Server) RegisteredHandlers() []Handler {
@@ -307,18 +322,16 @@ func (s *Server) handler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	// Extract the metadata from the request so we can allow access to the private router.
-	// If the metadata is not present, then we assume this is a public request.
-	callMeta, err := s.MetaFromRequest(transport.HTTPRequest(req))
-	if err != nil {
-		s.rootLogger.Error().Err(err).Msg("failed to extract metadata from request")
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	// Extract the call meta from the request
+	req, internalCaller, ok := s.extractCallMeta(w, req)
+	if !ok {
+		// extractCallMeta has already written the response
 		return
 	}
-	if callMeta.Internal != nil {
+	if internalCaller != nil && internalCaller.PrivateAPIAccess() {
+		// If this request is from another service running in this app, allow it access to the private API routes
 		router, fallbackRouter = s.private, s.privateFallback
 	}
-	req = req.WithContext(context.WithValue(req.Context(), metaContextKeyAuthInfo, callMeta))
 
 	path := determineRequestPath(req.URL)
 
@@ -368,15 +381,39 @@ func (s *Server) handler(w http.ResponseWriter, req *http.Request) {
 	errs.HTTPError(w, errs.B().Code(errs.NotFound).Msg("endpoint not found").Err())
 }
 
-func (s *Server) processRequest(h Handler, c IncomingContext) {
-	c.server.beginOperation()
-	defer c.server.finishOperation()
-
-	info, proceed := s.runAuthHandler(h, c)
-	if proceed {
-		c.auth = info
-		h.Handle(c)
+func (s *Server) extractCallMeta(w http.ResponseWriter, req *http.Request) (updatedReq *http.Request, internalCaller Caller, ok bool) {
+	// Extract the metadata from the request so we can allow access to the private router.
+	// If the metadata is not present, then we assume this is a public request.
+	meta, err := s.MetaFromRequest(transport.HTTPRequest(req))
+	if err != nil {
+		s.rootLogger.Error().Err(err).Msg("failed to extract metadata from request")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return nil, nil, false
 	}
+
+	// Extract any cloud generated Trace identifiers from the request.
+	// and use them if we don't have any trace information in the metadata already
+	cloudGeneratedTraceIDs := cloudtrace.ExtractCloudTraceIDs(s.rootLogger, req)
+	if meta.TraceID.IsZero() {
+		meta.TraceID = cloudGeneratedTraceIDs.TraceID
+	}
+
+	// SpanID will be zero already, so if our Cloud generated one for us, we should
+	// use it as the SpanID for this request
+	meta.SpanID = cloudGeneratedTraceIDs.SpanID
+
+	// If we still don't have a trace id, generate one.
+	if meta.TraceID.IsZero() {
+		meta.TraceID, _ = model.GenTraceID()
+		meta.ParentSpanID = model.SpanID{} // no parent span if we have no trace id
+	}
+
+	var caller Caller
+	if meta.Internal != nil {
+		caller = meta.Internal.Caller
+	}
+
+	return req.WithContext(SetCallMetaInContext(req.Context(), meta)), caller, true
 }
 
 func (s *Server) newExecContext(ctx context.Context, ps UnnamedParams, callMeta CallMeta) execContext {

--- a/runtime/appruntime/apisdk/api/services.go
+++ b/runtime/appruntime/apisdk/api/services.go
@@ -9,23 +9,6 @@ import (
 	"encore.dev/appruntime/shared/cloudtrace"
 )
 
-// IsHostedService returns true if the given service is hosted by this instance
-// of the Encore application, false otherwise.
-func (s *Server) IsHostedService(serviceName string) bool {
-	// No runtime configured services or gateways means all services are running here
-	if len(s.runtime.HostedServices) == 0 && len(s.runtime.Gateways) == 0 {
-		return true
-	}
-
-	for _, service := range s.runtime.HostedServices {
-		if service == serviceName {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (s *Server) createServiceHandlerAdapter(h Handler) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 		params := toUnnamedParams(ps)

--- a/runtime/appruntime/apisdk/api/transport/http.go
+++ b/runtime/appruntime/apisdk/api/transport/http.go
@@ -12,7 +12,12 @@ func HTTPRequest(req *http.Request) Transport {
 }
 
 // HTTPResponse returns a Transport implementation for the given HTTP response.
-func HTTPResponse(w http.ResponseWriter) Transport {
+func HTTPResponse(resp *http.Response) Transport {
+	return &httpHeaders{headers: resp.Header}
+}
+
+// HTTPResponseWriter returns a Transport implementation for the given HTTP response.
+func HTTPResponseWriter(w http.ResponseWriter) Transport {
 	return &httpHeaders{headers: w.Header()}
 }
 

--- a/runtime/appruntime/apisdk/service/service.go
+++ b/runtime/appruntime/apisdk/service/service.go
@@ -11,6 +11,7 @@ import (
 
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/exported/trace2"
+	"encore.dev/appruntime/shared/cfgutil"
 	"encore.dev/appruntime/shared/health"
 	"encore.dev/appruntime/shared/reqtrack"
 	"encore.dev/appruntime/shared/syncutil"
@@ -115,7 +116,7 @@ type Manager struct {
 
 func (mgr *Manager) RegisterService(i Initializer) {
 	name := i.ServiceName()
-	if !mgr.IsHosting(name) {
+	if !cfgutil.IsHostedService(mgr.runtime, name) {
 		return
 	}
 
@@ -124,21 +125,6 @@ func (mgr *Manager) RegisterService(i Initializer) {
 	}
 	mgr.svcMap[name] = i
 	mgr.svcInit = append(mgr.svcInit, i)
-}
-
-func (mgr *Manager) IsHosting(serviceName string) bool {
-	// If we're an all-in-one server, we're hosting everything.
-	if len(mgr.runtime.Gateways) == 0 && len(mgr.runtime.HostedServices) == 0 {
-		return true
-	}
-
-	// Otherwise check if we're hosting this
-	for _, svc := range mgr.runtime.HostedServices {
-		if svc == serviceName {
-			return true
-		}
-	}
-	return false
 }
 
 func (mgr *Manager) InitializeServices() error {

--- a/runtime/appruntime/infrasdk/secrets/manager_internal.go
+++ b/runtime/appruntime/infrasdk/secrets/manager_internal.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"encore.dev/appruntime/exported/config"
+	"encore.dev/appruntime/shared/cfgutil"
 )
 
 type Manager struct {
@@ -20,13 +21,13 @@ func NewManager(cfg *config.Runtime, appSecretsEnv string) *Manager {
 }
 
 // Load loads a secret.
-func (mgr *Manager) Load(key string) string {
+func (mgr *Manager) Load(key string, inService string) string {
 	if val, ok := mgr.secrets[key]; ok {
 		return val
 	}
 
-	// For anything but local development, a missing secret is a fatal error.
-	if mgr.cfg.EnvCloud != "local" {
+	// For anything but local development or a gateway, a missing secret is a fatal error.
+	if mgr.cfg.EnvCloud != "local" && cfgutil.IsHostedService(mgr.cfg, inService) {
 		fmt.Fprintln(os.Stderr, "encore: could not find secret", key)
 		os.Exit(2)
 	}

--- a/runtime/appruntime/infrasdk/secrets/secrets.go
+++ b/runtime/appruntime/infrasdk/secrets/secrets.go
@@ -12,6 +12,6 @@ var singleton = NewManager(
 	encoreenv.Get("ENCORE_APP_SECRETS"),
 )
 
-func Load(key string) string {
-	return singleton.Load(key)
+func Load(key string, inService string) string {
+	return singleton.Load(key, inService)
 }

--- a/runtime/appruntime/shared/cfgutil/svc.go
+++ b/runtime/appruntime/shared/cfgutil/svc.go
@@ -1,0 +1,32 @@
+package cfgutil
+
+import (
+	"encore.dev/appruntime/exported/config"
+)
+
+// IsHostedService returns true if the given service is hosted in this container
+// or false otherwise.
+//
+// If no service name is passed in, then this function returns true if any service
+// code is running in this container
+func IsHostedService(runtime *config.Runtime, serviceName string) bool {
+	// No runtime configured services or gateways means all services are running here
+	if len(runtime.HostedServices) == 0 && len(runtime.Gateways) == 0 {
+		return true
+	}
+
+	// If we're not hosting a gateway and no service name is passed in
+	// then we're checking if we're running any service code
+	if serviceName == "" && len(runtime.Gateways) == 0 {
+		return true
+	}
+
+	// Otherwise check if we're hosting this
+	for _, service := range runtime.HostedServices {
+		if service == serviceName {
+			return true
+		}
+	}
+
+	return false
+}

--- a/v2/codegen/infragen/infragen.go
+++ b/v2/codegen/infragen/infragen.go
@@ -2,6 +2,7 @@ package infragen
 
 import (
 	"encr.dev/pkg/fns"
+	"encr.dev/pkg/option"
 	"encr.dev/pkg/paths"
 	"encr.dev/v2/app"
 	"encr.dev/v2/codegen"
@@ -66,7 +67,8 @@ func Process(gg *codegen.Generator, appDesc *app.Desc) {
 				return r.(*pubsub.Subscription)
 			}))
 		case resource.Secrets:
-			secretsgen.Gen(gg, pkg, fns.Map(resources, func(r resource.Resource) *secrets.Secrets {
+			svc, _ := appDesc.ServiceForPath(pkg.FSPath)
+			secretsgen.Gen(gg, option.AsOptional(svc), pkg, fns.Map(resources, func(r resource.Resource) *secrets.Secrets {
 				return r.(*secrets.Secrets)
 			}))
 		case resource.ConfigLoad:

--- a/v2/codegen/infragen/secretsgen/secretsgen.go
+++ b/v2/codegen/infragen/secretsgen/secretsgen.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"strconv"
 
+	"encr.dev/pkg/option"
+	"encr.dev/v2/app"
 	"encr.dev/v2/codegen"
 	"encr.dev/v2/internals/pkginfo"
 	"encr.dev/v2/parser/infra/secrets"
 )
 
-func Gen(gen *codegen.Generator, pkg *pkginfo.Package, secrets []*secrets.Secrets) {
+func Gen(gen *codegen.Generator, svc option.Option[*app.Service], pkg *pkginfo.Package, secrets []*secrets.Secrets) {
 	addedImport := make(map[*pkginfo.File]bool)
 	for _, secret := range secrets {
 		file := secret.File
@@ -27,12 +29,21 @@ func Gen(gen *codegen.Generator, pkg *pkginfo.Package, secrets []*secrets.Secret
 			addedImport[secret.File] = true
 		}
 
+		svcName := strconv.Quote(
+			option.
+				Map(
+					svc,
+					func(svc *app.Service) string { return svc.Name },
+				).
+				GetOrElse(""),
+		)
+
 		// Rewrite the value spec to load the secrets.
 		spec := secret.Spec
 		var buf bytes.Buffer
 		buf.WriteString("{\n")
 		for _, key := range secret.Keys {
-			fmt.Fprintf(&buf, "\t%s: __encore_secrets.Load(%s),\n", key, strconv.Quote(key))
+			fmt.Fprintf(&buf, "\t%s: __encore_secrets.Load(%s, %s),\n", key, strconv.Quote(key), svcName)
 		}
 		ep := gen.FS.Position(spec.End())
 		fmt.Fprintf(&buf, "}/*line :%d:%d*/", ep.Line, ep.Column)

--- a/v2/codegen/infragen/secretsgen/secretsgen.go
+++ b/v2/codegen/infragen/secretsgen/secretsgen.go
@@ -29,14 +29,8 @@ func Gen(gen *codegen.Generator, svc option.Option[*app.Service], pkg *pkginfo.P
 			addedImport[secret.File] = true
 		}
 
-		svcName := strconv.Quote(
-			option.
-				Map(
-					svc,
-					func(svc *app.Service) string { return svc.Name },
-				).
-				GetOrElse(""),
-		)
+		getName := func(svc *app.Service) string { return svc.Name }
+		svcName := strconv.Quote(option.Map(svc, getName).GetOrElse(""))
 
 		// Rewrite the value spec to load the secrets.
 		spec := secret.Spec


### PR DESCRIPTION
This PR adds the ability for an Encore service (or gateway) to make a remote call to another container to run an auth handler.

This is required when the auth handler requires access to infrastructure that only the service it is defined in has access to. So all other containers will route their auth calls to that container.

This PR also fixes an issue where secrets would cause a panic in services when not set, even if those services where not running within the container.