### PR TITLE
pubsub: fix 'projectID string is empty' panic

### DIFF
--- a/runtime/pubsub/internal/gcp/clients.go
+++ b/runtime/pubsub/internal/gcp/clients.go
@@ -10,7 +10,7 @@ import (
 func (mgr *Manager) getClient() *pubsub.Client {
 	mgr.clientOnce.Do(func() {
 		// Create a new client
-		cl, err := pubsub.NewClient(mgr.ctxs.Connection, "")
+		cl, err := pubsub.NewClient(mgr.ctxs.Connection, "-")
 		if err != nil {
 			panic(fmt.Sprintf("failed to create pubsub client: %s", err))
 		}


### PR DESCRIPTION
Newer versions of the `cloud.google.com/go/pubsub` package
no longer permit creating a client without specifying a project id.

Since we don't use the default project id but always use `TopicInProject`
and `SubscriptionInProject`, work around this by specifying a placeholder
project id.
