### PR TITLE
pubsub: remove init-time subscription sanity checks

### DIFF
--- a/runtime/pubsub/internal/aws/topic.go
+++ b/runtime/pubsub/internal/aws/topic.go
@@ -71,22 +71,6 @@ func (t *topic) PublishMessage(ctx context.Context, orderingKey string, attrs ma
 }
 
 func (t *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadline time.Duration, retryPolicy *types.RetryPolicy, implCfg *config.PubsubSubscription, f types.RawSubscriptionCallback) {
-	// Double-check that the subscription exists at initialization
-	// to guard against configuration issues.
-	{
-		// Use a separate context to check if the subscription exists,
-		// since this is happening during initialization, and causes a race
-		// with as the underlying infrastructure tries to determine if the new revision is healthy.
-		existsCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_, err := t.sqsClient.GetQueueAttributes(existsCtx, &sqs.GetQueueAttributesInput{
-			QueueUrl: aws.String(implCfg.ProviderName),
-		})
-		if err != nil {
-			panic(fmt.Sprintf("unable to verify SQS queue attributes (may be missing IAM role allowing access): %v", err))
-		}
-	}
-
 	ackDeadline = utils.Clamp(ackDeadline, time.Second, 12*time.Hour)
 
 	if maxConcurrency == 0 {

--- a/runtime/pubsub/internal/gcp/topic.go
+++ b/runtime/pubsub/internal/gcp/topic.go
@@ -100,23 +100,6 @@ func (t *topic) Subscribe(logger *zerolog.Logger, maxConcurrency int, ackDeadlin
 		subscription.ReceiveSettings.MaxOutstandingMessages = maxConcurrency
 		subscription.ReceiveSettings.NumGoroutines = utils.Clamp(maxConcurrency, 1, maxConcurrency)
 
-		// Double-check that the subscription exists at initialization
-		// to guard against configuration issues.
-		{
-			// Use a separate context to check if the subscription exists,
-			// since this is happening during initialization, and causes a race
-			// with Cloud Run as it tries to determine if the new revision is healthy.
-			existsCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			exists, err := subscription.Exists(existsCtx)
-			if err != nil {
-				panic(fmt.Sprintf("pubsub subscription %s for topic %s status call failed: %s", subCfg.EncoreName, t.topicCfg.EncoreName, err))
-			}
-			if !exists {
-				panic(fmt.Sprintf("pubsub subscription %s for topic %s does not exist in GCP", subCfg.EncoreName, t.topicCfg.EncoreName))
-			}
-		}
-
 		// Start the subscription
 		go func() {
 			for t.mgr.ctxs.Fetch.Err() == nil {


### PR DESCRIPTION
It's causing issues with Cloud Run due to how it interacts with graceful shutdown when Cloud Run attempts to
verify if the new revision is healthy.