### PR TITLE
[ENC-1742] Add `encore kubernetes configure` command

### DIFF
--- a/cli/cmd/encore/k8s/auth.go
+++ b/cli/cmd/encore/k8s/auth.go
@@ -1,0 +1,56 @@
+package k8s
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"encr.dev/cli/cmd/encore/cmdutil"
+	"encr.dev/cli/cmd/encore/k8s/types"
+	"encr.dev/internal/conf"
+)
+
+var genAuthCmd = &cobra.Command{
+	Use:                   "exec-credentials",
+	Short:                 "Used by kubectl to get an authentication token for the Encore Kubernetes Proxy",
+	Args:                  cobra.NoArgs,
+	Hidden:                true,
+	DisableFlagsInUseLine: true,
+	Run:                   func(cmd *cobra.Command, args []string) { generateExecCredentials() },
+}
+
+func init() {
+	kubernetesCmd.AddCommand(genAuthCmd)
+}
+
+// GenerateExecCredentials generates the Kubernetes exec credentials and writes them to stdout.
+//
+// If an error occurs, it is written to stderr and the program exits with a non-zero exit code.
+func generateExecCredentials() {
+	// Get the OAuth token from the Encore API
+	token, err := conf.DefaultTokenSource.Token()
+	if err != nil {
+		cmdutil.Fatalf("error getting token: %v", err)
+	}
+
+	// Generate the kuberentes exec credentials datastructures
+	expiryTime := types.NewTime(token.Expiry)
+	execCredentials := &types.ExecCredential{
+		TypeMeta: types.TypeMeta{
+			APIVersion: "client.authentication.k8s.io/v1",
+			Kind:       "ExecCredential",
+		},
+		Status: &types.ExecCredentialStatus{
+			Token:               token.AccessToken,
+			ExpirationTimestamp: &expiryTime,
+		},
+	}
+
+	// Marshal the exec credentials to JSON and write to stdout
+	output, err := json.MarshalIndent(execCredentials, "", "  ")
+	if err != nil {
+		cmdutil.Fatalf("error marshalling exec credentials: %v", err)
+	}
+	_, _ = os.Stdout.Write(output)
+}

