### PR TITLE
miscellaneous fixes

### DIFF
--- a/.devcontainer/scripts/godeps.sh
+++ b/.devcontainer/scripts/godeps.sh
@@ -8,7 +8,7 @@ go install github.com/fatih/gomodifytags@latest
 go install github.com/josharian/impl@latest
 go install github.com/haya14busa/goplay/cmd/goplay@latest
 go install github.com/go-delve/delve/cmd/dlv@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install honnef.co/go/tools/cmd/staticcheck@master
 go install golang.org/x/tools/gopls@latest
 
 GOBIN=/tmp/ go install github.com/go-delve/delve/cmd/dlv@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Install ci tools
         run:  |
-              go install honnef.co/go/tools/cmd/staticcheck@latest
+              go install honnef.co/go/tools/cmd/staticcheck@master
               go install github.com/kisielk/errcheck@latest
               go install github.com/gordonklaus/ineffassign@latest
 

--- a/cli/daemon/redis/redis.go
+++ b/cli/daemon/redis/redis.go
@@ -16,6 +16,7 @@ type Server struct {
 	mini      *miniredis.Miniredis
 	cleanup   *time.Ticker
 	quit      chan struct{}
+	addr      string
 }
 
 const tickInterval = 1 * time.Second
@@ -32,6 +33,7 @@ func (s *Server) Start() error {
 		if err := s.mini.Start(); err != nil {
 			return errors.Wrap(err, "failed to start redis server")
 		}
+		s.addr = s.mini.Addr()
 		s.cleanup = time.NewTicker(tickInterval)
 		go s.doCleanup()
 		return nil
@@ -52,8 +54,7 @@ func (s *Server) Addr() string {
 	if err := s.Start(); err != nil {
 		panic(err)
 	}
-
-	return s.mini.Addr()
+	return s.addr
 }
 
 func (s *Server) doCleanup() {
@@ -81,10 +82,10 @@ func (s *Server) doCleanup() {
 // down to 100 persisted keys, as a simple way to bound
 // the max memory usage.
 func (s *Server) clearKeys() {
-	const max = 100
+	const maxKeys = 100
 	keys := s.mini.Keys()
-	if n := len(keys); n > max {
-		toDelete := n - max
+	if n := len(keys); n > maxKeys {
+		toDelete := n - maxKeys
 		deleted := 0
 		for deleted < toDelete {
 			id := rand.Intn(len(keys))

--- a/cli/daemon/redis/redis.go
+++ b/cli/daemon/redis/redis.go
@@ -1,7 +1,7 @@
 package redis
 
 import (
-	"math/rand"
+	mathrand "math/rand" // nosemgrep
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
@@ -88,7 +88,7 @@ func (s *Server) clearKeys() {
 		toDelete := n - maxKeys
 		deleted := 0
 		for deleted < toDelete {
-			id := rand.Intn(len(keys))
+			id := mathrand.Intn(len(keys))
 			if keys[id] != "" {
 				s.mini.Del(keys[id])
 				keys[id] = "" // mark it as deleted


### PR DESCRIPTION
## svcproxy: fix mutex handling
The svcproxy held a read lock for the duration of serving a request,
which was problematic when doing live reloads with long-running requests
like WebSockets.

Fix this by resolving the proxy with the mutex and then
forwarding the request without holding the lock.

## redis: fix panic
We were calling `.Addr()` on the miniredis server, but it turns out that panics
if calling it after `.Close()` has been called. Fix this by caching the address in
`Start` and looking it up afterwards.
