### PR TITLE
Allow databases in tests outside services

### DIFF
--- a/v2/app/testdata/sqldb_outside_svc_test.txt
+++ b/v2/app/testdata/sqldb_outside_svc_test.txt
@@ -1,0 +1,20 @@
+ parse
+
+-- svc/migrations/1_dummy.up.sql --
+-- svc/svc.go --
+package svc
+
+import "context"
+
+//encore:api
+func Foo(ctx context.Context) error { return nil }
+-- pkg/pkg_test.go --
+package pkg
+
+import (
+    "context"
+
+    "encore.dev/storage/sqldb"
+)
+
+var Moo = sqldb.Named("svc")

--- a/v2/app/validate_databases.go
+++ b/v2/app/validate_databases.go
@@ -24,10 +24,12 @@ func (d *Desc) validateDatabases(pc *parsectx.Context, result *parser.Result) {
 
 	// Check for usages outside of services
 	for _, db := range dbs {
-		for _, invalidUsage := range d.ResourceUsageOutsideServices[db] {
-			pc.Errs.Add(
-				errResourceUsedOutsideService.AtGoNode(invalidUsage, errors.AsError("used here")),
-			)
+		for _, u := range d.ResourceUsageOutsideServices[db] {
+			if !u.DeclaredIn().TestFile {
+				pc.Errs.Add(
+					errResourceUsedOutsideService.AtGoNode(u, errors.AsError("used here")),
+				)
+			}
 		}
 	}
 }


### PR DESCRIPTION
To allow for test-only databases to be used.

Thanks Dan Upton for reporting.
