### PR TITLE
scrub: fix edge case with nested objects in arrays

### DIFF
--- a/pkg/scrub/scrub.go
+++ b/pkg/scrub/scrub.go
@@ -132,11 +132,15 @@ func (s *stream) processValue(nodes []node) {
 }
 
 func (s *stream) processArray(nodes []node) {
+	s.next() // Move to first array value
 	for {
-		s.next()
-		if s.tok == unknown || s.tok == arrayEnd {
+		if s.tok == unknown {
+			return
+		} else if s.tok == arrayEnd {
+			s.next()
 			return
 		}
+
 		s.processValue(nodes)
 	}
 }
@@ -144,7 +148,10 @@ func (s *stream) processArray(nodes []node) {
 func (s *stream) processObject(nodes []node) {
 	s.next() // Move to the first key
 	for {
-		if s.tok == unknown || s.tok == objectEnd {
+		if s.tok == unknown {
+			return
+		} else if s.tok == objectEnd {
+			s.next()
 			return
 		}
 

--- a/pkg/scrub/scrub_test.go
+++ b/pkg/scrub/scrub_test.go
@@ -240,6 +240,18 @@ func TestJSON(t *testing.T) {
 			},
 			wantOutput: `{"One":["\"one\""]}}`,
 		},
+		{
+			name:  "multiple_array_nested_obj",
+			input: `{"one": [{"two": {"three": "ABC"}}, {"two": {"three": "DEF"}}]}`,
+			paths: []Path{
+				[]PathEntry{
+					{Kind: ObjectField, FieldName: `"one"`, CaseSensitive: true},
+					{Kind: ObjectField, FieldName: `"two"`, CaseSensitive: true},
+					{Kind: ObjectField, FieldName: `"three"`, CaseSensitive: true},
+				},
+			},
+			wantOutput: `{"one": [{"two": {"three": "[sensitive]"}}, {"two": {"three": "[sensitive]"}}]}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In certain conditions the scrubbing would end up getting
out of sync with its position in the stream.

Thanks Dan Upton for reporting.