### PR TITLE
Use persistent work dirs

### DIFF
--- a/.devcontainer/scripts/godeps.sh
+++ b/.devcontainer/scripts/godeps.sh
@@ -8,7 +8,7 @@ go install github.com/fatih/gomodifytags@latest
 go install github.com/josharian/impl@latest
 go install github.com/haya14busa/goplay/cmd/goplay@latest
 go install github.com/go-delve/delve/cmd/dlv@latest
-go install honnef.co/go/tools/cmd/staticcheck@latest
+go install honnef.co/go/tools/cmd/staticcheck@master
 go install golang.org/x/tools/gopls@latest
 
 GOBIN=/tmp/ go install github.com/go-delve/delve/cmd/dlv@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Install ci tools
         run:  |
-              go install honnef.co/go/tools/cmd/staticcheck@latest
+              go install honnef.co/go/tools/cmd/staticcheck@master
               go install github.com/kisielk/errcheck@latest
               go install github.com/gordonklaus/ineffassign@latest
 

--- a/cli/daemon/export/export.go
+++ b/cli/daemon/export/export.go
@@ -87,9 +87,6 @@ func Docker(ctx context.Context, app *apps.Instance, req *daemonpb.ExportRequest
 		},
 	})
 
-	if result != nil && result.Dir != "" {
-		defer os.RemoveAll(result.Dir)
-	}
 	if err != nil {
 		log.Info().Err(err).Msg("compilation failed")
 		return false, errors.Wrap(err, "compilation failed")

--- a/cli/daemon/run/check.go
+++ b/cli/daemon/run/check.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"context"
-	"os"
 	"runtime"
 
 	"encr.dev/cli/daemon/apps"
@@ -82,13 +81,8 @@ func (mgr *Manager) Check(ctx context.Context, p CheckParams) (buildDir string, 
 		},
 	})
 
-	if result != nil && result.Dir != "" {
-		if p.CodegenDebug {
-			buildDir = result.Dir
-		} else {
-			_ = os.RemoveAll(result.Dir)
-		}
+	if result != nil {
+		buildDir = result.Dir
 	}
-
 	return buildDir, err
 }

--- a/cli/daemon/run/exec_script.go
+++ b/cli/daemon/run/exec_script.go
@@ -139,11 +139,6 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 		}
 		return nil
 	})