--- a/cli/cmd/encore/k8s/config.go
+++ b/cli/cmd/encore/k8s/config.go
@@ -1,0 +1,278 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"encr.dev/cli/cmd/encore/cmdutil"
+	"encr.dev/cli/cmd/encore/k8s/types"
+	"encr.dev/cli/internal/platform"
+	"encr.dev/internal/conf"
+
+	"sigs.k8s.io/yaml"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "configure --env=ENV_NAME",
+	Short: "Updates your kubectl config to point to the Kubernetes cluster(s) for the specified environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		appSlug := cmdutil.AppSlug()
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
+
+		if k8sEnvName == "" {
+			_ = cmd.Help()
+			cmdutil.Fatal("must specify environment name with --env")
+		}
+
+		err := configureForAppEnv(ctx, appSlug, k8sEnvName)
+		if err != nil {
+			cmdutil.Fatalf("error configuring kubectl: %v", err)
+		}
+	},
+}
+
+var (
+	k8sEnvName string
+)
+
+func init() {
+	configCmd.Flags().StringVarP(&k8sEnvName, "env", "e", "", "Environment name")
+	_ = configCmd.MarkFlagRequired("env")
+	kubernetesCmd.AddCommand(configCmd)
+}
+
+func configureForAppEnv(ctx context.Context, appID string, envName string) error {
+	appSlug, envName, clusters, err := platform.KubernetesClusters(ctx, appID, envName)
+	if err != nil {
+		return errors.Wrap(err, "unable to get Kubernetes clusters for environment")
+	}
+	if len(clusters) == 0 {
+		return errors.New("no Kubernetes clusters found for environment")
+	}
+
+	// Read the existing kubeconfig file
+	configFilePath := filepath.Join(types.HomeDir(), ".kube", "config")
+	cfg, err := readKubeConfig(configFilePath)
+	if err != nil {
+		return err
+	}
+
+	// Add the clusters
+	contextPrefix := fmt.Sprintf("encore_%s_%s", appSlug, envName)
+	authName := "encore-proxy-auth"
+	contextNames := make([]string, len(clusters))
+	for i, cluster := range clusters {
+		// Create a context name for the cluster
+		// by default we use the app slug and env name seperated by a underscore (e.g. encore-myapp_prod)
+		// however if the environment has multiple clusters then we also include the cluster name (e.g. encore-myapp_prod_cluster1)
+		contextName := contextPrefix
+		if len(clusters) > 1 {
+			contextName += "_" + cluster.Name
+		}
+		contextNames[i] = contextName
+
+		// Add the cluster using the cluster name as the context name
+		cfg.clusters = appendOrUpdate(cfg.clusters, map[string]any{
+			"name": contextName,
+			"cluster": map[string]any{
+				"server": fmt.Sprintf("%s/k8s-api-proxy/%s/%s/", conf.APIBaseURL, cluster.EnvID, cluster.ResID),
+			},
+		})
+
+		k8sContext := map[string]any{
+			"cluster": contextName,
+			"user":    authName,
+		}
+		if cluster.DefaultNamespace != "" {
+			k8sContext["namespace"] = cluster.DefaultNamespace
+		}
+
+		cfg.contexts = appendOrUpdate(cfg.contexts, map[string]any{
+			"name":    contextName,
+			"context": k8sContext,
+		})
+	}
+
+	// Remove any old contexts or clusters
+	// We do this by iterating over the existing contexts and clusters and removing any that are not in the new list
+	for i := len(cfg.contexts) - 1; i >= 0; i-- {
+		if foundContext, ok := cfg.contexts[i].(map[string]any); ok {
+			if contextName, ok := foundContext["name"].(string); ok {
+				if strings.HasPrefix(contextName, contextPrefix) && !slices.Contains(contextNames, contextName) {
+					cfg.contexts = append(cfg.contexts[:i], cfg.contexts[i+1:]...)
+				}
+			}
+		}
+	}
+	for i := len(cfg.clusters) - 1; i >= 0; i-- {
+		if foundCluster, ok := cfg.clusters[i].(map[string]any); ok {
+			if clusterName, ok := foundCluster["name"].(string); ok {
+				if strings.HasPrefix(clusterName, contextPrefix) && !slices.Contains(contextNames, clusterName) {
+					cfg.clusters = append(cfg.clusters[:i], cfg.clusters[i+1:]...)
+				}
+			}
+		}
+	}
+
+	// If we added a cluster then we need to update the encore-k8s-proxy user
+	cfg.users = appendOrUpdate(cfg.users, map[string]any{
+		"name": authName,
+		"user": map[string]any{
+			"exec": map[string]any{
+				"apiVersion":         "client.authentication.k8s.io/v1",
+				"args":               []string{"kubernetes", "exec-credentials"},
+				"command":            "encore",
+				"env":                nil,
+				"installHint":        "Install encore for use with kubectl, see https://encore.dev",
+				"interactiveMode":    "Never",
+				"provideClusterInfo": false,
+			},
+		},
+	})
+
+	// Update the current context to the first cluster for the environment
+	cfg.raw["current-context"] = contextNames[0]
+
+	if err := writeKubeConfig(configFilePath, cfg); err != nil {
+		return err
+	}
+
+	if len(clusters) == 1 {
+		_, _ = fmt.Fprintf(os.Stdout, "kubectl configured for cluster %s under context %s.\n", color.CyanString(clusters[0].Name), color.CyanString(contextNames[0]))
+	} else {
+		_, _ = fmt.Fprintf(os.Stdout, "kubectl configured for %d clusters:\n\n", len(clusters))
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.StripEscape)
+		_, _ = fmt.Fprint(w, "CLUSTER\tCONTEXT\tACTIVE\n")
+		for i, cluster := range clusters {
+			active := ""
+			if i == 0 {
+				active = "yes"
+			}
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", cluster.Name, contextNames[0], active)
+		}
+		_ = w.Flush()
+	}
+
+	return nil
+}
+
+// readKubeConfig reads the existing kubeconfig file and returns a Cfg struct.
+// however this is as untyped as possible, so that we can easily marshal it back without losing any data.
+func readKubeConfig(file string) (*Cfg, error) {
+	b, err := os.ReadFile(file)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, errors.Wrap(err, "unable to read kubeconfig file")
+	}
+
+	// Read the existing kubeconfig file
+	var kubeConfig map[string]any
+	if len(b) > 0 {
+		if err = yaml.Unmarshal(b, &kubeConfig); err != nil {
+			return nil, errors.Wrap(err, "unable to parse kubeconfig file")
+		}
+	}
+
+	// Ensure the kubeConfig struct is valid
+	if kubeConfig == nil {
+		kubeConfig = map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Config",
+		}
+	} else if kubeConfig["apiVersion"] != "v1" || kubeConfig["kind"] != "Config" {
+		return nil, errors.New("invalid existing kubeconfig file")
+	}
+	cfg := &Cfg{
+		raw: kubeConfig,
+	}
+
+	if clusters, ok := kubeConfig["clusters"]; ok {
+		if clusters, ok := clusters.([]any); ok {
+			cfg.clusters = clusters
+		} else {
+			return nil, errors.Newf("clusters is not an array got %T", clusters)
+		}
+	}
+
+	if users, ok := kubeConfig["users"]; ok {
+		if users, ok := users.([]any); ok {
+			cfg.users = users
+		} else {
+			return nil, errors.Newf("users is not an array got %T", users)
+		}
+	}
+
+	if contexts, ok := kubeConfig["contexts"]; ok {
+		if contexts, ok := contexts.([]any); ok {
+			cfg.contexts = contexts
+		} else {
+			return nil, errors.Newf("contexts is not an array got %T", contexts)
+		}
+	}
+
+	return cfg, nil
+}
+
+// writeKubeConfig writes the kubeconfig back to the file.
+func writeKubeConfig(file string, cfg *Cfg) error {
+	// Update the raw kubeconfig struct
+	cfg.raw["clusters"] = cfg.clusters
+	cfg.raw["users"] = cfg.users
+	cfg.raw["contexts"] = cfg.contexts
+
+	b, err := yaml.Marshal(cfg.raw)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal kubeconfig back into yaml")
+	}
+
+	// Ensure the directory exists
+	if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
+		return errors.Wrap(err, "unable to create kubeconfig directory")
+	}
+
+	// Then write the file
+	err = os.WriteFile(file, b, 0600)
+	if err != nil {
+		return errors.Wrap(err, "unable to write kubeconfig file")
+	}
+	return nil
+}
+
+type Cfg struct {
+	raw      map[string]any
+	clusters []any
+	users    []any
+	contexts []any
+}
+
+// appendOrUpdate looks at the array for an entry which is a map and has a "name" key which matches the name in val, if found
+// it will update the entry with val, otherwise it will append val to the array.
+func appendOrUpdate(dst []any, val map[string]any) []any {
+	idx := slices.IndexFunc(dst, func(entry any) bool {
+		if entry, ok := entry.(map[string]any); ok {
+			if entry["name"] == val["name"] {
+				return true
+			}
+		}
+		return false
+	})
+
+	if idx == -1 {
+		return append(dst, val)
+	} else {
+		dst[idx] = val
+		return dst
+	}
+}

