### PR TITLE
Update .devcontainer golang to 1.21.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.19
+FROM golang:1.21.0
 
 RUN apt-get update && apt-get install -y sudo
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
-	apt-get install -y nodejs
+	apt-get install -y nodejs npm
 
 ADD scripts /scripts
 RUN bash /scripts/install.sh


### PR DESCRIPTION
building the project using dev containers was failing. I was trying to use codespaces to test.

 - `go test -golden-update` fails without installing npm.
