### PR TITLE
cli: bump 'encore gen wrappers timeout'

### DIFF
--- a/cli/cmd/encore/gen.go
+++ b/cli/cmd/encore/gen.go
@@ -117,7 +117,7 @@ which may require the user-facing wrapper code to be manually generated.`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			appRoot, _ := determineAppRoot()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			daemon := setupDaemon(ctx)
 			_, err := daemon.GenWrappers(ctx, &daemonpb.GenWrappersRequest{


### PR DESCRIPTION
We've gotten reports that the command times out.
It's not clear whether it's due to taking a long time to parse
larger projects with a cold cache, or due to a deadlock.

I haven't been able to reproduce the deadlock, so let's start
by bumping the timeout and seeing if that helps.
