### PR TITLE
cli: support '--example=empty' to create empty app

### DIFF
--- a/cli/cmd/encore/app/create.go
+++ b/cli/cmd/encore/app/create.go
@@ -66,6 +66,11 @@ func createApp(ctx context.Context, name, template string) (err error) {
 	if name == "" || template == "" {
 		name, template = selectTemplate(name, template)
 	}
+	// Treat the special name "empty" as the empty app template
+	// (the rest of the code assumes that's the empty string).
+	if template == "empty" {
+		template = ""
+	}
 
 	if err := validateName(name); err != nil {
 		return err


### PR DESCRIPTION
To support scripting without the interactive template picker,
add `--example=empty` as a way to create an empty app.

Thanks Ismoil Hasanov for the suggestion.