-	defer func() {
-		if build != nil {
-			os.RemoveAll(build.Dir)
-		}
-	}()
 
 	if err := jobs.Wait(); err != nil {
 		return err

--- a/v2/compiler/build/build.go
+++ b/v2/compiler/build/build.go
@@ -78,34 +78,26 @@ type builder struct {
 	// overlays are the additional overlay files to apply.
 	overlays []overlay.File
 
-	// workdir is the temporary workdir for the build.
 	workdir paths.FS
+	// deleteWorkDir reports whether the workdir should be deleted.
+	// It's true for temporarily generated workdirs.
+	tempWorkDir bool
 }
 
 func (b *builder) Build() *Result {
-	workdir, err := os.MkdirTemp("", "encore-build")
-	if err != nil {
-		b.errs.AddStd(err)
-	}
+	workdir, tempWorkDir := b.prepareWorkDir()
+	b.workdir = workdir
 
-	// NOTE(andre): There appears to be a bug in go's handling of overlays
-	// when the source or destination is a symlink.
-	// I haven't dug into the root cause exactly, but it causes weird issues
-	// with tests since macOS's /var/tmp is a symlink to /private/var/tmp.
-	if d, err := filepath.EvalSymlinks(workdir); err == nil {
-		workdir = d
-	}
-
-	b.workdir = paths.RootedFSPath(workdir, ".")
-
-	defer func() {
-		// If we have a bailout or any errors, delete the workdir.
-		if _, ok := perr.CatchBailout(recover()); ok || b.errs.Len() > 0 {
-			if !b.cfg.KeepOutput && workdir != "" {
-				_ = os.RemoveAll(workdir)
+	if tempWorkDir {
+		defer func() {
+			// If we have a bailout or any errors, delete the workdir.
+			if _, ok := perr.CatchBailout(recover()); ok || b.errs.Len() > 0 {
+				if !b.cfg.KeepOutput && workdir != "" {
+					_ = os.RemoveAll(workdir.ToIO())
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	res := &Result{
 		Dir: b.workdir,
@@ -421,4 +413,38 @@ func isGo118Plus(f *modfile.File) bool {
 	major, _ := strconv.Atoi(m[1])
 	minor, _ := strconv.Atoi(m[2])
 	return major > 1 || (major == 1 && minor >= 18)
+}
+
+func (b *builder) prepareWorkDir() (workdir paths.FS, temporary bool) {
+	work, isTemp := (func() (string, bool) {
+		// If we have an appID, use a persistent work dir.
+		if appID, ok := b.cfg.Ctx.AppID.Get(); ok {
+			baseDir, err := os.UserCacheDir()
+			if err != nil {
+				b.errs.Fatalf(token.NoPos, "unable to get user cache dir: %v", err)
+			}
+			workdir := filepath.Join(baseDir, "encore-build", appID)
+			return workdir, false
+		}
+
+		tmp, err := os.MkdirTemp("", "encore-build")
+		if err != nil {
+			b.errs.Fatalf(token.NoPos, "unable to create workdir: %v", err)
+		}
+		return tmp, true
+	})()
+
+	// NOTE(andre): There appears to be a bug in go's handling of overlays
+	// when the source or destination is a symlink.
+	// I haven't dug into the root cause exactly, but it causes weird issues
+	// with tests since macOS's /var/tmp is a symlink to /private/var/tmp.
+	if d, err := filepath.EvalSymlinks(work); err == nil {
+		work = d
+	}
+
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		b.errs.Fatalf(token.NoPos, "unable to create workdir: %v", err)
+	}
+
+	return paths.RootedFSPath(work, "."), isTemp
 }

--- a/v2/internals/parsectx/pctx.go
+++ b/v2/internals/parsectx/pctx.go
@@ -19,6 +19,10 @@ import (
 
 // Context holds all the context for parsing.
 type Context struct {
+	// AppID is a unique id of the application, used for workdir caching.
+	// If left empty, a random workdir is used.
+	AppID option.Option[string]
+
 	// Ctx provides cancellation.
 	Ctx context.Context
 

--- a/v2/v2builder/v2builder.go
+++ b/v2/v2builder/v2builder.go
@@ -46,11 +46,12 @@ func (BuilderImpl) Parse(ctx context.Context, p builder.ParseParams) (*builder.P
 		defer func() {
 			err, _ = perr.CatchBailoutAndPanic(err, recover())
 		}()
-		fs := token.NewFileSet()
-		errs := perr.NewList(ctx, fs)
+		fset := token.NewFileSet()
+		errs := perr.NewList(ctx, fset)
 		pc := &parsectx.Context{
-			Ctx: ctx,
-			Log: p.Build.Logger.GetOrElse(zerolog.New(zerolog.NewConsoleWriter())).Level(zerolog.InfoLevel),
+			AppID: option.Some(p.App.PlatformOrLocalID()),
+			Ctx:   ctx,
+			Log:   p.Build.Logger.GetOrElse(zerolog.New(zerolog.NewConsoleWriter())).Level(zerolog.InfoLevel),
 			Build: parsectx.BuildInfo{
 				Experiments: p.Experiments,
 				// We use GetOrElseF here because GoRoot / Runtime path will panic
@@ -74,7 +75,7 @@ func (BuilderImpl) Parse(ctx context.Context, p builder.ParseParams) (*builder.P
 				MainPkg:            p.Build.MainPkg,
 			},
 			MainModuleDir: paths.RootedFSPath(p.App.Root(), "."),
-			FS:            fs,
+			FS:            fset,
 			ParseTests:    p.ParseTests,
 			Errs:          errs,
 		}


### PR DESCRIPTION
It turns out the `go` tool's build cache derives its cache keys
from the physical location of files when using overlays.

As a result, since Encore created temporary work dirs for those files, any packages that Encore generated code for were not cached.

Fix this by using a persistent work directory, keyed by the app id.

The end result is live reloads are dramatically faster, and if nothing
changes between builds the application now starts up instantaneously.
