### PR TITLE
Support different outbound SvcAuth methods

### DIFF
--- a/runtime/appruntime/apisdk/api/call_meta.go
+++ b/runtime/appruntime/apisdk/api/call_meta.go
@@ -162,7 +162,7 @@ func (meta CallMeta) AddToRequest(server *Server, targetService config.Service, 
 		}
 
 		// If we're making an internal call, sign the request
-		targetAuth := server.internalAuth[targetService.ServiceAuth.Method]
+		targetAuth := server.outboundSvcAuth[targetService.ServiceAuth.Method]
 		if targetAuth == nil {
 			return errs.B().Msg("no internal auth method configured to talk with target service").Err()
 		}
@@ -192,7 +192,7 @@ func (s *Server) MetaFromRequest(req transport.Transport) (meta CallMeta, err er
 
 	// If it was an internal call, read the internal metadata
 	if callerStr, found := req.ReadMeta(callerMetaName); found {
-		isInternalCall, err := svcauth.Verify(req, s.internalAuth)
+		isInternalCall, err := svcauth.Verify(req, s.inboundSvcAuth)
 		if err != nil {
 			return CallMeta{}, fmt.Errorf("failed to verify internal call: %w", err)
 		}

--- a/runtime/appruntime/apisdk/api/server.go
+++ b/runtime/appruntime/apisdk/api/server.go
@@ -112,7 +112,8 @@ type Server struct {
 	private         *httprouter.Router
 	privateFallback *httprouter.Router
 	encore          *httprouter.Router
-	internalAuth    map[string]svcauth.ServiceAuth // auth methods for internal service-to-service calls
+	inboundSvcAuth  map[string]svcauth.ServiceAuth // auth methods used to accept inbound service-to-service calls
+	outboundSvcAuth map[string]svcauth.ServiceAuth // auth methods used to make outbound service-to-service calls
 	httpsrv         *http.Server
 
 	callCtr uint64
@@ -139,7 +140,7 @@ func NewServer(static *config.Static, runtime *config.Runtime, rt *reqtrack.Requ
 		return router
 	}
 
-	svcAuth, err := svcauth.LoadMethods(clock, runtime)
+	inboundSvcAuth, outboundSvcAuth, err := svcauth.LoadMethods(clock, runtime)
 	if err != nil {
 		panic(fmt.Errorf("error loading service auth methods: %w", err))
 	}
@@ -165,7 +166,8 @@ func NewServer(static *config.Static, runtime *config.Runtime, rt *reqtrack.Requ
 		private:         newRouter(),
 		privateFallback: newRouter(),
 		encore:          newRouter(),
-		internalAuth:    svcAuth,
+		inboundSvcAuth:  inboundSvcAuth,
+		outboundSvcAuth: outboundSvcAuth,
 	}
 
 	// Configure CORS


### PR DESCRIPTION
This commit updates the runtime to allow outbound requests to be signed with different auth methods than inbound requests can use.

This is useful in a Kubernetes environment where the API Gateway might use `encore-auth`, but services inside the cluster might use `noop`. In this case the Gateway has to only accept `encore-auth`, but it needs to also load `noop` during system startup to sign the outbound requests it makes.