### PR TITLE
Fix windows build

### DIFF
--- a/pkg/make-release/windows/build.bat
+++ b/pkg/make-release/windows/build.bat
@@ -70,7 +70,7 @@ if exist .deps\prepared goto :build
 :copy_artifacts
 	echo [+] Copying files
 	xcopy /S /I /E /H /Q "%ENCORE_GOROOT%" "%DST%\encore-go" || exit /b 1
-	xcopy /S /I /E /H /Q "%ROOT%\runtimes\go" "%DST%\runtime\go" || exit /b 1
+	xcopy /S /I /E /H /Q "%ROOT%\runtimes\go" "%DST%\runtimes\go" || exit /b 1
 	goto :eof
 
 :error


### PR DESCRIPTION
The runtime was being copied into the wrong folder.

Thanks Dhinesh Devanathan for reporting.