### PR TITLE
schema: parse 'any' into empty interface

### DIFF
--- a/v2/app/testdata/rpc_err_any.txt
+++ b/v2/app/testdata/rpc_err_any.txt
@@ -1,0 +1,38 @@
+! parse
+
+-- svc/svc.go --
+package svc
+
+import (
+	"context"
+)
+
+type Params struct {
+    Foo any
+}
+
+//encore:api public
+func Any(ctx context.Context, p *Params) error { return nil }
+-- want: errors --
+
+── Invalid API schema ─────────────────────────────────────────────────────────────────────[E9999]──
+
+Interfaces are not supported in API schemas.
+
+    ╭─[ svc/svc.go:8:9 ]
+    │
+  6 │
+  7 │ type Params struct {
+  8 │     Foo any
+    ⋮         ─┬─
+    ⋮          ╰─ defined here
+    ·
+    ·
+ 10 │
+ 11 │ //encore:api public
+ 12 │ func Any(ctx context.Context, p *Params) error { return nil }
+    ⋮                                 ───┬───
+    ⋮                                    ╰─ used here
+────╯
+
+For more information on API schemas, see https://encore.dev/docs/develop/api-schemas

--- a/v2/internals/schema/schema_parser.go
+++ b/v2/internals/schema/schema_parser.go
@@ -112,6 +112,21 @@ func (r *typeResolver) parseType(file *pkginfo.File, expr ast.Expr) Type {
 				}
 			}
 
+			switch expr.Name {
+			case "any":
+				return InterfaceType{
+					AST: &ast.InterfaceType{
+						// HACK: Set dummy positions to make the error messages nicer,
+						// pointing at "any" instead of reporting no position whatsoever.
+						Interface: expr.Pos(),
+						Methods: &ast.FieldList{
+							Opening: expr.Pos(),
+							Closing: expr.End() - 1,
+						},
+					},
+				}
+			}
+
 			r.errs.Addf(expr.Pos(), "undefined type: %s", expr.Name)
 
 		case *ast.SelectorExpr:


### PR DESCRIPTION
We weren't handling `any` well as we generally don't support interfaces.
This led to confusing error messages for new users. Fix this.
