### PR TITLE
Support GKE in GCP Cloud Monitoring

### DIFF
--- a/runtime/appruntime/infrasdk/metadata/cloud_run_collector.go
+++ b/runtime/appruntime/infrasdk/metadata/cloud_run_collector.go
@@ -30,15 +30,31 @@ func init() {
 			}
 			revision = strings.TrimPrefix(revision, service+"-")
 
-			instanceID, err := gcemetadata.InstanceID()
-			if err != nil {
-				return nil, fmt.Errorf("unable to get instance ID: %w", err)
+			instanceID, ok := os.LookupEnv("K_POD")
+			if !ok {
+				// If we don't have a K8s POD name, we're running on Cloud Run and can get the instance ID from the metadata server
+				var err error
+				instanceID, err = gcemetadata.InstanceID()
+				if err != nil {
+					return nil, fmt.Errorf("unable to get instance ID: %w", err)
+				}
+				instanceID = instanceID[len(instanceID)-8:]
+			} else {
+				// If we have a K8s POD name, take the last part of it which is the random pod ID
+				// On GKE, the InstanceID appears to be the Node, so if the multiple replicas are running
+				// on the same InstanceID then we'd have a collision. This is unlikely, but possible -
+				// hence why we use the pod ID instead.
+				idx := strings.LastIndex(instanceID, "-")
+				if idx == -1 {
+					return nil, fmt.Errorf("invalid instance ID '%s'", instanceID)
+				}
+				instanceID = instanceID[idx+1:]
 			}
 
 			return &ContainerMetadata{
 				ServiceID:  service,
 				RevisionID: revision,
-				InstanceID: instanceID[len(instanceID)-8:],
+				InstanceID: instanceID,
 			}, nil
 		},
 	})

--- a/runtime/appruntime/infrasdk/metrics/gcp_cloud_monitoring_exporter.go
+++ b/runtime/appruntime/infrasdk/metrics/gcp_cloud_monitoring_exporter.go
@@ -3,6 +3,9 @@
 package metrics
 
 import (
+	"os"
+	"strings"
+
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/infrasdk/metadata"
 	"encore.dev/appruntime/infrasdk/metrics/gcp"
@@ -22,12 +25,19 @@ func init() {
 			}
 
 			metricsCfg := mgr.runtime.Metrics
+
 			nodeID, ok := metricsCfg.CloudMonitoring.MonitoredResourceLabels["node_id"]
-			if !ok {
-				mgr.rootLogger.Err(err).Msg("unable to initialize metrics exporter: missing node_id")
-				return nil
+			if ok {
+				metricsCfg.CloudMonitoring.MonitoredResourceLabels["node_id"] = nodeID + "-" + containerMetadata.InstanceID
 			}
-			metricsCfg.CloudMonitoring.MonitoredResourceLabels["node_id"] = nodeID + "-" + containerMetadata.InstanceID
+
+			// Replace $ENV: prefix with the actual environment variable value
+			for k, v := range metricsCfg.CloudMonitoring.MonitoredResourceLabels {
+				if strings.HasPrefix(v, "$ENV:") {
+					metricsCfg.CloudMonitoring.MonitoredResourceLabels[k] = os.Getenv(v[5:])
+				}
+			}
+
 			return gcp.New(mgr.static.BundledServices, metricsCfg.CloudMonitoring, containerMetadata, mgr.rootLogger)
 		},
 	})


### PR DESCRIPTION
This commit adds support for us to deploy into GKE and emit metrics as a [K8S container](https://cloud.google.com/monitoring/api/resources#tag_k8s_container)