### PR TITLE
[ENC-1669] Fix duplicate COR's origin headers

### DIFF
--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -198,7 +198,7 @@ func (pg *ProcGroup) NewAllInOneProc(params *NewProcParams) error {
 	pg.Gateway = p
 
 	// Generate the environmental variables for the process
-	envs, err := pg.EnvGenerator.ForAllInOne(ports.Gateway.ListenAddr)
+	envs, err := pg.EnvGenerator.ForAllInOne(ports.Gateway.ListenAddr, "localhost", ports.Gateway.ListenAddr.Addr().String())
 	if err != nil {
 		return errors.Wrap(err, "failed to generate environment variables")
 	}

--- a/runtime/appruntime/apisdk/cors/cors_test.go
+++ b/runtime/appruntime/apisdk/cors/cors_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestOptions(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name               string
 		cfg                config.CORS
@@ -204,6 +206,8 @@ func TestOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := Options(&tt.cfg, []string{"X-Static-Test"}, []string{"X-Exposed-Test"})
 			got.Debug = true
 			c := cors.New(got)


### PR DESCRIPTION
Under a multi-process setup when COR's was being handled by the application and the gateway, which caused the `Allow-Origin` to get duplicated after the preflights; this resulted in the browsers rejecting the requests.