### PR TITLE
cli: refactor sqldb ns to use docker volumes

### DIFF
--- a/cli/cmd/encore/cmdutil/output.go
+++ b/cli/cmd/encore/cmdutil/output.go
@@ -1,0 +1,65 @@
+package cmdutil
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"golang.org/x/exp/slices"
+)
+
+type Output struct {
+	Value   string
+	Allowed []string
+}
+
+func (o *Output) AddFlag(s *pflag.FlagSet) {
+	s.VarP(o, "output", "o", o.Usage())
+}
+
+func (o *Output) String() string {
+	return o.Value
+}
+
+func (o *Output) Type() string {
+	return "output"
+}
+
+func (o *Output) Set(v string) error {
+	if slices.Contains(o.Allowed, v) {
+		o.Value = v
+		return nil
+	}
+
+	var b strings.Builder
+	b.WriteString("must be one of ")
+	o.oneOf(&b)
+	return errors.New(b.String())
+}
+
+func (o *Output) Usage() string {
+	var b strings.Builder
+	b.WriteString("Output format. One of (")
+	o.oneOf(&b)
+	b.WriteString(").")
+	return b.String()
+}
+
+func (o *Output) oneOf(b *strings.Builder) {
+	n := len(o.Allowed)
+	for i, s := range o.Allowed {
+		if i > 0 {
+			switch {
+			case n == 2:
+				b.WriteString(" or ")
+			case i == n-1:
+				b.WriteString(", or ")
+			default:
+				b.WriteString(", ")
+			}
+		}
+
+		b.WriteString(strconv.Quote(s))
+	}
+}

--- a/cli/daemon/db.go
+++ b/cli/daemon/db.go
@@ -98,10 +98,10 @@ func (s *Server) dbConnectLocal(ctx context.Context, req *daemonpb.DBConnectRequ
 	}
 
 	clusterType := sqldb.Run
-	passwd := "local-" + string(clusterNS.Name)
+	passwd := "local-" + string(clusterNS.ID)
 	if req.Test {
 		clusterType = sqldb.Test
-		passwd = "test-" + string(clusterNS.Name)
+		passwd = "test-" + string(clusterNS.ID)
 	}
 
 	clusterID := sqldb.GetClusterID(app, clusterType, clusterNS)

--- a/cli/daemon/namespace/namespace.go
+++ b/cli/daemon/namespace/namespace.go
@@ -187,6 +187,7 @@ func (m *Manager) Delete(ctx context.Context, app *apps.Instance, name Name) err
 	if ns.Active {
 		return ErrActive
 	}
+	ns.App = app
 
 	// Check all the deletion handlers.
 	for _, h := range m.handlers {
@@ -282,6 +283,7 @@ func (m *Manager) GetActive(ctx context.Context, app *apps.Instance) (*Namespace
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	} else if err == nil {
+		ns.App = app
 		return &ns, nil
 	}
 

--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -205,12 +205,12 @@ func (c *Cluster) initDBs(md *meta.Data, reinit bool) {
 func (c *Cluster) initDB(encoreName string) *DB {
 	driverName := encoreName
 	if !c.driver.Meta().ClusterIsolation {
-		driverName += fmt.Sprintf("-%s-%s", c.ID.App.PlatformOrLocalID(), c.ID.Type)
+		driverName += fmt.Sprintf("-%s-%s", c.ID.NS.App.PlatformOrLocalID(), c.ID.Type)
 
 		// Add the namespace id, as long as it's not the default namespace
 		// (for backwards compatibility).
-		if c.ID.NSName != "default" {
-			driverName += "-" + string(c.ID.NSID)
+		if c.ID.NS.Name != "default" {
+			driverName += "-" + string(c.ID.NS.ID)
 		}
 	}
 

--- a/cli/daemon/sqldb/driver.go
+++ b/cli/daemon/sqldb/driver.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"encr.dev/cli/daemon/namespace"
 	"encr.dev/internal/optracker"
 )
 
@@ -25,6 +26,10 @@ type Driver interface {
 	// DestroyCluster destroys a cluster with the given id.
 	// If a Driver doesn't support destroying the cluster it reports ErrUnsupported.
 	DestroyCluster(ctx context.Context, id ClusterID) error
+
+	// DestroyNamespaceData destroys the data associated with a namespace.
+	// If a Driver doesn't support destroying data it reports ErrUnsupported.
+	DestroyNamespaceData(ctx context.Context, ns *namespace.Namespace) error
 
 	// ClusterStatus reports the current status of a cluster.
 	ClusterStatus(ctx context.Context, id ClusterID) (*ClusterStatus, error)

--- a/cli/daemon/sqldb/external/external.go
+++ b/cli/daemon/sqldb/external/external.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"encr.dev/cli/daemon/namespace"
 	"encr.dev/cli/daemon/sqldb"
 )
 
@@ -44,6 +45,10 @@ func (d *Driver) CanDestroyCluster(ctx context.Context, id sqldb.ClusterID) erro
 }
 
 func (d *Driver) DestroyCluster(ctx context.Context, id sqldb.ClusterID) error {
+	return sqldb.ErrUnsupported
+}
+
+func (d *Driver) DestroyNamespaceData(ctx context.Context, ns *namespace.Namespace) error {
 	return sqldb.ErrUnsupported
 }
 

--- a/cli/daemon/sqldb/proxy.go
+++ b/cli/daemon/sqldb/proxy.go
@@ -97,14 +97,14 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 
 		ctx := context.Background()
 
-		clusterType, nsName, ok := strings.Cut(startup.Password, "-")
+		clusterType, nsID, ok := strings.Cut(startup.Password, "-")
 
 		// Look up the namespace to use.
 		var ns *namespace.Namespace
 		if !ok {
 			ns, err = cm.ns.GetActive(ctx, app)
 		} else {
-			ns, err = cm.ns.GetByName(ctx, app, namespace.Name(nsName))
+			ns, err = cm.ns.GetByID(ctx, app, namespace.ID(nsID))
 		}
 		if err != nil {
 			cm.log.Error().Err(err).Msg("dbproxy: could not find infra namespace")


### PR DESCRIPTION
We've observed permission-related issues when using `colima`
with volume mounts. See if it works better with docker volumes.

Also add output options to `encore ns list` to make CLI tooling easier.