### PR TITLE
docker: use encoredotdev/postgres image

### DIFF
--- a/cli/daemon/sqldb/docker/docker.go
+++ b/cli/daemon/sqldb/docker/docker.go
@@ -304,7 +304,7 @@ func PullImage(ctx context.Context) error {
 	return cmd.Run()
 }
 
-const Image = "postgres:14-alpine"
+const Image = "encoredotdev/postgres:15"
 
 func isDockerRunning(ctx context.Context) bool {
 	err := exec.CommandContext(ctx, "docker", "info").Run()


### PR DESCRIPTION
This adds support for the popular `vector` and `postgis`
extensions and gives us more flexibility in the future.
