### PR TITLE
appfile: add build configuration

### DIFF
--- a/docs/deploy/deploying.md
+++ b/docs/deploy/deploying.md
@@ -45,3 +45,36 @@ To configure which branch name is used to trigger deploys, open your app in the 
 
 When you connect your GitHub account and push changes to a pull request, Encore will automatically create a [Preview Environment](/docs/deploy/preview-environments). This is a fully functional, isolated environment where you can test your application as it would run in production. This environment runs in Encore's free development cloud, giving you an efficient way to validate your changes before they are merged and deployed to the primary environment.
 
+## Custom build settings
+
+You can override certain aspects of the CI/CD process in the `encore.app` file:
+
+* The Docker base image to use when deploying
+* Whether to build with Cgo enabled
+* Whether to bundle the source code in the docker image (useful for [Sentry stack traces](https://docs.sentry.io/platforms/go/usage/serverless/))
+
+Below are the available build settings configurable in the `encore.app` file,
+with their default values:
+
+```cue
+{
+    "build": {
+        // Enables cgo when building the application and running tests
+        // in Encore's CI/CD system.
+        "cgo_enabled": false,
+        
+        // Docker-related configuration
+        "docker": {
+        	// The Docker base image to use when deploying the application.
+        	// It must be a publicly accessible image, and defaults to "scratch".
+            "base_image": "scratch",
+            
+            // Whether to bundle the source code in the docker image.
+            // The source code will be copied into /workspace as part
+            // of the build process. This is primarily useful for tools like
+            // Sentry that need access to the source code to generate stack traces.
+            "bundle_source": false
+        }
+    }
+}
+```

--- a/docs/how-to/cgo.md
+++ b/docs/how-to/cgo.md
@@ -9,7 +9,7 @@ with libraries written in other languages using C bindings.
 
 By default, for improved portability Encore builds applications with cgo support disabled.
 
-To enable cgo for your application, add `"cgo_enabled": true` to your `encore.app` file.
+To enable cgo for your application, add `"build": {"cgo_enabled": true}` to your `encore.app` file.
 
 For example:
 
@@ -17,12 +17,14 @@ For example:
 -- encore.app --
 {
   "id": "my-app-id",
-  "cgo_enabled": true
+  "build": {
+    "cgo_enabled": true
+  }
 }
 ```
 
 With this setting Encore's build system will compile the application using an Ubuntu builder image
-with gcc preinstalled.
+with gcc pre-installed.
 
 ## Static linking
 

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -36,12 +36,38 @@ type File struct {
 	// will be applied to all API gateways into the application.
 	GlobalCORS *CORS `json:"global_cors,omitempty"`
 
+	// Build contains build settings for the application.
+	Build Build `json:"build,omitempty"`
+
 	// CgoEnabled enables building with cgo.
+	//
+	// Deprecated: Use build.cgo_enabled instead.
 	CgoEnabled bool `json:"cgo_enabled,omitempty"`
 
 	// DockerBaseImage changes the docker base image used for building the application
 	// in Encore's CI/CD system. If unspecified it defaults to "scratch".
+	//
+	// Deprecated: Use build.docker.base_image instead.
 	DockerBaseImage string `json:"docker_base_image,omitempty"`
+}
+
+type Build struct {
+	// CgoEnabled enables building with cgo.
+	CgoEnabled bool `json:"cgo_enabled,omitempty"`
+
+	// Docker configures the docker images built
+	// by Encore's CI/CD system.
+	Docker Docker `json:"docker,omitempty"`
+}
+
+type Docker struct {
+	// BaseImage changes the docker base image used for building the application
+	// in Encore's CI/CD system. If unspecified it defaults to "scratch".
+	BaseImage string `json:"base_image,omitempty"`
+
+	// BundleSource determines whether the source code of the application
+	// should be bundled into the binary.
+	BundleSource bool `json:"bundle_source,omitempty"`
 }
 
 type CORS struct {
@@ -84,6 +110,13 @@ func Parse(data []byte) (*File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("appfile.Parse: %v", err)
 	}
+
+	// Parse deprecated fields into the new Build struct.
+	f.Build.CgoEnabled = f.Build.CgoEnabled || f.CgoEnabled
+	if f.Build.Docker.BaseImage == "" {
+		f.Build.Docker.BaseImage = f.DockerBaseImage
+	}
+
 	return &f, nil
 }
 


### PR DESCRIPTION
This adds the ability to bundle source code into the built
Docker image, and reorganizes the encore.app file slightly
to group build settings together.