### PR TITLE
docker: fix permission issue

### DIFF
--- a/cli/daemon/sqldb/docker/docker.go
+++ b/cli/daemon/sqldb/docker/docker.go
@@ -124,17 +124,19 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 			"-d",
 			"-p", "5432",
 			"--shm-size=1gb",
+			"--user", "root",
 			"-e", "POSTGRES_USER=" + DefaultSuperuserUsername,
 			"-e", "POSTGRES_PASSWORD=" + DefaultSuperuserPassword,
 			"-e", "POSTGRES_DB=" + DefaultRootDatabase,
 			"-e", "PGDATA=" + defaultDataDir,
+			"-e", "BITNAMI_DEBUG=true",
 			"--name", cnames[0],
 		}
 		if p.Memfs {
 			args = append(args,
-				"--mount", "type=tmpfs,destination=/var/lib/postgresql/data",
+				"--mount", "type=tmpfs,destination="+defaultDataDir+",tmpfs-mode=1777",
+				"-e", "POSTGRESQL_FSYNC=off",
 				Image,
-				"-c", "fsync=off",
 			)
 		} else {
 			clusterDataDir, err := ClusterDataDir(cid)


### PR DESCRIPTION
The new encoredotdev/postgres:15 image must be run with root
in order to be able to change the filesystem permissions of the
mounted volume during startup.
