### PR TITLE
runtime: support streaming traces

### DIFF
--- a/pkg/traceparser/parser_test.go
+++ b/pkg/traceparser/parser_test.go
@@ -663,9 +663,9 @@ func TestParse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			log := &trace2.Log{}
+			log := trace2.NewLog()
 			tt.Emit(log)
-			data := log.GetAndClear()
+			data, _ := log.GetAndClear()
 			ta := trace2.NewTimeAnchor(0, now)
 			got, err := ParseEvent(bufio.NewReader(bytes.NewReader(data)), ta)
 			if err != nil {

--- a/runtimes/go/appruntime/apisdk/api/handler_test.go
+++ b/runtimes/go/appruntime/apisdk/api/handler_test.go
@@ -310,6 +310,10 @@ func TestDescGeneratesTrace(t *testing.T) {
 				EXPECT().
 				RequestSpanEnd(gomock.Any()).MaxTimes(1)
 
+			traceMock.EXPECT().WaitAndClear().AnyTimes()
+			traceMock.EXPECT().WaitUntilDone().AnyTimes()
+			traceMock.EXPECT().MarkDone().MaxTimes(1)
+
 			handler.Handle(server.NewIncomingContext(w, req, ps, api.CallMeta{}))
 
 			if diff := cmp.Diff(test.want, beginReq, opts...); diff != "" {
@@ -362,6 +366,9 @@ func TestRawEndpointOverflow(t *testing.T) {
 		func(p trace2.BodyStreamParams) {
 			params = append(params, p)
 		}).AnyTimes()
+
+	traceMock.EXPECT().WaitAndClear().MinTimes(1)
+	traceMock.EXPECT().MarkDone().Times(1)
 
 	handler.Handle(server.NewIncomingContext(w, req, ps, api.CallMeta{}))
 

--- a/runtimes/go/appruntime/exported/experiments/names.go
+++ b/runtimes/go/appruntime/exported/experiments/names.go
@@ -27,6 +27,10 @@ const (
 	// AuthDataRoundTrip forces auth data to be round-tripped through the wireformat
 	// when internal API calls are made.
 	AuthDataRoundTrip Name = "auth-data-round-trip"
+
+	// StreamTraces enables streaming traces to the Encore platform as they're happening,
+	// as opposed to waiting for the request to finish before starting the upload.
+	StreamTraces Name = "stream-traces"
 )
 
 // Valid reports whether the given name is a known experiment.
@@ -37,7 +41,8 @@ func (x Name) Valid() bool {
 		V2,
 		BetaRuntime,
 		LocalMultiProcess,
-		AuthDataRoundTrip:
+		AuthDataRoundTrip,
+		StreamTraces:
 		return true
 	default:
 		return false

--- a/runtimes/go/appruntime/exported/trace2/logger.go
+++ b/runtimes/go/appruntime/exported/trace2/logger.go
@@ -3,6 +3,7 @@ package trace2
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"encore.dev/appruntime/exported/model"
 	"encore.dev/appruntime/exported/stack"
@@ -11,8 +12,14 @@ import (
 //go:generate mockgen -source=./logger.go -package=mock_trace -destination ../../shared/traceprovider/mock_trace/mock_trace.go Logger
 
 type Logger interface {
+	MarkDone()
 	Add(Event) EventID
-	GetAndClear() []byte
+
+	WaitUntilDone()
+	WaitAtLeast(time.Duration) bool
+	GetAndClear() (data []byte, done bool)
+	WaitAndClear() (data []byte, done bool)
+
 	RequestSpanStart(req *model.Request, goid uint32)
 	RequestSpanEnd(params RequestSpanEndParams)
 	AuthSpanStart(req *model.Request, goid uint32)

--- a/runtimes/go/appruntime/shared/platform/streaming_trace.go
+++ b/runtimes/go/appruntime/shared/platform/streaming_trace.go
@@ -1,0 +1,131 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"encore.dev/appruntime/exported/experiments"
+	"encore.dev/appruntime/exported/trace2"
+)
+
+func (c *Client) StreamTrace(log trace2.Logger) error {
+	if experiments.StreamTraces.Enabled(c.exp) {
+		return c.streamingTrace(log)
+	} else {
+		return c.blockingTrace(log)
+	}
+}
+
+// streamingTrace streams a trace to the platform.
+func (c *Client) streamingTrace(log trace2.Logger) error {
+	// Wait a bit for the trace to start, so we can avoid the overhead
+	// of small chunk streaming if the trace is short.
+	done := log.WaitAtLeast(1 * time.Second)
+	var body io.Reader
+	if done {
+		data, _ := log.GetAndClear()
+		if len(data) == 0 {
+			return nil
+		}
+
+		// Use a bytes.Reader so net/http knows the Content-Length.
+		body = bytes.NewReader(data)
+	} else {
+		r := &traceLogReader{log: log}
+		if r.IsDoneAndEmpty() {
+			// We didn't get any trace data; don't bother streaming.
+			return nil
+		}
+		body = r
+	}
+
+	// Use a background context since the trace is streaming,
+	// and we don't know how long it will take to complete.
+	ctx := context.Background()
+	return c.sendTraceRequest(ctx, body)
+}
+
+// blockingTrace waits for the trace to complete before sending it.
+func (c *Client) blockingTrace(log trace2.Logger) error {
+	// Wait for the trace to complete
+	log.WaitUntilDone()
+	data, _ := log.GetAndClear()
+	if len(data) == 0 {
+		return nil // optimization
+	}
+	body := bytes.NewReader(data)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return c.sendTraceRequest(ctx, body)
+}
+
+func (c *Client) sendTraceRequest(ctx context.Context, body io.Reader) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", c.runtime.TraceEndpoint, body)
+	if err != nil {
+		return err
+	}
+
+	ta, err := trace2.NewTimeAnchorNow().MarshalText()
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("X-Encore-App-ID", c.runtime.AppID)
+	req.Header.Set("X-Encore-Env-ID", c.runtime.EnvID)
+	req.Header.Set("X-Encore-Deploy-ID", c.runtime.DeployID)
+	req.Header.Set("X-Encore-App-Commit", c.static.AppCommit.AsRevisionString())
+	req.Header.Set("X-Encore-Trace-Version", strconv.Itoa(int(trace2.CurrentVersion)))
+	req.Header.Set("X-Encore-Trace-TimeAnchor", string(ta))
+	c.addAuthKey(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("http %s: %s", resp.Status, body)
+	}
+	return nil
+}
+
+// traceLogReader implements io.Reader by reading from a trace log.
+type traceLogReader struct {
+	log  trace2.Logger
+	data []byte // current buffer
+	done bool
+}
+
+func (r *traceLogReader) Read(b []byte) (int, error) {
+	r.readMoreIfNeeded()
+	// Post-condition: we have data, or we're done (or both).
+
+	if len(r.data) > 0 {
+		n := copy(b, r.data)
+		r.data = r.data[n:]
+		return n, nil
+	} else {
+		return 0, io.EOF
+	}
+}
+
+// IsDoneAndEmpty blocks until we have some trace data, and then
+// reports whether the trace is done and empty.
+func (r *traceLogReader) IsDoneAndEmpty() bool {
+	r.readMoreIfNeeded()
+	return len(r.data) == 0 && r.done
+}
+
+func (r *traceLogReader) readMoreIfNeeded() {
+	for len(r.data) == 0 && !r.done {
+		r.data, r.done = r.log.WaitAndClear()
+	}
+	// Post-condition: we have data, or we're done (or both).
+}

--- a/runtimes/go/appruntime/shared/reqtrack/impl_app.go
+++ b/runtimes/go/appruntime/shared/reqtrack/impl_app.go
@@ -64,12 +64,12 @@ func beginHTTPRoundTrip(req *http.Request) (context.Context, error) {
 		return nil, fmt.Errorf("http: nil Request.URL")
 	}
 
-	return g.op.trace.HTTPBeginRoundTrip(req, g.req.data, g.goctr)
+	return g.op.trace.Logger().HTTPBeginRoundTrip(req, g.req.data, g.goctr)
 }
 
 //go:linkname finishHTTPRoundTrip net/http.encoreFinishRoundTrip
 func finishHTTPRoundTrip(req *http.Request, resp *http.Response, err error) {
 	if g := getEncoreG(); g != nil && g.req != nil && g.op.trace != nil {
-		g.op.trace.HTTPCompleteRoundTrip(req, resp, g.goctr, err)
+		g.op.trace.Logger().HTTPCompleteRoundTrip(req, resp, g.goctr, err)
 	}
 }

--- a/runtimes/go/appruntime/shared/reqtrack/trace_stream.go
+++ b/runtimes/go/appruntime/shared/reqtrack/trace_stream.go
@@ -1,0 +1,57 @@
+package reqtrack
+
+import (
+	"sync"
+
+	"encore.dev/appruntime/exported/trace2"
+)
+
+type TraceStreamer interface {
+	StreamTrace(trace2.Logger) error
+}
+
+type noopTraceStreamer struct{}
+
+// StreamTrace implements TraceStreamer by consuming the trace log
+// but not doing anything with it.
+func (noopTraceStreamer) StreamTrace(log trace2.Logger) error {
+	for {
+		_, done := log.WaitAndClear()
+		if done {
+			return nil
+		}
+	}
+}
+
+func newLazyTrace(rt *RequestTracker) *lazyTraceInit {
+	log := rt.trace.NewLogger()
+	return &lazyTraceInit{rt: rt, log: log}
+}
+
+// lazyTraceInit is a lazily initialized trace logger.
+// It is used to defer trace streaming until the trace is actually used.
+type lazyTraceInit struct {
+	rt       *RequestTracker
+	log      trace2.Logger
+	initOnce sync.Once
+}
+
+func (l *lazyTraceInit) MarkDone() {
+	l.log.MarkDone()
+	l.initStream()
+}
+
+func (l *lazyTraceInit) Logger() trace2.Logger {
+	l.initStream()
+	return l.log
+}
+
+func (l *lazyTraceInit) initStream() {
+	l.initOnce.Do(func() {
+		go func() {
+			if err := l.rt.streamer.StreamTrace(l.log); err != nil {
+				l.rt.rootLogger.Error().Err(err).Msg("failed to stream trace")
+			}
+		}()
+	})
+}

--- a/runtimes/go/appruntime/shared/traceprovider/mock_trace/mock_trace.go
+++ b/runtimes/go/appruntime/shared/traceprovider/mock_trace/mock_trace.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	http "net/http"
 	reflect "reflect"
+	time "time"
 
 	model "encore.dev/appruntime/exported/model"
 	stack "encore.dev/appruntime/exported/stack"
@@ -167,11 +168,12 @@ func (mr *MockLoggerMockRecorder) DBTransactionStart(arg0, arg1 interface{}) *go
 }
 
 // GetAndClear mocks base method.
-func (m *MockLogger) GetAndClear() []byte {
+func (m *MockLogger) GetAndClear() ([]byte, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAndClear")
 	ret0, _ := ret[0].([]byte)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 // GetAndClear indicates an expected call of GetAndClear.
@@ -217,6 +219,18 @@ func (m *MockLogger) LogMessage(arg0 trace2.LogMessageParams) {
 func (mr *MockLoggerMockRecorder) LogMessage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogMessage", reflect.TypeOf((*MockLogger)(nil).LogMessage), arg0)
+}
+
+// MarkDone mocks base method.
+func (m *MockLogger) MarkDone() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MarkDone")
+}
+
+// MarkDone indicates an expected call of MarkDone.
+func (mr *MockLoggerMockRecorder) MarkDone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkDone", reflect.TypeOf((*MockLogger)(nil).MarkDone))
 }
 
 // PubsubMessageSpanEnd mocks base method.
@@ -343,4 +357,45 @@ func (m *MockLogger) ServiceInitStart(arg0 trace2.ServiceInitStartParams) trace2
 func (mr *MockLoggerMockRecorder) ServiceInitStart(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceInitStart", reflect.TypeOf((*MockLogger)(nil).ServiceInitStart), arg0)
+}
+
+// WaitAndClear mocks base method.
+func (m *MockLogger) WaitAndClear() ([]byte, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitAndClear")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// WaitAndClear indicates an expected call of WaitAndClear.
+func (mr *MockLoggerMockRecorder) WaitAndClear() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitAndClear", reflect.TypeOf((*MockLogger)(nil).WaitAndClear))
+}
+
+// WaitAtLeast mocks base method.
+func (m *MockLogger) WaitAtLeast(arg0 time.Duration) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitAtLeast", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// WaitAtLeast indicates an expected call of WaitAtLeast.
+func (mr *MockLoggerMockRecorder) WaitAtLeast(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitAtLeast", reflect.TypeOf((*MockLogger)(nil).WaitAtLeast), arg0)
+}
+
+// WaitUntilDone mocks base method.
+func (m *MockLogger) WaitUntilDone() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "WaitUntilDone")
+}
+
+// WaitUntilDone indicates an expected call of WaitUntilDone.
+func (mr *MockLoggerMockRecorder) WaitUntilDone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilDone", reflect.TypeOf((*MockLogger)(nil).WaitUntilDone))
 }

--- a/runtimes/go/appruntime/shared/traceprovider/traceprovider.go
+++ b/runtimes/go/appruntime/shared/traceprovider/traceprovider.go
@@ -10,4 +10,4 @@ type Factory interface {
 
 type DefaultFactory struct{}
 
-func (*DefaultFactory) NewLogger() trace2.Logger { return &trace2.Log{} }
+func (*DefaultFactory) NewLogger() trace2.Logger { return trace2.NewLog() }


### PR DESCRIPTION
This adds a new experiment that enables streaming traces
to the platform as they're happening, as opposed to waiting
for the trace to complete.
