### PR TITLE
cli: fix missing secret warning

### DIFF
--- a/cli/daemon/run/runtime_config.go
+++ b/cli/daemon/run/runtime_config.go
@@ -292,6 +292,16 @@ func (g *RuntimeEnvGenerator) secretsForServices(services []*meta.Service) (stri
 
 	// Shortcut if we want it for all services
 	if len(services) == len(g.Meta.Svcs) {
+
+		// Grab all the missing secrets so we can report them.
+		for _, pkg := range g.Meta.Pkgs {
+			for _, key := range pkg.Secrets {
+				if _, found := g.Secrets[key]; !found {
+					g.missingSecrets[key] = struct{}{}
+				}
+			}
+		}
+
 		return encodeSecretsEnv(g.Secrets), nil
 	}
 


### PR DESCRIPTION
The shortcut when all services are running in the same
process was missing the check for missing secrets.

Thanks Neal Lathia for reporting.
