### PR TITLE
v2/compiler/build: fix concurrent build+test

### DIFF
--- a/v2/compiler/build/tests.go
+++ b/v2/compiler/build/tests.go
@@ -37,6 +37,7 @@ func Test(ctx context.Context, cfg *TestConfig) {
 		ctx:     ctx,
 		cfg:     &cfg.Config,
 		testCfg: cfg,
+		mode:    testMode,
 		errs:    cfg.Ctx.Errs,
 	}
 	b.Test()


### PR DESCRIPTION
When concurrently building and testing, we would sometimes
get spurious compilation errors due to the code generation
being different between the build modes.

Fix this by using separate work directories for each build mode.
