### PR TITLE
Update graceful shutdown process to force an exit

### DIFF
--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -389,7 +389,7 @@ func (p *Proc) Close() {
 		p.Kill()
 	}
 
-	timer := time.NewTimer(10 * time.Second)
+	timer := time.NewTimer(gracefulShutdownTime + (500 * time.Millisecond))
 	defer timer.Stop()
 
 	select {

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -399,6 +399,8 @@ type StartProcGroupParams struct {
 	Experiments    *experiments.Set
 }
 
+const gracefulShutdownTime = 10 * time.Second
+
 // StartProcGroup starts a single actual OS process for app.
 func (r *Run) StartProcGroup(params *StartProcGroupParams) (p *ProcGroup, err error) {
 	pid := GenID()
@@ -418,17 +420,20 @@ func (r *Run) StartProcGroup(params *StartProcGroupParams) (p *ProcGroup, err er
 		ID:  pid,
 		Run: r,
 		EnvGenerator: &RuntimeEnvGenerator{
-			App:             r.App,
-			InfraManager:    r.ResourceManager,
-			Meta:            params.Meta,
-			Secrets:         params.Secrets,
-			SvcConfigs:      params.ServiceConfigs,
-			AppID:           option.Some(r.ID),
-			EnvID:           option.Some(pid),
-			TraceEndpoint:   option.Some(fmt.Sprintf("http://localhost:%d/trace", r.Mgr.RuntimePort)),
-			AuthKey:         option.Some(authKey),
-			DaemonProxyAddr: option.Some(listenAddr),
-			ListenAddresses: procListenAddresses,
+			App:                  r.App,
+			InfraManager:         r.ResourceManager,
+			Meta:                 params.Meta,
+			Secrets:              params.Secrets,
+			SvcConfigs:           params.ServiceConfigs,
+			AppID:                option.Some(r.ID),
+			EnvID:                option.Some(pid),
+			TraceEndpoint:        option.Some(fmt.Sprintf("http://localhost:%d/trace", r.Mgr.RuntimePort)),
+			AuthKey:              option.Some(authKey),
+			DaemonProxyAddr:      option.Some(listenAddr),
+			GracefulShutdownTime: option.Some(gracefulShutdownTime),
+			ShutdownHooksGrace:   option.Some(4 * time.Second),
+			HandlersGrace:        option.Some(2 * time.Second),
+			ListenAddresses:      procListenAddresses,
 		},
 		Experiments: params.Experiments,
 		Meta:        params.Meta,

--- a/runtime/appruntime/apisdk/service/singleton.go
+++ b/runtime/appruntime/apisdk/service/singleton.go
@@ -9,9 +9,15 @@ import (
 	"encore.dev/appruntime/shared/health"
 	"encore.dev/appruntime/shared/logging"
 	"encore.dev/appruntime/shared/reqtrack"
+	"encore.dev/appruntime/shared/shutdown"
 )
 
-var Singleton = NewManager(appconf.Runtime, reqtrack.Singleton, health.Singleton, logging.RootLogger)
+var Singleton *Manager
+
+func init() {
+	Singleton = NewManager(appconf.Runtime, reqtrack.Singleton, health.Singleton, logging.RootLogger)
+	shutdown.Singleton.OnShutdown(Singleton.Shutdown)
+}
 
 func Register(i Initializer) {
 	Singleton.RegisterService(i)

--- a/runtime/appruntime/shared/shutdown/shutdown.go
+++ b/runtime/appruntime/shared/shutdown/shutdown.go
@@ -2,7 +2,13 @@ package shutdown
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 	"os/signal"
+	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -10,42 +16,114 @@ import (
 	"github.com/rs/zerolog"
 
 	"encore.dev/appruntime/exported/config"
+	"encore.dev/beta/errs"
 )
 
+// Hook are functions which have registered to perform cooperative
+// shutdown tasks. They are called concurrently when the server wants
+// to perform a graceful shutdown.
+//
+// The force context will be canceled when the server is going to give
+// up on the hook returning and will proceed to forcefully shutdown
+// the instance.
+//
+// Hooks are called instantly when the server is starting a graceful
+// shutdown, and are expected to block until they are done.
+type Hook func(force context.Context)
+
+// HandlerHook are functions which have registered to be notified
+// when contexts passed to currently running handlers should be cancelled.
+//
+// HandlerHooks are only called after the Handler timeout has occurred.
+// These functions are expected to block until all active handlers have
+// returned.
+type HandlerHook func()
+
 type Tracker struct {
-	runtime *config.Runtime
-	logger  zerolog.Logger
+	logger zerolog.Logger
+
+	watchSignals         bool
+	logShutdown          bool
+	gracefulTimeout      time.Duration
+	handlerTimeout       time.Duration
+	shutdownHooksTimeout time.Duration
 
 	initiated chan struct{} // closed when graceful shutdown is initiated
-	completed chan struct{} // closed when graceful shutdown is completed
 	once      sync.Once     // to trigger shutdown logic only once
 
 	mu       sync.Mutex
-	handlers []func(force context.Context)
+	hooks    []Hook
+	handlers []HandlerHook
 }
 
 func NewTracker(runtime *config.Runtime, logger zerolog.Logger) *Tracker {
-	return &Tracker{
-		runtime:   runtime,
-		logger:    logger,
-		initiated: make(chan struct{}),
-		completed: make(chan struct{}),
+	t := &Tracker{
+		logger:       logger,
+		watchSignals: runtime.EnvType != "test",
+		logShutdown:  runtime.EnvCloud != "local",
+		initiated:    make(chan struct{}),
 	}
+	t.timingsFromConfig(runtime)
+
+	return t
+}
+
+func (t *Tracker) timingsFromConfig(runtime *config.Runtime) config.GracefulShutdownTimings {
+	// Setup the config
+	var cfg config.GracefulShutdownTimings
+	if runtime.GracefulShutdown != nil {
+		cfg = *runtime.GracefulShutdown
+	}
+
+	// Handle the migration from ShutdownTimout to GracefulShutdown configuration
+	if cfg.Total == nil {
+		t.gracefulTimeout = runtime.ShutdownTimeout
+		if t.gracefulTimeout <= 0 {
+			t.gracefulTimeout = 500 * time.Millisecond
+		}
+	} else {
+		t.gracefulTimeout = *cfg.Total
+	}
+	if t.gracefulTimeout < 0 {
+		t.gracefulTimeout = 0
+	}
+
+	// Get the handler timeout
+	if cfg.Handlers == nil {
+		t.handlerTimeout = t.gracefulTimeout - 1*time.Second
+	} else {
+		t.handlerTimeout = t.gracefulTimeout - *cfg.Handlers
+	}
+	if t.handlerTimeout < 0 {
+		t.handlerTimeout = 0
+	}
+
+	// Get the shutdown hook timeout
+	if cfg.ShutdownHooks == nil {
+		t.shutdownHooksTimeout = t.gracefulTimeout - 1*time.Second
+	} else {
+		t.shutdownHooksTimeout = t.gracefulTimeout - *cfg.ShutdownHooks
+	}
+	if t.shutdownHooksTimeout < 0 {
+		t.shutdownHooksTimeout = 0
+	}
+
+	return cfg
 }
 
 // WatchForShutdownSignals watches for shutdown signals (SIGTERM, SIGINT)
 // and triggers the graceful shutdown when such a signal is received.
 func (t *Tracker) WatchForShutdownSignals() {
-	if t.runtime.EnvType == "test" {
-		// Do nothing during tests.
+	if !t.watchSignals {
 		return
 	}
 
-	graceful, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	gracefulSignal := make(chan os.Signal, 1)
+	signal.Notify(gracefulSignal, syscall.SIGTERM, syscall.SIGINT)
+
 	go func() {
-		<-graceful.Done()
-		cancel()
-		t.Shutdown()
+		signalReceived := <-gracefulSignal
+		t.Shutdown(signalReceived, nil)
 	}()
 }
 
@@ -56,12 +134,24 @@ func (t *Tracker) WatchForShutdownSignals() {
 // time to forcefully shut down. force.Deadline() can be inspected to learn when this
 // will happen in advance.
 //
-// The shutdown is cooperative: the process will not exit until all shutdown handlers
+// The shutdown is cooperative: the process will not exit until all shutdown hooks
 // have returned, unless the process is forcefully killed by a signal (which may happen
 // in certain cloud environments if the graceful shutdown takes longer than its timeout).
 //
 // If t is nil this function is a no-op.
-func (t *Tracker) OnShutdown(fn func(force context.Context)) {
+func (t *Tracker) OnShutdown(fn Hook) {
+	if t == nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.hooks = append(t.hooks, fn)
+}
+
+// RegisterHandlerHook registers a handler hook that will be called when the app
+// wants to cancel all currently running handlers.
+func (t *Tracker) RegisterHandlerHook(fn HandlerHook) {
 	if t == nil {
 		return
 	}
@@ -73,42 +163,105 @@ func (t *Tracker) OnShutdown(fn func(force context.Context)) {
 
 // Shutdown triggers the shutdown logic.
 // If it has already been triggered, it does nothing and returns immediately.
-func (t *Tracker) Shutdown() {
+func (t *Tracker) Shutdown(reasonSignal os.Signal, reasonError error) {
 	t.once.Do(func() {
 		close(t.initiated)
 
-		doLog := t.runtime.EnvCloud != "local"
-		if doLog {
-			t.logger.Info().Msg("got shutdown signal, initiating graceful shutdown")
+		// This is so we can debug the shutdown logic, but default it's off
+		const debugTraceShutdown = false
+
+		// Create the contexts we need to initiate the shutdown
+		gracefulCtx, cancelGraceful := context.WithTimeout(context.Background(), t.gracefulTimeout)
+		defer cancelGraceful()
+		shutdownCtx, cancelShutdown := context.WithTimeout(gracefulCtx, t.shutdownHooksTimeout)
+		defer cancelShutdown()
+		handlerCtx, cancelHandler := context.WithTimeout(gracefulCtx, t.handlerTimeout)
+		defer cancelHandler()
+
+		if t.logShutdown {
+			if reasonSignal != nil {
+				t.logger.Warn().Str("signal", reasonSignal.String()).Msg("got shutdown signal, initiating graceful shutdown")
+			} else if reasonError != nil {
+				t.logger.Err(reasonError).Msg("a fatal error occurred, initiating graceful shutdown")
+			} else {
+				t.logger.Info().Msg("initiating graceful shutdown")
+			}
 		}
 
-		var maxWait time.Duration
-		if t := t.runtime.ShutdownTimeout; t > 0 {
-			maxWait = t
-		}
-		force, cancel := context.WithTimeout(context.Background(), maxWait)
-		defer cancel()
+		// Start a goroutine that will forcefully shutdown the process when the graceful context
+		// is closed.
+		//
+		// If it timed out, we exit with a non-zero exit code to signal that the shutdown was not graceful.
+		// If it was cancelled, we exit with a zero exit code to signal that the shutdown was graceful.
+		go func() {
+			<-gracefulCtx.Done()
+
+			if errors.Is(gracefulCtx.Err(), context.DeadlineExceeded) {
+				if t.logShutdown {
+					t.logger.Info().Msg("graceful shutdown window closed, forcing shutdown")
+				}
+				os.Exit(1)
+			} else {
+				if t.logShutdown {
+					t.logger.Info().Msg("graceful shutdown completed")
+				}
+				os.Exit(0)
+			}
+		}()
 
 		t.mu.Lock()
-		handlers := t.handlers
+		hooks := t.hooks
+		handlerHooks := t.handlers
 		t.mu.Unlock()
 
-		// Run our handlers concurrently and wait for them to complete.
+		// Run our hooks concurrently and wait for them to complete.
 		var wg sync.WaitGroup
-		wg.Add(len(handlers))
-		for _, fn := range handlers {
+		wg.Add(len(hooks) + len(handlerHooks))
+
+		for _, fn := range hooks {
 			fn := fn
+			name := functionName(fn)
 			go func() {
 				defer wg.Done()
-				fn(force)
+				defer func() {
+					if r := recover(); r != nil {
+						t.logger.Err(errs.B().Msg("recovered panic").Err()).Interface("panic", r).Msg("panic encountered during shutdown hook")
+					}
+				}()
+
+				if debugTraceShutdown {
+					defer t.logger.Trace().Str("hook", name).Msg("shutdown hook completed")
+					t.logger.Trace().Str("hook", name).Msg("running shutdown hook...")
+				}
+				fn(shutdownCtx)
 			}()
 		}
+
+		for _, fn := range handlerHooks {
+			fn := fn
+			name := functionName(fn)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						t.logger.Err(errs.B().Msg("recovered panic").Err()).Interface("panic", r).Msg("panic encountered running shutdown hook")
+					}
+				}()
+
+				// Wait for the handler context to be cancelled before calling the handler hook
+				<-handlerCtx.Done()
+				if debugTraceShutdown {
+					defer t.logger.Trace().Str("hook", name).Msg("shutdown hook completed")
+					t.logger.Trace().Str("hook", name).Msg("running shutdown hook...")
+				}
+				fn()
+			}()
+		}
+
 		wg.Wait()
 
-		if doLog {
-			t.logger.Info().Msg("shutdown completed")
-		}
-		close(t.completed)
+		// If here we've gracefully shutdown, so we can cancel the graceful context
+		cancelGraceful()
 	})
 }
 
@@ -120,4 +273,14 @@ func (t *Tracker) ShutdownInitiated() bool {
 	default:
 		return false
 	}
+}
+
+func functionName(fn any) (rtn string) {
+	defer func() {
+		if r := recover(); r != nil && rtn == "" {
+			rtn = fmt.Sprintf("<panic getting function name: %v>", r)
+		}
+	}()
+
+	return strings.TrimSuffix(runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name(), "-fm")
 }

--- a/runtime/pubsub/internal/aws/topic_test.go
+++ b/runtime/pubsub/internal/aws/topic_test.go
@@ -12,6 +12,7 @@ import (
 
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/pubsub/internal/types"
+	"encore.dev/pubsub/internal/utils"
 )
 
 const (
@@ -47,8 +48,9 @@ func Test_AWS_PubSub_E2E(t *testing.T) {
 		},
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctxs := utils.NewContexts(ctx)
 	defer cancel()
-	mgr := NewManager(ctx)
+	mgr := NewManager(ctxs)
 
 	topic := mgr.NewTopic(runtime.PubsubProviders[0], types.TopicConfig{DeliveryGuarantee: types.AtLeastOnce}, runtime.PubsubTopics["test-topic"])
 

--- a/runtime/pubsub/internal/encorecloud/manager.go
+++ b/runtime/pubsub/internal/encorecloud/manager.go
@@ -1,23 +1,22 @@
 package encorecloud
 
 import (
-	"context"
-
 	"go.encore.dev/platform-sdk"
 	"go.encore.dev/platform-sdk/encorecloud"
 	"go.encore.dev/platform-sdk/pkg/auth"
 
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/pubsub/internal/types"
+	"encore.dev/pubsub/internal/utils"
 )
 
 type Manager struct {
-	ctx          context.Context
+	ctxs         *utils.Contexts
 	client       *encorecloud.Client
 	pushRegistry types.PushEndpointRegistry
 }
 
-func NewManager(ctx context.Context, runtime *config.Runtime, pushRegistry types.PushEndpointRegistry) *Manager {
+func NewManager(ctxs *utils.Contexts, runtime *config.Runtime, pushRegistry types.PushEndpointRegistry) *Manager {
 	// It's possible that the runtime is nil, for example if the app isn't using this manager
 	// so we need to check for that.
 	server := ""
@@ -32,7 +31,7 @@ func NewManager(ctx context.Context, runtime *config.Runtime, pushRegistry types
 		platform.WithAppDetails(runtime.AppSlug, runtime.EnvName),
 		platform.WithAuthKeys(authKeys...),
 	)
-	return &Manager{ctx: ctx, client: sdk.EncoreCloud, pushRegistry: pushRegistry}
+	return &Manager{ctxs: ctxs, client: sdk.EncoreCloud, pushRegistry: pushRegistry}
 }
 
 func (mgr *Manager) ProviderName() string {

--- a/runtime/pubsub/internal/gcp/clients.go
+++ b/runtime/pubsub/internal/gcp/clients.go
@@ -10,7 +10,7 @@ import (
 func (mgr *Manager) getClient() *pubsub.Client {
 	mgr.clientOnce.Do(func() {
 		// Create a new client
-		cl, err := pubsub.NewClient(mgr.ctx, "")
+		cl, err := pubsub.NewClient(mgr.ctxs.Connection, "")
 		if err != nil {
 			panic(fmt.Sprintf("failed to create pubsub client: %s", err))
 		}

--- a/runtime/pubsub/internal/utils/contexts.go
+++ b/runtime/pubsub/internal/utils/contexts.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"context"
+)
+
+// Contexts is a struct containing all the contexts used by the pubsub package
+type Contexts struct {
+	// Fetch is the context used for fetching messages from the pubsub provider
+	//
+	// It is cancelled when the manager is shutdown and is used to indicate that
+	// no more messages should be fetched from the provider.
+	//
+	// The fetch context is always the first context to be cancelled.
+	Fetch                 context.Context
+	StopFetchingNewEvents context.CancelFunc
+
+	// Handler is the context used for handling messages from the pubsub provider
+	//
+	// It is cancelled when the manager is told to stop any active handlers.
+	//
+	// If cancelled before the fetch context, it will also cancel the fetch context.
+	Handler       context.Context
+	CancelHandler context.CancelFunc
+
+	// Connection is the context used for the connection to the pubsub provider
+	//
+	// If cancelled, it will cancel both the fetch and handler contexts.
+	Connection       context.Context
+	CloseConnections context.CancelFunc
+}
+
+// NewContexts creates a new set of contexts for the pubsub package
+func NewContexts(base context.Context) *Contexts {
+	connection, cancelConnection := context.WithCancel(base)
+	handler, cancelHandler := context.WithCancel(connection)
+	fetch, cancelFetch := context.WithCancel(handler)
+
+	ctxs := &Contexts{
+		Fetch:                 fetch,
+		StopFetchingNewEvents: cancelFetch,
+		Handler:               handler,
+		CancelHandler:         cancelHandler,
+		Connection:            connection,
+		CloseConnections:      cancelConnection,
+	}
+
+	return ctxs
+}

--- a/runtime/pubsub/internal/utils/workers_test.go
+++ b/runtime/pubsub/internal/utils/workers_test.go
@@ -173,7 +173,7 @@ func TestWorkConcurrently(t *testing.T) {
 				return nil
 			}
 
-			err := WorkConcurrently(ctx, tt.concurrency, tt.maxBatchSize, fetcher, processor)
+			err := WorkConcurrently(NewContexts(ctx), tt.concurrency, tt.maxBatchSize, fetcher, processor)
 
 			workMu.Lock()
 			defer workMu.Unlock()
@@ -247,7 +247,7 @@ func TestWorkConcurrentlyLoad(t *testing.T) {
 	var err error
 
 	for ctx.Err() == nil {
-		err = WorkConcurrently(ctx, 25, 10, func(ctx context.Context, maxToFetch int) ([]string, error) {
+		err = WorkConcurrently(NewContexts(ctx), 25, 10, func(ctx context.Context, maxToFetch int) ([]string, error) {
 			mu.Lock()
 			defer mu.Unlock()
 

--- a/runtime/pubsub/provider_aws.go
+++ b/runtime/pubsub/provider_aws.go
@@ -6,6 +6,6 @@ import "encore.dev/pubsub/internal/aws"
 
 func init() {
 	registerProvider(func(mgr *Manager) provider {
-		return aws.NewManager(mgr.ctx)
+		return aws.NewManager(mgr.ctxs)
 	})
 }

--- a/runtime/pubsub/provider_azure.go
+++ b/runtime/pubsub/provider_azure.go
@@ -6,6 +6,6 @@ import "encore.dev/pubsub/internal/azure"
 
 func init() {
 	registerProvider(func(mgr *Manager) provider {
-		return azure.NewManager(mgr.ctx)
+		return azure.NewManager(mgr.ctxs)
 	})
 }

--- a/runtime/pubsub/provider_encorecloud.go
+++ b/runtime/pubsub/provider_encorecloud.go
@@ -8,6 +8,6 @@ import (
 
 func init() {
 	registerProvider(func(mgr *Manager) provider {
-		return encorecloud.NewManager(mgr.ctx, mgr.runtime, mgr)
+		return encorecloud.NewManager(mgr.ctxs, mgr.runtime, mgr)
 	})
 }

--- a/runtime/pubsub/provider_gcp.go
+++ b/runtime/pubsub/provider_gcp.go
@@ -8,6 +8,6 @@ import (
 
 func init() {
 	registerProvider(func(mgr *Manager) provider {
-		return gcp.NewManager(mgr.ctx, mgr.runtime, mgr)
+		return gcp.NewManager(mgr.ctxs, mgr.runtime, mgr)
 	})
 }

--- a/runtime/pubsub/provider_nsq.go
+++ b/runtime/pubsub/provider_nsq.go
@@ -8,6 +8,6 @@ import (
 
 func init() {
 	registerProvider(func(mgr *Manager) provider {
-		return nsq.NewManager(mgr.ctx, mgr.rt)
+		return nsq.NewManager(mgr.ctxs, mgr.rt)
 	})
 }

--- a/runtime/pubsub/topic.go
+++ b/runtime/pubsub/topic.go
@@ -103,6 +103,10 @@ func (t *Topic[T]) Meta() TopicMeta {
 // If an error is returned, it is probable that the message failed to be published, however it is possible
 // that the message could still be received by subscriptions to the topic.
 func (t *Topic[T]) Publish(ctx context.Context, msg T) (id string, err error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+
 	if t.runtimeCfg == nil || t.topic == nil {
 		return "", errs.B().Code(errs.Unimplemented).Msg("pubsub topic was not created using pubsub.NewTopic").Err()
 	}

--- a/runtime/storage/cache/pkgfn.go
+++ b/runtime/storage/cache/pkgfn.go
@@ -2,16 +2,6 @@
 
 package cache
 
-import (
-	"encore.dev/appruntime/shared/appconf"
-	"encore.dev/appruntime/shared/jsonapi"
-	"encore.dev/appruntime/shared/reqtrack"
-	"encore.dev/appruntime/shared/testsupport"
-)
-
-//publicapigen:drop
-var Singleton = NewManager(appconf.Static, appconf.Runtime, reqtrack.Singleton, testsupport.Singleton, jsonapi.Default)
-
 // NewCluster declares a new cache cluster.
 //
 // See https://encore.dev/docs/develop/caching for more information.

--- a/runtime/storage/cache/zzz_singleton_internal.go
+++ b/runtime/storage/cache/zzz_singleton_internal.go
@@ -1,11 +1,10 @@
 //go:build encore_app
 
-package pubsub
+package cache
 
 import (
 	"encore.dev/appruntime/shared/appconf"
 	"encore.dev/appruntime/shared/jsonapi"
-	"encore.dev/appruntime/shared/logging"
 	"encore.dev/appruntime/shared/reqtrack"
 	"encore.dev/appruntime/shared/shutdown"
 	"encore.dev/appruntime/shared/testsupport"
@@ -20,10 +19,6 @@ import (
 var Singleton *Manager
 
 func init() {
-	Singleton = NewManager(
-		appconf.Static, appconf.Runtime, reqtrack.Singleton, testsupport.Singleton,
-		logging.RootLogger, jsonapi.Default,
-	)
+	Singleton = NewManager(appconf.Static, appconf.Runtime, reqtrack.Singleton, testsupport.Singleton, jsonapi.Default)
 	shutdown.Singleton.OnShutdown(Singleton.Shutdown)
-	shutdown.Singleton.RegisterHandlerHook(Singleton.StopHandlers)
 }

--- a/runtime/storage/sqldb/pkgfn.go
+++ b/runtime/storage/sqldb/pkgfn.go
@@ -4,10 +4,6 @@ package sqldb
 
 import (
 	"context"
-
-	"encore.dev/appruntime/shared/appconf"
-	"encore.dev/appruntime/shared/reqtrack"
-	"encore.dev/appruntime/shared/testsupport"
 )
 
 // NewDatabase declares a new SQL database.
@@ -120,9 +116,6 @@ type constStr string
 func Named(name constStr) *Database {
 	return Singleton.GetDB(string(name))
 }
-
-//publicapigen:drop
-var Singleton = NewManager(appconf.Runtime, reqtrack.Singleton, testsupport.Singleton)
 
 func getCurrentDB() *Database {
 	return Singleton.GetCurrentDB()

--- a/runtime/storage/sqldb/zzz_singleton_internal.go
+++ b/runtime/storage/sqldb/zzz_singleton_internal.go
@@ -1,11 +1,9 @@
 //go:build encore_app
 
-package pubsub
+package sqldb
 
 import (
 	"encore.dev/appruntime/shared/appconf"
-	"encore.dev/appruntime/shared/jsonapi"
-	"encore.dev/appruntime/shared/logging"
 	"encore.dev/appruntime/shared/reqtrack"
 	"encore.dev/appruntime/shared/shutdown"
 	"encore.dev/appruntime/shared/testsupport"
@@ -20,10 +18,6 @@ import (
 var Singleton *Manager
 
 func init() {
-	Singleton = NewManager(
-		appconf.Static, appconf.Runtime, reqtrack.Singleton, testsupport.Singleton,
-		logging.RootLogger, jsonapi.Default,
-	)
+	Singleton = NewManager(appconf.Runtime, reqtrack.Singleton, testsupport.Singleton)
 	shutdown.Singleton.OnShutdown(Singleton.Shutdown)
-	shutdown.Singleton.RegisterHandlerHook(Singleton.StopHandlers)
 }


### PR DESCRIPTION
On AWS Fargate we've encountered cases where a `SIGTERM` was sent to the container, however Fargate never actually killed the process.

This refactor updates our `Shutdown` module such that after the Graceful time window has expired, the process will exit with an exit code of 1. However if all the shutdown hooks return within the graceful time window, then we will exit the process with an exit code of 0.

This redesign has introduced a new config type deprecating the old `ShutdownTimeout` config, allowing us to specify how long each part of the process has.

It has rewritten the PubSub system to now have three different contexts which get cancelled at different points, so that no new events should be fetched during a shutdown - but handlers will be given time to complete, and the connection context will remain up for the longest to ack or nack those events already inflight.

The HTTP server has had a base context introduced, which allows us to now cancel the context of running handlers - where as before the HTTP server would stop accepting new requests, but wouldn't signal already active handlers they needed to stop.

Finally I noticed a lot of Encore's own `Shutdown` methods where not wired into the shutdown module, so I fixed this while I was there.