--- a/cli/cmd/encore/k8s/kubernetes.go
+++ b/cli/cmd/encore/k8s/kubernetes.go
@@ -1,0 +1,17 @@
+package k8s
+
+import (
+	"github.com/spf13/cobra"
+
+	"encr.dev/cli/cmd/encore/root"
+)
+
+var kubernetesCmd = &cobra.Command{
+	Use:     "kubernetes",
+	Short:   "Kubernetes management commands",
+	Aliases: []string{"k8s"},
+}
+
+func init() {
+	root.Cmd.AddCommand(kubernetesCmd)
+}

--- a/cli/cmd/encore/k8s/types/KUBERNETES_LICENSE.txt
+++ b/cli/cmd/encore/k8s/types/KUBERNETES_LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cli/cmd/encore/k8s/types/README.md
+++ b/cli/cmd/encore/k8s/types/README.md
@@ -1,0 +1,4 @@
+# Kubernetes Types
+
+This package contains types copied directly from the [Kubernetes](https://github.com/kubernetes/kubernetes) project, this
+is to prevent the Encore CLI needing to have a dependency on the Kubernetes project for just these types.

--- a/cli/cmd/encore/k8s/types/clientauthentication_types.go
+++ b/cli/cmd/encore/k8s/types/clientauthentication_types.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+// ExecCredential is used by exec-based plugins to communicate credentials to
+// HTTP transports.
+type ExecCredential struct {
+	TypeMeta `json:",inline"`
+
+	// Spec holds information passed to the plugin by the transport.
+	Spec ExecCredentialSpec `json:"spec,omitempty"`
+
+	// Status is filled in by the plugin and holds the credentials that the transport
+	// should use to contact the API.
+	// +optional
+	Status *ExecCredentialStatus `json:"status,omitempty"`
+}
+
+// ExecCredentialSpec holds request and runtime specific information provided by
+// the transport.
+type ExecCredentialSpec struct {
+	// Cluster contains information to allow an exec plugin to communicate with the
+	// kubernetes cluster being authenticated to. Note that Cluster is non-nil only
+	// when provideClusterInfo is set to true in the exec provider config (i.e.,
+	// ExecConfig.ProvideClusterInfo).
+	// +optional
+	Cluster *Cluster `json:"cluster,omitempty"`
+
+	// Interactive declares whether stdin has been passed to this exec plugin.
+	Interactive bool `json:"interactive"`
+}
+
+// ExecCredentialStatus holds credentials for the transport to use.
+//
+// Token and ClientKeyData are sensitive fields. This data should only be
+// transmitted in-memory between client and exec plugin process. Exec plugin
+// itself should at least be protected via file permissions.
+type ExecCredentialStatus struct {
+	// ExpirationTimestamp indicates a time when the provided credentials expire.
+	// +optional
+	ExpirationTimestamp *Time `json:"expirationTimestamp,omitempty"`
+	// Token is a bearer token used by the client for request authentication.
+	Token string `json:"token,omitempty" datapolicy:"token"`
+	// PEM-encoded client TLS certificates (including intermediates, if any).
+	ClientCertificateData string `json:"clientCertificateData,omitempty"`
+	// PEM-encoded private key for the above certificate.
+	ClientKeyData string `json:"clientKeyData,omitempty" datapolicy:"security-key"`
+}
+
+// Cluster contains information to allow an exec plugin to communicate
+// with the kubernetes cluster being authenticated to.
+//
+// To ensure that this struct contains everything someone would need to communicate
+// with a kubernetes cluster (just like they would via a kubeconfig), the fields
+// should shadow "k8s.io/client-go/tools/clientcmd/api/v1".Cluster, with the exception
+// of CertificateAuthority, since CA data will always be passed to the plugin as bytes.
+type Cluster struct {
+	// Server is the address of the kubernetes cluster (https://hostname:port).
+	Server string `json:"server"`
+	// TLSServerName is passed to the server for SNI and is used in the client to
+	// check server certificates against. If ServerName is empty, the hostname
+	// used to contact the server is used.
+	// +optional
+	TLSServerName string `json:"tls-server-name,omitempty"`
+	// InsecureSkipTLSVerify skips the validity check for the server's certificate.
+	// This will make your HTTPS connections insecure.
+	// +optional
+	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty"`
+	// CAData contains PEM-encoded certificate authority certificates.
+	// If empty, system roots should be used.
+	// +listType=atomic
+	// +optional
+	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`
+	// ProxyURL is the URL to the proxy to be used for all requests to this
+	// cluster.
+	// +optional
+	ProxyURL string `json:"proxy-url,omitempty"`
+	// DisableCompression allows client to opt-out of response compression for all requests to the server. This is useful
+	// to speed up requests (specifically lists) when client-server network bandwidth is ample, by saving time on
+	// compression (server-side) and decompression (client-side): https://github.com/kubernetes/kubernetes/issues/112296.
+	// +optional
+	DisableCompression bool `json:"disable-compression,omitempty"`
+	// Config holds additional config data that is specific to the exec
+	// plugin with regards to the cluster being authenticated to.
+	//
+	// This data is sourced from the clientcmd Cluster object's
+	// extensions[client.authentication.k8s.io/exec] field:
+	//
+	// clusters:
+	// - name: my-cluster
+	//   cluster:
+	//     ...
+	//     extensions:
+	//     - name: client.authentication.k8s.io/exec  # reserved extension name for per cluster exec config
+	//       extension:
+	//         audience: 06e3fbd18de8  # arbitrary config
+	//
+	// In some environments, the user config may be exactly the same across many clusters
+	// (i.e. call this exec plugin) minus some details that are specific to each cluster
+	// such as the audience.  This field allows the per cluster config to be directly
+	// specified with the cluster info.  Using this field to store secret data is not
+	// recommended as one of the prime benefits of exec plugins is that no secrets need
+	// to be stored directly in the kubeconfig.
+	// +optional
+	Config RawExtension `json:"config,omitempty"`
+}

--- a/cli/cmd/encore/k8s/types/homedir.go
+++ b/cli/cmd/encore/k8s/types/homedir.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// HomeDir returns the home directory for the current user.
+// On Windows:
+// 1. the first of %HOME%, %HOMEDRIVE%%HOMEPATH%, %USERPROFILE% containing a `.kube\config` file is returned.
+// 2. if none of those locations contain a `.kube\config` file, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists and is writeable is returned.
+// 3. if none of those locations are writeable, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that exists is returned.
+// 4. if none of those locations exists, the first of %HOME%, %USERPROFILE%, %HOMEDRIVE%%HOMEPATH% that is set is returned.
+func HomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOME")
+		homeDriveHomePath := ""
+		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
+			homeDriveHomePath = homeDrive + homePath
+		}
+		userProfile := os.Getenv("USERPROFILE")
+
+		// Return first of %HOME%, %HOMEDRIVE%/%HOMEPATH%, %USERPROFILE% that contains a `.kube\config` file.
+		// %HOMEDRIVE%/%HOMEPATH% is preferred over %USERPROFILE% for backwards-compatibility.
+		for _, p := range []string{home, homeDriveHomePath, userProfile} {
+			if len(p) == 0 {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(p, ".kube", "config")); err != nil {
+				continue
+			}
+			return p
+		}
+
+		firstSetPath := ""
+		firstExistingPath := ""
+
+		// Prefer %USERPROFILE% over %HOMEDRIVE%/%HOMEPATH% for compatibility with other auth-writing tools
+		for _, p := range []string{home, userProfile, homeDriveHomePath} {
+			if len(p) == 0 {
+				continue
+			}
+			if len(firstSetPath) == 0 {
+				// remember the first path that is set
+				firstSetPath = p
+			}
+			info, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			if len(firstExistingPath) == 0 {
+				// remember the first path that exists
+				firstExistingPath = p
+			}
+			if info.IsDir() && info.Mode().Perm()&(1<<(uint(7))) != 0 {
+				// return first path that is writeable
+				return p
+			}
+		}
+
+		// If none are writeable, return first location that exists
+		if len(firstExistingPath) > 0 {
+			return firstExistingPath
+		}
+
+		// If none exist, return first location that is set
+		if len(firstSetPath) > 0 {
+			return firstSetPath
+		}
+
+		// We've got nothing
+		return ""
+	}
+	return os.Getenv("HOME")
+}

--- a/cli/cmd/encore/k8s/types/meta_types.go
+++ b/cli/cmd/encore/k8s/types/meta_types.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// TypeMeta describes an individual object in an API response or request
+// with strings representing the type of the object and its API schema version.
+// Structures that are versioned or persisted should inline TypeMeta.
+//
+// +k8s:deepcopy-gen=false
+type TypeMeta struct {
+	// Kind is a string value representing the REST resource this object represents.
+	// Servers may infer this from the endpoint the client submits requests to.
+	// Cannot be updated.
+	// In CamelCase.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
+
+	// APIVersion defines the versioned schema of this representation of an object.
+	// Servers should convert recognized schemas to the latest internal value, and
+	// may reject unrecognized values.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
+}
+
+// Time is a wrapper around time.Time which supports correct
+// marshaling to YAML and JSON.  Wrappers are provided for many
+// of the factory methods that the time package offers.
+//
+// +protobuf.options.marshal=false
+// +protobuf.as=Timestamp
+// +protobuf.options.(gogoproto.goproto_stringer)=false
+type Time struct {
+	time.Time `protobuf:"-"`
+}
+
+// NewTime returns a wrapped instance of the provided time
+func NewTime(time time.Time) Time {
+	return Time{time}
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (t *Time) UnmarshalJSON(b []byte) error {
+	if len(b) == 4 && string(b) == "null" {
+		t.Time = time.Time{}
+		return nil
+	}
+
+	var str string
+	err := json.Unmarshal(b, &str)
+	if err != nil {
+		return err
+	}
+
+	pt, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return err
+	}
+
+	t.Time = pt.Local()
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t Time) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		// Encode unset/nil objects as JSON's "null".
+		return []byte("null"), nil
+	}
+	buf := make([]byte, 0, len(time.RFC3339)+2)
+	buf = append(buf, '"')
+	// time cannot contain non escapable JSON characters
+	buf = t.UTC().AppendFormat(buf, time.RFC3339)
+	buf = append(buf, '"')
+	return buf, nil
+}

--- a/cli/cmd/encore/k8s/types/runtime_types.go
+++ b/cli/cmd/encore/k8s/types/runtime_types.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package types
+
+// RawExtension is used to hold extensions in external versions.
+//
+// To use this, make a field which has RawExtension as its type in your external, versioned
+// struct, and Object in your internal struct. You also need to register your
+// various plugin types.
+//
+// // Internal package:
+//
+//	type MyAPIObject struct {
+//		runtime.TypeMeta `json:",inline"`
+//		MyPlugin runtime.Object `json:"myPlugin"`
+//	}
+//
+//	type PluginA struct {
+//		AOption string `json:"aOption"`
+//	}
+//
+// // External package:
+//
+//	type MyAPIObject struct {
+//		runtime.TypeMeta `json:",inline"`
+//		MyPlugin runtime.RawExtension `json:"myPlugin"`
+//	}
+//
+//	type PluginA struct {
+//		AOption string `json:"aOption"`
+//	}
+//
+// // On the wire, the JSON will look something like this:
+//
+//	{
+//		"kind":"MyAPIObject",
+//		"apiVersion":"v1",
+//		"myPlugin": {
+//			"kind":"PluginA",
+//			"aOption":"foo",
+//		},
+//	}
+//
+// So what happens? Decode first uses json or yaml to unmarshal the serialized data into
+// your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked.
+// The next step is to copy (using pkg/conversion) into the internal struct. The runtime
+// package's DefaultScheme has conversion functions installed which will unpack the
+// JSON stored in RawExtension, turning it into the correct object type, and storing it
+// in the Object. (TODO: In the case where the object is of an unknown type, a
+// runtime.Unknown object will be created and stored.)
+//
+// +k8s:deepcopy-gen=true
+// +protobuf=true
+// +k8s:openapi-gen=true
+type RawExtension struct {
+	// Raw is the underlying serialization of this object.
+	//
+	// TODO: Determine how to detect ContentType and ContentEncoding of 'Raw' data.
+	Raw []byte `json:"-" protobuf:"bytes,1,opt,name=raw"`
+	// Object can hold a representation of this extension - useful for working with versioned
+	// structs.
+	Object any `json:"-"`
+}

--- a/cli/cmd/encore/main.go
+++ b/cli/cmd/encore/main.go
@@ -22,6 +22,7 @@ import (
 	daemonpb "encr.dev/proto/encore/daemon"
 	// Register commands
 	_ "encr.dev/cli/cmd/encore/app"
+	_ "encr.dev/cli/cmd/encore/k8s"
 	_ "encr.dev/cli/cmd/encore/namespace"
 	_ "encr.dev/cli/cmd/encore/secrets"
 )

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/nsqio/nsq v1.2.1
 	github.com/peterbourgon/diskv v2.0.1+incompatible
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
@@ -63,6 +64,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230803162519-f966b187b2e5
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 require (
@@ -127,7 +129,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc1 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20201118171849-f6a6b3f636fc // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2242,4 +2242,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=


### PR DESCRIPTION
This commit adds a new command to the Encore CLI, which allows Encore to configure your `~/.kube/config` file with all the Kubernetes clusters running in your applications environment.

Once configured, you can use `kubectl` directly from your computer against your Encore provisioned kubernetes clusters, without needing to configure firewalls in your cloud account.

Initially, this command is only available for application owners.
