### PR TITLE
Add quick start guide for TS

### DIFF
--- a/docs/quick-start.ts.mdx
+++ b/docs/quick-start.ts.mdx
@@ -1,0 +1,194 @@
+---
+seotitle: Quick Start Guide – Learn how to build backends using TypeScript with Encore
+seodesc: See how you to build and ship a cloud based backend application using TypeScript and Encore. Install Encore and build a REST API in just a few minutes.
+title: Quick Start Guide
+subtitle: Get started building with Encore in minutes
+---
+
+In this short guide, you'll learn key concepts and experience the Encore workflow using TypeScript.
+It should only take about 5 minutes to complete and by the end you'll have an API running in Encore's free development Cloud (Encore Cloud).
+
+To make it easy to follow along, we've laid out a trail of croissants to guide your way.
+Whenever you see a 🥐 it means there's something for you to do.
+
+Let's get started!
+
+## 1. Install the Encore CLI
+To develop with Encore, you need the Encore CLI. It provisions your local environment, and runs your local development dashboard complete with tracing and API documentation.
+
+🥐 Install by running the appropriate command for your system:
+
+<InstallTSInstructions/>
+
+## 2. Create your app
+🥐 Create your app by running:
+```shell
+$ encore-beta app create --example=hello-world-ts <my app name>
+```
+Since this is the first time you're using Encore, you'll be asked to create a free account.
+This is needed so that Encore can orchestrate functionality like tracing, secrets, and manage cloud deployments.
+You can use your account with GitHub, Google, or create an account using your email.
+
+This will create an example application, with a simple REST API, in a new folder using the app name you picked.
+
+### Let's take a look at the code
+
+Part of what makes Encore different is the simple developer experience when building distributed systems.
+Let's look at the code to better understand how to build applications with Encore.
+
+🥐 Open the `hello.ts` file in your code editor. It's located in the folder: `your-app-name/hello/`.
+
+You should see this:
+
+```ts
+import { api } from "encore.dev/api";
+
+export const world = api(
+  { method: "GET", path: "/hello/:name" },
+  async ({ name }: { name: string }): Promise<Response> => {
+    const msg = `Hello ${name}!`;
+    return { message: msg };
+  },
+);
+
+interface Response {
+  message: string;
+}
+```
+
+As you can see, it's all standard TypeScript.
+
+You define an API endpoint by wrapping a regular async function in a call to `api`. Doing this makes Encore identify the `hello` directory as a service,
+and that the `world` function is a public API endpoint. Encore automatically handles authentication, HTTP routing, request validation, error handling, observability, API documentation, and more.
+
+If you want to create more services and endpoints, you simply create new folders and define endpoints by wrapping functions in the `api` function. _If you're curious, you can read more about [defining services and APIs](/docs/ts/primitives/services-and-apis)._
+
+Encore's [Infrastructure SDK](/docs/ts/primitives/overview) provides several declarative ways of using backend primitives like databases, Pub/Sub, and scheduled tasks by simply writing code.
+
+## 3. Start your app & Explore Local Development Dashboard
+
+🥐 Now let's run your app locally:
+
+```shell
+$ cd your-app-name # replace with the app name you picked
+$ encore-beta run
+```
+
+You should see this:
+
+<video autoPlay playsInline loop controls muted className="w-full h-full">
+  <source src="/assets/docs/encorerun.mp4" className="w-full h-full" type="video/mp4"/>
+</video>
+
+That means your local development environment is up and running!
+Encore takes care of setting up all the necessary infrastructure for your applications, including databases.
+
+🥐 While you keep the app running, open a separate terminal and call your API endpoint:
+
+```shell
+$ curl http://localhost:4000/hello/world
+{"message": "Hello, world!"}
+```
+If you see this JSON response, you've successfully made an API call to your very first Encore application.
+
+_Well done, you're on your way!_
+
+### Open the Local Development Dashboard
+
+You can now start using your [Local Development Dashboard](/docs/ts/observability/dev-dash).
+
+🥐 Open [http://localhost:9400](http://localhost:9400) in your browser to access it.
+
+The Local Development Dashboard is a powerful tool to help you move faster when you're developing new features.
+
+It comes with an API explorer with automatically generated documentation, and powerful oberservability features like [distributed tracing](/docs/ts/observability/tracing). _Did we mention Encore automatically instruments your entire application with logs and tracing?_
+
+Through the Local Development Dashboard you also have access to [Encore Flow](/docs/ts/develop/encore-flow) which is a visual representation
+of your microservice architecture that updates in real-time as you develop your application.
+
+<video autoPlay playsInline loop controls muted className="w-full h-full">
+  <source src="/assets/docs/localdashvideo.mp4" className="w-full h-full" type="video/mp4"/>
+</video>
+
+## 4. Push a code change and deploy
+
+Let's put our mark on this API and make our first code change.
+
+🥐 Head back to your code editor and look at the `hello.ts` file again.
+If you can't come up a creative change yourself, why not simply change the "Hello" message to a more sassy "Howdy"?
+
+🥐 Once you've made your change, save the file.
+
+When you save, the daemon run by the Encore CLI instantly detects the change and automatically recompiles your application and reloads your local development environment.
+
+The output where you're running your app will look something like this:
+
+```output
+Changes detected, recompiling...
+Reloaded successfully.
+INF registered endpoint endpoint=World path=/hello/:name service=hello
+INF listening for incoming HTTP requests
+```
+
+🥐 Test your change by calling your API in a separate terminal:
+
+```shell
+$ curl http://localhost:4000/hello/world
+{"message": "Howdy, world!"}
+```
+
+Great job, you're now ready to head to the cloud!
+
+### Deploy your app to the cloud
+
+The first time you deploy, Encore will by default create a staging [environment](/docs/ts/deploy/environments) in Encore's free development cloud (Encore Cloud).
+
+Later, when you are ready to create a production environment you can [deploy to your own cloud account](/docs/ts/deploy/own-cloud) with GCP and AWS.
+(Or even all of them, Encore makes it seamless to deploy to multiple cloud environments all at once.)
+
+🥐 Now push your changes and deploy your application by running:
+
+```shell
+$ git add -A .
+$ git commit -m 'Initial commit'
+$ git push encore
+```
+
+Encore will now build and test your app, provision the needed infrastructure, and deploy your application to the cloud.
+
+_Your app will soon be running in the cloud, isn't this exciting?_
+
+## 5. Explore the Cloud Dashboard
+
+After triggering the deployment, you will see a URL where you can view its progress in Encore's Cloud Dashboard.
+It will look something like: `https://app.encore.dev/$APP_ID/deploys/...`
+
+🥐 Open the URL to access the Cloud Dashboard and check the progress of your deployment.
+
+You can now use the Cloud Dashboard to view production [logs](/docs/ts/observability/logging) and [traces](/docs/ts/observability/tracing), create new [environments](/docs/ts/deploy/environments), connect the [cloud account of your choice](/docs/ts/deploy/own-cloud), [integrate with GitHub](/docs/ts/how-to/github), and much more.
+
+<video autoPlay playsInline loop controls muted className="w-full h-full">
+  <source src="/assets/docs/webdashvideo.mp4" className="w-full h-full" type="video/mp4"/>
+</video>
+
+### Call your API in the cloud
+
+Now that you've created your staging environment, you're ready to call your API running in the cloud.
+Your API Base URL will be something like: `https://staging-$APP_ID.encr.app`
+
+🥐 When the deploy is finished, call your API from the terminal (replacing `$APP_ID` with your own App ID):
+
+```shell
+$ curl https://staging-$APP_ID.encr.app/hello/world
+{"Message": "Howdy, world!"}
+```
+
+If you see this you've successfully made an API call to your very first Encore app running in the cloud.
+
+_Congratulations, you're well on your way to escaping the maze of cloud complexity!_
+
+## What's next?
+
+🥐 Check out the [Uptime Monitor tutorial](/docs/ts/tutorials/uptime) to learn how to add more services, use databases, PubSub, and cron jobs.
+
+If you want to chat to other pioneering developers already building with Encore, or need help, join the friendly community on [Slack](/slack).


### PR DESCRIPTION
Assumptions I have taken:
* We will have cloud deploys available when going live with the docs
* We will have TS links for other docs pages that we are linking to from this page. This will be easier then going back to this doc and updating it for every new docs page we add. But before going live we will need to click though everything and check for broken links.