### PR TITLE
reqtrack: bump trace stream timeout

### DIFF
--- a/runtimes/go/appruntime/shared/reqtrack/reqtrack.go
+++ b/runtimes/go/appruntime/shared/reqtrack/reqtrack.go
@@ -129,7 +129,7 @@ func (t *RequestTracker) sendTrace(tr trace2.Logger) {
 	}
 
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		err := t.platform.SendTrace(ctx, bytes.NewReader(data))
 		if err != nil {


### PR DESCRIPTION
For large traces it's sometimes too low.