### PR TITLE
v2/app: allow dbs to be defined outside svcs

### DIFF
--- a/v2/app/testdata/sqldb_outside_svc.txt
+++ b/v2/app/testdata/sqldb_outside_svc.txt
@@ -1,5 +1,4 @@
-! parse
-err 'cannot define SQL Database resource in non-service package'
+parse
 
 -- svc/migrations/1_dummy.up.sql --
 -- svc/svc.go --
@@ -19,9 +18,3 @@ import (
 )
 
 var Moo = sqldb.Named("svc")
-
--- want: errors --
-
-── Resource defined outside of service ────────────────────────────────────────────────────[E9999]──
-
-Resources can only be defined within a service.

--- a/v2/app/validate.go
+++ b/v2/app/validate.go
@@ -9,6 +9,7 @@ import (
 	"encr.dev/v2/parser/apis/middleware"
 	"encr.dev/v2/parser/infra/pubsub"
 	"encr.dev/v2/parser/infra/secrets"
+	"encr.dev/v2/parser/infra/sqldb"
 )
 
 // validate checks that the application is in a valid state across all services and compilation units.
@@ -45,6 +46,9 @@ func (d *Desc) validate(pc *parsectx.Context, result *parser.Result) {
 			continue
 		case *secrets.Secrets:
 			// Secrets are allowed anywhere
+			continue
+		case *sqldb.Database:
+			// Databases are allowed anywhere
 			continue
 
 		default:


### PR DESCRIPTION
Since we now accurately track database usages, we can
relax where they are defined. They can still only be *used*
from within services, to ensure permissions are mapped correctly.