### PR TITLE
Implement service and endpoint mocking support in tests

### DIFF
--- a/docs/develop/mocking.md
+++ b/docs/develop/mocking.md
@@ -45,7 +45,7 @@ func Test_Something(t *testing.T) {
 	t.Parallel() // Run this test in parallel with other tests without the mock implementation interfering
 	
 	// Create a mock implementation of pricing API which will only impact this test and any sub-tests
-	et.MockAPI("products", "GetPrice", func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
+	et.MockAPI(products.GetPrice, func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
 		return &products.PriceResponse{Price: 100}, nil
 	})
 	

--- a/docs/develop/mocking.md
+++ b/docs/develop/mocking.md
@@ -1,0 +1,146 @@
+---
+seotitle: Mocking out your APIs and services for testing
+seodesc: Learn how to mock out your APIs and services for testing, and how to use the built-in mocking support in Encore.
+title: Mocking
+subtitle: Testing your application in isolation
+infobox: {
+  title: "Testing",
+  import: "encore.dev/et",
+}
+---
+
+Encore comes with built-in support for mocking out APIs and services, which makes it easier to test your application in
+isolation.
+
+## Mocking APIs
+
+Let's say you have a function that calls an external API in our `products` service:
+
+```go
+//encore:api private
+func GetPrice(ctx context.Context, p *PriceParams) (*PriceResponse, error) {
+    // Call external API to get the price
+}
+```
+
+When testing this function, you don't want to call the real external API since that would be slow and cause your tests
+to fail if the API is down. Instead, you want to mock out the API call and return a fake response.
+
+In Encore, you can do this by adding a mock implementation of the API using the `et.MockAPI` function inside your test:
+
+```go
+package shoppingcart
+
+import (
+	"context"
+	"testing"
+	
+	"encore.dev/et" // Encore's test support package
+	
+	"your_app/products"
+)
+
+
+func Test_Something(t *testing.T) {
+	t.Parallel() // Run this test in parallel with other tests without the mock implementation interfering
+	
+	// Create a mock implementation of pricing API which will only impact this test and any sub-tests
+	et.MockAPI("products", "GetPrice", func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
+		return &products.PriceResponse{Price: 100}, nil
+	})
+	
+	// ... the rest of your test code here ...
+} 
+```
+
+When any code within the test, or any sub-test calls the `GetPrice` API, the mock implementation will be called instead.
+The mock will not impact any other tests running in parallel. The function you pass to `et.MockAPI` must have the same
+signature as the real API.
+
+If you want to mock out the API for all tests in the package, you can add the mock implementation to the `TestMain` function:
+
+```go
+package shoppingcart
+
+import (
+	"context"
+	"os"
+    "testing"
+    
+    "encore.dev/et"
+	
+	"your_app/products"
+)
+
+func TestMain(m *testing.M) {
+    // Create a mock implementation of pricing API which will impact all tests within this package
+    et.MockAPI("products", "GetPrice", func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
+        return &products.PriceResponse{Price: 100}, nil
+    })
+    
+    // Now run the tests
+    os.Exit(m.Run())
+}
+```
+
+Mocks can be changed at any time, including removing them by setting the mock implementation to `nil`.
+
+## Mocking services
+
+As well as mocking individual APIs, you can also mock entire services. This can be useful if you want to inject a different
+set of dependencies into your service for testing, or a service that your code depends on. This can be done using the
+`et.MockService` function:
+
+```go
+package shoppingcart
+
+import (
+    "context"
+    "testing"
+    
+    "encore.dev/et" // Encore's test support package
+    
+    "your_app/products"
+)
+
+func Test_Something(t *testing.T) {
+    t.Parallel() // Run this test in parallel with other tests without the mock implementation interfering
+    
+    // Create a instance of the products service which will only impact this test and any sub-tests
+    et.MockService("products", &products.Service{
+		SomeField: "a testing value",
+	})
+    
+    // ... the rest of your test code here ...
+}
+```
+
+When any code within the test, or any sub-test calls the `products` service, the mock implementation will be called instead.
+Unlike `et.MockAPI`, the mock implementation does not need to have the same signature, and can be any object. The only requirement
+is that any of the services APIs that are called during the test must be implemented by as a receiver method on the mock object.
+(This also includes APIs that are defined as package level functions in the service, and are not necessarily defined as receiver methods
+on that services struct).
+
+To help with compile time saftey on service mocking, for every service Encore will automatically generate an `Interface` interface
+which contains all the APIs defined in the service. This interface can be passed as a generic argument to `et.MockService` to ensure
+that the mock object implements all the APIs defined in the service:
+
+```go
+type myMockObject struct{}
+
+func (m *myMockObject) GetPrice(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
+    return &products.PriceResponse{Price: 100}, nil
+}
+
+func Test_Something(t *testing.T) {
+    t.Parallel() // Run this test in parallel with other tests without the mock implementation interfering
+    
+    // This will cause a compile time error if myMockObject does not implement all the APIs defined in the products service
+    et.MockService[products.Interface]("products", &myMockObject{})
+}
+```
+                                          \
+### Automatic generation of mock objects
+
+Thanks to the generated `Interface` interface, it's possible to automatically generate mock objects for your services using
+either [Mockery](https://vektra.github.io/mockery/latest/) or [GoMock](https://github.com/uber-go/mock).

--- a/docs/develop/mocking.md
+++ b/docs/develop/mocking.md
@@ -12,9 +12,9 @@ infobox: {
 Encore comes with built-in support for mocking out APIs and services, which makes it easier to test your application in
 isolation.
 
-## Mocking APIs
+## Mocking Endpoints
 
-Let's say you have a function that calls an external API in our `products` service:
+Let's say you have an endpoint that calls an external API in our `products` service:
 
 ```go
 //encore:api private
@@ -26,7 +26,7 @@ func GetPrice(ctx context.Context, p *PriceParams) (*PriceResponse, error) {
 When testing this function, you don't want to call the real external API since that would be slow and cause your tests
 to fail if the API is down. Instead, you want to mock out the API call and return a fake response.
 
-In Encore, you can do this by adding a mock implementation of the API using the `et.MockAPI` function inside your test:
+In Encore, you can do this by adding a mock implementation of the endpoint using the `et.MockEndpoint` function inside your test:
 
 ```go
 package shoppingcart
@@ -45,7 +45,7 @@ func Test_Something(t *testing.T) {
 	t.Parallel() // Run this test in parallel with other tests without the mock implementation interfering
 	
 	// Create a mock implementation of pricing API which will only impact this test and any sub-tests
-	et.MockAPI(products.GetPrice, func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
+	et.MockEndpoint(products.GetPrice, func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
 		return &products.PriceResponse{Price: 100}, nil
 	})
 	
@@ -54,8 +54,8 @@ func Test_Something(t *testing.T) {
 ```
 
 When any code within the test, or any sub-test calls the `GetPrice` API, the mock implementation will be called instead.
-The mock will not impact any other tests running in parallel. The function you pass to `et.MockAPI` must have the same
-signature as the real API.
+The mock will not impact any other tests running in parallel. The function you pass to `et.MockEndpoint` must have the same
+signature as the real endpoint.
 
 If you want to mock out the API for all tests in the package, you can add the mock implementation to the `TestMain` function:
 
@@ -74,7 +74,7 @@ import (
 
 func TestMain(m *testing.M) {
     // Create a mock implementation of pricing API which will impact all tests within this package
-    et.MockAPI("products", "GetPrice", func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
+    et.MockEndpoint(products.GetPrice, func(ctx context.Context, p *products.PriceParams) (*products.PriceResponse, error) {
         return &products.PriceResponse{Price: 100}, nil
     })
     
@@ -116,7 +116,7 @@ func Test_Something(t *testing.T) {
 ```
 
 When any code within the test, or any sub-test calls the `products` service, the mock implementation will be called instead.
-Unlike `et.MockAPI`, the mock implementation does not need to have the same signature, and can be any object. The only requirement
+Unlike `et.MockEndpoint`, the mock implementation does not need to have the same signature, and can be any object. The only requirement
 is that any of the services APIs that are called during the test must be implemented by as a receiver method on the mock object.
 (This also includes APIs that are defined as package level functions in the service, and are not necessarily defined as receiver methods
 on that services struct).

--- a/docs/develop/testing.md
+++ b/docs/develop/testing.md
@@ -38,6 +38,15 @@ In general, Encore applications tend to focus more on integration tests
 compared to traditional applications that are heavier on unit tests.
 This is nothing to worry about and is the recommended best practice.
 
+### Service Structs
+
+In tests, [service structs](/docs/primitives/services-and-apis/service-structs) are initialised on demand when the first
+API call is made to that service and then that instance of the service struct for all future tests. This means your tests
+can run faster as they don't have to each initialise all the service struct's each time a new test starts.
+
+However, in some situations you might be storing state in the service struct that would interfere with other tests. When
+you have a test you want to have it's own instance of the service struct, you can use the `et.EnableServiceInstanceIsolation()` function within the test to enable this for just that test, while the rest of your tests will continue to use the shared instance.
+
 ## Test-only infrastructure
 
 Encore allows tests to define infrastructure resources specifically for testing.
@@ -59,4 +68,3 @@ It lets you run unit tests directly from within your IDE with support for debug 
 There's no official VS Code plugin available yet, but we are happy to include your contribution if you  build one. Reach out on [Slack](/slack) if you need help to get started.
 
 For advice on debugging when using VS Code, see the [Debugging docs](/docs/how-to/debug).
-

--- a/docs/menu.cue
+++ b/docs/menu.cue
@@ -328,6 +328,12 @@
 									text: "Testing"
 									path: "/develop/testing"
 									file: "develop/testing"
+									inline_menu: [{
+										kind: "basic"
+										text: "Mocking"
+										path: "/develop/testing/mocking"
+										file: "develop/mocking"
+									}]
 								}, {
 									kind: "basic"
 									text: "Validation"

--- a/docs/menu.json
+++ b/docs/menu.json
@@ -254,7 +254,14 @@
       {
         "Path": "/develop/testing",
         "Title": "Testing",
-        "DocSlug": "develop/testing"
+        "DocSlug": "develop/testing",
+        "Children": [
+          {
+            "Path": "/develop/testing/mocking",
+            "Title": "Mocking",
+            "DocSlug": "develop/mocking"
+          }
+        ]
       },
       {
         "Path": "/develop/validation",

--- a/e2e-tests/testdata/testscript/et_mocking.txt
+++ b/e2e-tests/testdata/testscript/et_mocking.txt
@@ -1,0 +1,196 @@
+test
+
+-- products/price.go --
+package products
+
+import (
+    "context"
+)
+
+type PriceParams struct {
+    Quantity int
+}
+
+type PriceResult struct {
+    Total float64
+}
+
+//encore:api public method=GET path=/products/:productID/price
+func GetPrice(ctx context.Context, productID int, p *PriceParams) (*PriceResult, error) {
+    return &PriceResult{ Total: 99.99 * float64(p.Quantity) }, nil
+}
+
+-- shoppingcart/cart.go --
+package shoppingcart
+
+import (
+    "context"
+
+    "test/products"
+)
+
+type CartItem struct {
+    ProductID int
+    Quantity int
+}
+
+//encore:service
+type Service struct {
+    Items []CartItem
+}
+
+func initService() (*Service, error) {
+    return &Service{
+        Items: []CartItem{
+            { ProductID: 1, Quantity: 2 },
+            { ProductID: 2, Quantity: 1 },
+        },
+    }, nil
+}
+
+type TotalResult struct {
+    Total float64
+}
+
+//encore:api public method=GET path=/cart/total
+func (s *Service) Total(ctx context.Context) (*TotalResult, error) {
+    var total float64
+
+    for _, item := range s.Items {
+        price, err := products.GetPrice(ctx, item.ProductID, &products.PriceParams{ Quantity: item.Quantity })
+        if err != nil {
+            return nil, err
+        }
+
+        total += price.Total
+    }
+
+    return &TotalResult{ Total: total }, nil
+}
+
+//encore:api private
+func (s *Service) Empty(ctx context.Context) error {
+    s.Items = []CartItem{}
+    return nil
+}
+
+-- shoppingcart/cart_test.go --
+package shoppingcart
+
+import (
+    "context"
+    "math"
+    "testing"
+
+    "encore.dev/et"
+
+    "test/products"
+)
+
+func callAndExpect(t *testing.T, total float64) {
+    resp, err := Total(context.Background())
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if math.Abs(resp.Total - total) > 0.001 {
+        t.Fatalf("expected total to be %f, got %f", total, resp.Total)
+    }
+}
+
+func TestTotal_NoMocking(t *testing.T) {
+    t.Parallel()
+
+    callAndExpect(t, 299.97)
+}
+
+func TestTotal_WithMockingOfProductsEndpoint(t *testing.T) {
+    t.Parallel()
+
+    et.MockEndpoint(products.GetPrice, func(ctx context.Context, productID int, p *products.PriceParams) (*products.PriceResult, error) {
+       return &products.PriceResult{ Total: 20 * float64(p.Quantity) }, nil
+    })
+
+    callAndExpect(t, 60.0)
+}
+
+func TestTotal_WithMockingOfServiceMethod(t *testing.T) {
+    t.Parallel()
+
+    et.MockEndpoint(Total, func(ctx context.Context) (*TotalResult, error) {
+        return &TotalResult{ Total: 100.0 }, nil
+    })
+
+    callAndExpect(t, 100.0)
+}
+
+func TestTotal_WithMockingOfServiceObjectWithDifferentInstance(t *testing.T) {
+    t.Parallel()
+
+    et.MockService("shoppingcart", &Service{
+        Items: []CartItem{
+            { ProductID: 1, Quantity: 5 },
+        },
+    })
+
+    callAndExpect(t, 499.95)
+}
+
+func TestTotal_WithMockingOfServiceWithMockObject(t *testing.T) {
+    t.Parallel()
+
+    et.MockService[products.Interface]("products", &mockProducts{})
+
+    callAndExpect(t, 303.0)
+}
+
+type mockProducts struct{}
+
+func (m *mockProducts) GetPrice(ctx context.Context, productID int, p *products.PriceParams) (*products.PriceResult, error) {
+    return &products.PriceResult{ Total: float64(productID) + float64(p.Quantity * 100) }, nil
+}
+
+func TestTotal_UsingServiceIsolation(t *testing.T) {
+    t.Parallel()
+
+    callAndExpect(t, 299.97)
+
+    // These don't run with parallel so we can test the isolation
+    t.Run("emptied in isolation", func(t *testing.T) {
+        et.EnableServiceInstanceIsolation()
+        Empty(context.Background())
+        callAndExpect(t, 0.0)
+    })
+
+    t.Run("non isolated still has items", func(t *testing.T) {
+        callAndExpect(t, 299.97)
+    })
+}
+
+func TestTotal_RemovingMockServices(t *testing.T) {
+    t.Parallel()
+
+    et.MockService[products.Interface]("products", &mockProducts{})
+
+    t.Run("remove mock", func(t *testing.T) {
+        et.MockService[products.Interface]("products", nil)
+        callAndExpect(t, 299.97)
+    })
+
+    callAndExpect(t, 303.0)
+}
+
+func TestTotal_RemovingMockEndpoints(t *testing.T) {
+    t.Parallel()
+
+    et.MockEndpoint(products.GetPrice, func(ctx context.Context, productID int, p *products.PriceParams) (*products.PriceResult, error) {
+       return &products.PriceResult{ Total: 20 * float64(p.Quantity) }, nil
+    })
+
+    t.Run("remove mock", func(t *testing.T) {
+        et.MockEndpoint(products.GetPrice, nil)
+        callAndExpect(t, 299.97)
+    })
+
+    callAndExpect(t, 60.0)
+}

--- a/e2e-tests/testdata/testscript/graceful_shutdown.txt
+++ b/e2e-tests/testdata/testscript/graceful_shutdown.txt
@@ -5,7 +5,6 @@ checklog '{"message": "shutting down"}'
 package svc
 
 import (
-    "context"
     "encore.dev/shutdown"
     "encore.dev/rlog"
 )

--- a/internal/clientgen/testdata/expected_golang.go
+++ b/internal/clientgen/testdata/expected_golang.go
@@ -252,6 +252,7 @@ type SvcWrapper[T any] struct {
 type SvcClient interface {
 	// DummyAPI is a dummy endpoint.
 	DummyAPI(ctx context.Context, params SvcRequest) error
+	FallbackPath(ctx context.Context, a string, b []string) error
 	Get(ctx context.Context, params SvcGetRequest) error
 	GetRequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[int]) (SvcHeaderOnlyStruct, error)
 	HeaderOnlyRequest(ctx context.Context, params SvcHeaderOnlyStruct) error
@@ -264,6 +265,7 @@ type SvcClient interface {
 	// and this comment is also multiline, so multiline comments get tested as well.
 	TupleInputOutput(ctx context.Context, params SvcTuple[string, SvcWrappedRequest]) (SvcTuple[bool, SvcFoo], error)
 	Webhook(ctx context.Context, a string, b []string, request *http.Request) (*http.Response, error)
+	Webhook2(ctx context.Context, a string, b []string) error
 }
 
 type svcClient struct {
@@ -303,6 +305,11 @@ func (c *svcClient) DummyAPI(ctx context.Context, params SvcRequest) error {
 	}
 
 	_, err := callAPI(ctx, c.base, "POST", fmt.Sprintf("/svc.DummyAPI?%s", queryString.Encode()), headers, body, nil)
+	return err
+}
+
+func (c *svcClient) FallbackPath(ctx context.Context, a string, b []string) error {
+	_, err := callAPI(ctx, c.base, "POST", fmt.Sprintf("/fallbackPath/%s/%s", url.PathEscape(a), pathEscapeSlice(b)), nil, nil, nil)
 	return err
 }
 
@@ -503,6 +510,11 @@ func (c *svcClient) Webhook(ctx context.Context, a string, b []string, request *
 	}
 
 	return c.base.Do(request)
+}
+
+func (c *svcClient) Webhook2(ctx context.Context, a string, b []string) error {
+	_, err := callAPI(ctx, c.base, "POST", fmt.Sprintf("/webhook2/%s/%s", url.PathEscape(a), pathEscapeSlice(b)), nil, nil, nil)
+	return err
 }
 
 type NestedType struct {

--- a/internal/clientgen/testdata/expected_javascript.js
+++ b/internal/clientgen/testdata/expected_javascript.js
@@ -104,6 +104,10 @@ class SvcServiceClient {
         await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
     }
 
+    async FallbackPath(a, b) {
+        await this.baseClient.callAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+    }
+
     async Get(params) {
         // Convert our params into the objects we need for the request
         const query = makeRecord({
@@ -212,6 +216,10 @@ class SvcServiceClient {
 
     async Webhook(method, a, b, body, options) {
         return this.baseClient.callAPI(method, `/webhook/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, body, options)
+    }
+
+    async Webhook2(a, b) {
+        await this.baseClient.callAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
     }
 }
 

--- a/internal/clientgen/testdata/expected_openapi.json
+++ b/internal/clientgen/testdata/expected_openapi.json
@@ -153,6 +153,78 @@
   },
   "openapi": "3.0.0",
   "paths": {
+    "/fallbackPath/{a}/{b}": {
+      "get": {
+        "operationId": "GET:svc.FallbackPath",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "a",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "b",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success response"
+          },
+          "default": {
+            "$ref": "#/components/responses/APIError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "POST:svc.FallbackPath",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "a",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "b",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success response"
+          },
+          "default": {
+            "$ref": "#/components/responses/APIError"
+          }
+        }
+      }
+    },
     "/path/{a}/{b}": {
       "get": {
         "operationId": "GET:svc.RESTPath",
@@ -1155,6 +1227,78 @@
       },
       "put": {
         "operationId": "PUT:svc.Webhook",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "a",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "b",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success response"
+          },
+          "default": {
+            "$ref": "#/components/responses/APIError"
+          }
+        }
+      }
+    },
+    "/webhook2/{a}/{b}": {
+      "get": {
+        "operationId": "GET:svc.Webhook2",
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "a",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          },
+          {
+            "allowEmptyValue": true,
+            "explode": false,
+            "in": "path",
+            "name": "b",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success response"
+          },
+          "default": {
+            "$ref": "#/components/responses/APIError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "POST:svc.Webhook2",
         "parameters": [
           {
             "allowEmptyValue": true,

--- a/internal/clientgen/testdata/expected_typescript.ts
+++ b/internal/clientgen/testdata/expected_typescript.ts
@@ -262,6 +262,10 @@ export namespace svc {
             await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
         }
 
+        public async FallbackPath(a: string, b: string[]): Promise<void> {
+            await this.baseClient.callAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+        }
+
         public async Get(params: GetRequest): Promise<void> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
@@ -370,6 +374,10 @@ export namespace svc {
 
         public async Webhook(method: string, a: string, b: string[], body?: BodyInit, options?: CallParameters): Promise<Response> {
             return this.baseClient.callAPI(method, `/webhook/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, body, options)
+        }
+
+        public async Webhook2(a: string, b: string[]): Promise<void> {
+            await this.baseClient.callAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
         }
     }
 }

--- a/internal/clientgen/testdata/input.go
+++ b/internal/clientgen/testdata/input.go
@@ -125,6 +125,13 @@ func RESTPath(ctx context.Context, a string, b int) error {
 //encore:api public raw path=/webhook/:a/*b
 func Webhook(w http.ResponseWriter, req *http.Request) {}
 
+
+//encore:api public path=/webhook2/:a/*b
+func Webhook2(ctx context.Context, a string, b string) error { return nil }
+
+//encore:api public path=/fallbackPath/:a/!b
+func FallbackPath(ctx context.Context, a string, b string) error { return nil }
+
 //encore:api public method=POST
 func RequestWithAllInputTypes(ctx context.Context, req *AllInputTypes[string]) (*AllInputTypes[float64], error) {
     return nil

--- a/runtimes/go/appruntime/apisdk/api/handler.go
+++ b/runtimes/go/appruntime/apisdk/api/handler.go
@@ -449,7 +449,6 @@ func (d *Desc[Req, Resp]) Call(c CallContext, req Req) (respData Resp, respErr e
 	// we'll make an internal call to the API
 	if c.server.static.Testing {
 		if mockedAPI, found := c.server.testingMgr.GetAPIMock(d.Service, d.Endpoint); found && mockedAPI.Function != nil {
-			fmt.Println("mocked API")
 			function, err := d.getMockFunction(mockedAPI)
 			if err != nil {
 				return respData, errs.Wrap(err, "unable to call mocked API due to an issue with the mock")

--- a/runtimes/go/appruntime/apisdk/api/handler.go
+++ b/runtimes/go/appruntime/apisdk/api/handler.go
@@ -501,6 +501,7 @@ func (d *Desc[Req, Resp]) getMockMethod(obj any) (reflectedAPIMethod[Req, Resp],
 		}
 
 		// Get the method
+		// nosemgrep
 		methodVal := val.MethodByName(d.Endpoint)
 		if !methodVal.IsValid() {
 			return nil, errs.B().Code(errs.Internal).Msgf("method %s not found on object %T", d.Endpoint, obj).Err()

--- a/runtimes/go/appruntime/apisdk/api/handler_test.go
+++ b/runtimes/go/appruntime/apisdk/api/handler_test.go
@@ -422,7 +422,8 @@ func testServer(t *testing.T, klock clock.Clock, mockTraces bool) (*api.Server, 
 	tsMgr := testsupport.NewManager(static, rt, logger)
 	pubsubMgr := pubsub.NewManager(static, runtime, rt, tsMgr, logger, json)
 	healthMgr := health.NewCheckRegistry()
-	server := api.NewServer(static, runtime, rt, nil, encoreMgr, pubsubMgr, logger, metricsRegistry, healthMgr, json, klock)
+	testingMgr := testsupport.NewManager(static, rt, logger)
+	server := api.NewServer(static, runtime, rt, nil, encoreMgr, pubsubMgr, logger, metricsRegistry, healthMgr, testingMgr, json, klock)
 	return server, traceMock, metricsRegistry
 }
 

--- a/runtimes/go/appruntime/apisdk/api/reflection.go
+++ b/runtimes/go/appruntime/apisdk/api/reflection.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"encore.dev/beta/errs"
+)
+
+var (
+	voidType    = reflect.TypeOf((*Void)(nil)).Elem()
+	contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errorType   = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+type reflectedAPIMethod[Req any, Resp any] func(ctx context.Context, req Req) (Resp, error)
+
+// createReflectionCaller takes a reflected function which should match the signature of an API method which is
+// described by the Req and Resp types, and returns a function which can be used to call that function using
+// the provided request and response types.
+//
+// It will return an error if the function does not match the expected signature.
+func createReflectionCaller[Req any, Resp any](function reflect.Value) (reflectedAPIMethod[Req, Resp], error) {
+	// Sanity check that the function is a function
+	if function.Kind() != reflect.Func {
+		return nil, errs.B().Code(errs.Internal).Msgf("expected a function, got %s", function.Kind()).Err()
+	}
+	typ := function.Type()
+
+	// Get the request type
+	requestType := reflect.TypeOf((*Req)(nil)).Elem()
+	if requestType.Kind() != reflect.Pointer {
+		return nil, errs.B().Code(errs.Internal).Msgf("expected request type to be a pointer, got %s", requestType.Kind()).Err()
+	}
+	requestType = requestType.Elem()
+	if requestType.Kind() != reflect.Struct {
+		return nil, errs.B().Code(errs.Internal).Msgf("expected request type to be a struct, got %s", requestType.Kind()).Err()
+	}
+
+	expectedNumInParams := 1 + requestType.NumField()
+
+	// Build up the list of parameters we expect in the order they should be passed to the function
+	expectedParamTypes := make([]reflect.Type, 1, expectedNumInParams)
+	paramFieldIndexes := make([]int, 1, expectedNumInParams)
+
+	// All API's must always have a context as the first parameter
+	expectedParamTypes[0] = contextType
+	paramFieldIndexes[0] = -1 // -1 means it's not a field on the request struct
+
+	// Now dynamically add the rest of the parameters both the payload and any path parameters
+	var payloadType reflect.Type
+	var payloadFieldIndex int
+	for i := 0; i < requestType.NumField(); i++ {
+		if requestType.Field(i).Name == "Payload" {
+			payloadType = requestType.Field(i).Type
+			payloadFieldIndex = i
+		} else {
+			expectedParamTypes = append(expectedParamTypes, requestType.Field(i).Type)
+			paramFieldIndexes = append(paramFieldIndexes, i)
+		}
+	}
+	if payloadType != nil {
+		expectedParamTypes = append(expectedParamTypes, payloadType)
+		paramFieldIndexes = append(paramFieldIndexes, payloadFieldIndex)
+	}
+
+	// Check the number of parameters is correct, if not return an error
+	numInParams := typ.NumIn()
+	if numInParams != expectedNumInParams {
+		expectedParams := make([]string, expectedNumInParams)
+		expectedParams[0] = "context.Context"
+		for i := 0; i < requestType.NumField(); i++ {
+			expectedParams[i+1] = requestType.Field(i).Type.String()
+		}
+
+		return nil, errs.B().Code(errs.Internal).Msgf("expected %d parameters (%s), got %d parameters", expectedNumInParams, strings.Join(expectedParams, ", "), numInParams).Err()
+	}
+
+	// Check all the parameters are of the correct type, if not return an error
+	for i, expected := range expectedParamTypes {
+		actual := typ.In(i)
+		if actual != expected {
+			return nil, errs.B().Code(errs.Internal).Msgf("expected parameter %d to be %s, got %s", i+1, expected, actual).Err()
+		}
+	}
+
+	// If Resp is of type Void, then we expect 1 return value, otherwise 2
+	responseType := reflect.TypeOf((*Resp)(nil)).Elem()
+	numReturnValues := typ.NumOut()
+	isVoidResponse := responseType == voidType
+	var errResponseIdx int
+
+	if isVoidResponse {
+		errResponseIdx = 0
+
+		if numReturnValues != 1 {
+			return nil, errs.B().Code(errs.Internal).Msgf("expected one return value (error), got %d return values", numReturnValues).Err()
+		}
+
+		if typ.Out(0) != errorType {
+			return nil, errs.B().Code(errs.Internal).Msgf("expected the return value to be an error, got %s", typ.Out(0)).Err()
+		}
+	} else {
+		errResponseIdx = 1
+
+		if numReturnValues != 2 {
+			return nil, errs.B().Code(errs.Internal).Msgf("expected two return values (%s, error), got %d return values", responseType, numReturnValues).Err()
+		}
+
+		if typ.Out(0) != responseType {
+			return nil, errs.B().Code(errs.Internal).Msgf("expected first return value to be %s, got %s", responseType, typ.Out(0)).Err()
+		}
+
+		if typ.Out(1) != errorType {
+			return nil, errs.B().Code(errs.Internal).Msgf("expected second return value to be an error, got %s", typ.Out(1)).Err()
+		}
+	}
+
+	return func(ctx context.Context, req Req) (respObj Resp, respErr error) {
+		inParams := make([]reflect.Value, 1, expectedNumInParams)
+		inParams[0] = reflect.ValueOf(ctx)
+
+		// If we have parameters on the request, then we need to pass them to the function
+		reqValue := reflect.ValueOf(req)
+		if !reqValue.IsNil() {
+			reqValue = reqValue.Elem() // deference the pointer that Encore always sets here
+
+			for i := 1; i < expectedNumInParams; i++ {
+				inParams = append(inParams, reqValue.Field(paramFieldIndexes[i]))
+			}
+		} else {
+			// If we don't have an `EncoreInteral_FoobarRequest` object, then we need to pass in the zero value for each
+			// parameter - this shouldn't happen as all Encore generated API calls will always pass in a request object
+			for i := 1; i < expectedNumInParams; i++ {
+				inParams = append(inParams, reflect.Zero(expectedParamTypes[i]))
+			}
+		}
+
+		outParams := function.Call(inParams)
+
+		// These two casts are safe because we've already checked the types above
+		respParam := outParams[0]
+		if !isVoidResponse && respParam.IsValid() && !respParam.IsZero() {
+			respObj = respParam.Interface().(Resp)
+		}
+
+		outErr := outParams[errResponseIdx]
+		if outErr.IsValid() && !outErr.IsZero() {
+			respErr = outErr.Interface().(error)
+		}
+		return
+	}, nil
+}

--- a/runtimes/go/appruntime/apisdk/api/reflection_test.go
+++ b/runtimes/go/appruntime/apisdk/api/reflection_test.go
@@ -1,0 +1,305 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func Test_createReflectionCaller(t *testing.T) {
+	c := qt.New(t)
+	c.Parallel()
+
+	c.Run("test parameter types are type checked", func(c *qt.C) {
+		c.Run("missing context param", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, Void](reflect.ValueOf(func() {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected 1 parameters \\(context.Context\\), got 0 parameters")
+		})
+
+		c.Run("context param is wrong type", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, Void](reflect.ValueOf(func(int) {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected parameter 1 to be context.Context, got int")
+		})
+
+		c.Run("missing parameter type", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreExampleParamsRequest, Void](reflect.ValueOf(func(context.Context) {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected 2 parameters \\(context.Context, \\*api.ExampleParams\\), got 1 parameters")
+		})
+
+		c.Run("parameter type is wrong", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreExampleParamsRequest, Void](reflect.ValueOf(func(context.Context, int) {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected parameter 2 to be \\*api.ExampleParams, got int")
+		})
+
+		c.Run("path params are type checks", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreExampleWithPathParams, Void](reflect.ValueOf(func(context.Context, *ExampleParams, string, int, []string) {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected parameter 2 to be string, got \\*api.ExampleParams")
+		})
+	})
+
+	c.Run("test response types are type checked", func(c *qt.C) {
+		c.Run("void api doesn't return error", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, Void](reflect.ValueOf(func(context.Context) {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected one return value \\(error\\), got 0 return values")
+		})
+
+		c.Run("void api returns too many values", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, Void](reflect.ValueOf(func(context.Context) (error, Void) { return nil, Void{} }))
+			c.Assert(err, qt.ErrorMatches, ".*expected one return value \\(error\\), got 2 return values")
+		})
+
+		c.Run("api returns nothing", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, *ExampleResponse](reflect.ValueOf(func(context.Context) {}))
+			c.Assert(err, qt.ErrorMatches, ".*expected two return values \\(\\*api.ExampleResponse, error\\), got 0 return values")
+		})
+
+		c.Run("api response type is wrong", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, *ExampleResponse](reflect.ValueOf(func(context.Context) (int, error) { return 0, nil }))
+			c.Assert(err, qt.ErrorMatches, ".*expected first return value to be \\*api.ExampleResponse, got int")
+		})
+
+		c.Run("api error type is wrong", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, *ExampleResponse](reflect.ValueOf(func(context.Context) (*ExampleResponse, int) { return nil, 0 }))
+			c.Assert(err, qt.ErrorMatches, ".*expected second return value to be an error, got int")
+		})
+
+		c.Run("api returns too many values", func(c *qt.C) {
+			c.Parallel()
+			_, err := createReflectionCaller[*EncoreEmptyReq, *ExampleResponse](reflect.ValueOf(func(context.Context) (*ExampleResponse, error, int) { return nil, nil, 0 }))
+			c.Assert(err, qt.ErrorMatches, ".*expected two return values \\(\\*api.ExampleResponse, error\\), got 3 return values")
+		})
+	})
+
+	c.Run("test calling the returned functions", func(c *qt.C) {
+		c.Run("basic api only returning an error", func(c *qt.C) {
+			c.Parallel()
+			called := false
+			shouldError := false
+
+			method, err := createReflectionCaller[*EncoreEmptyReq, Void](reflect.ValueOf(func(ctx context.Context) error {
+				if shouldError {
+					return errors.New("test error")
+				}
+				called = true
+				return nil
+			}))
+			c.Assert(err, qt.IsNil, qt.Commentf("unable to create the reflection caller"))
+
+			// Test the method works and actually gets called
+			resp, err := method(context.Background(), nil)
+			c.Assert(err, qt.IsNil, qt.Commentf("api should return no error"))
+			c.Assert(resp, qt.Equals, Void{}, qt.Commentf("api should return Void{}"))
+			c.Assert(called, qt.Equals, true, qt.Commentf("api should have been called"))
+
+			// Test the error is returned if the API errors
+			shouldError = true
+			resp, err = method(context.Background(), nil)
+			c.Assert(err, qt.ErrorMatches, "test error", qt.Commentf("api should return an error now"))
+		})
+
+		c.Run("api that takes parameters but returns nothing", func(c *qt.C) {
+			c.Parallel()
+			calledWith := "<not called>"
+
+			method, err := createReflectionCaller[*EncoreExampleParamsRequest, Void](reflect.ValueOf(func(ctx context.Context, params *ExampleParams) error {
+				if params.Param2 == "error" {
+					return errors.New(params.Param1)
+				}
+
+				calledWith = params.Param1
+				return nil
+			}))
+			c.Assert(err, qt.IsNil, qt.Commentf("unable to create the reflection caller"))
+
+			// Test the method works and actually gets called
+			resp, err := method(context.Background(), &EncoreExampleParamsRequest{
+				Payload: &ExampleParams{
+					Param1: "this value",
+					Param2: "ignored",
+				},
+			})
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.Equals, Void{}, qt.Commentf("api should return Void{}"))
+			c.Assert(calledWith, qt.Equals, "this value", qt.Commentf("api should have been called with the correct value"))
+
+			// Test the error is returned if the API errors
+			resp, err = method(context.Background(), &EncoreExampleParamsRequest{
+				Payload: &ExampleParams{
+					Param1: "my amazing error message",
+					Param2: "error",
+				},
+			})
+			c.Assert(err, qt.ErrorMatches, "my amazing error message", qt.Commentf("api should return an error now"))
+		})
+
+		c.Run("api that takes path parameters", func(c *qt.C) {
+			c.Parallel()
+
+			calledWith := "<not called>"
+			method, err := createReflectionCaller[*EncoreExampleWithPathParams, Void](reflect.ValueOf(func(ctx context.Context, name string, age int, tags []string, params *ExampleParams) error {
+				calledWith = fmt.Sprintf("%s - %s=%d %v", params.Param1, name, age, tags)
+				return nil
+			}))
+			c.Assert(err, qt.IsNil, qt.Commentf("unable to create the reflection caller"))
+
+			// Test the method works and actually gets called
+			resp, err := method(context.Background(), &EncoreExampleWithPathParams{
+				Payload: &ExampleParams{
+					Param1: "this value",
+					Param2: "ignored",
+				},
+				P0: "first param",
+				P1: 1337,
+				P2: []string{"a", "b", "c"},
+			})
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.Equals, Void{}, qt.Commentf("api should return Void{}"))
+			c.Assert(calledWith, qt.Equals, "this value - first param=1337 [a b c]", qt.Commentf("api should have been called with the correct value"))
+		})
+
+		c.Run("api that returns a response", func(c *qt.C) {
+			c.Parallel()
+
+			returnNil := false
+			returnErr := false
+			method, err := createReflectionCaller[*EncoreEmptyReq, *ExampleResponse](reflect.ValueOf(func(ctx context.Context) (*ExampleResponse, error) {
+				if returnErr {
+					return nil, errors.New("test error")
+				}
+				if returnNil {
+					return nil, nil
+				}
+				return &ExampleResponse{Value: "hello"}, nil
+			}))
+			c.Assert(err, qt.IsNil, qt.Commentf("unable to create the reflection caller"))
+
+			// Test the method works and actually gets called
+			resp, err := method(context.Background(), nil)
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.DeepEquals, &ExampleResponse{Value: "hello"}, qt.Commentf("api should return the correct response"))
+
+			// Test nil, nil is handled correctly
+			returnNil = true
+			resp, err = method(context.Background(), nil)
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.IsNil, qt.Commentf("api should return nil"))
+
+			// Test error is returned correctly
+			returnErr = true
+			resp, err = method(context.Background(), nil)
+			c.Assert(err, qt.ErrorMatches, "test error", qt.Commentf("api should return an error"))
+			c.Assert(resp, qt.IsNil, qt.Commentf("api should return nil"))
+		})
+
+		c.Run("test receiver methods work too", func(c *qt.C) {
+			c.Parallel()
+
+			obj := &ExampleMockService{value: "hello", calledWith: "<not called>"}
+			method, err := createReflectionCaller[*EncoreExampleParamsRequest, *ExampleResponse](reflect.ValueOf(obj.ExampleMethod))
+			c.Assert(err, qt.IsNil, qt.Commentf("unable to create the reflection caller"))
+
+			// Test the method works and actually gets called, and can reference the struct instance
+			resp, err := method(context.Background(), &EncoreExampleParamsRequest{
+				Payload: &ExampleParams{
+					Param1: "this value",
+					Param2: "ignored",
+				},
+			})
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.DeepEquals, &ExampleResponse{Value: "hello"}, qt.Commentf("api should return the correct response"))
+			c.Assert(obj.calledWith, qt.Equals, "this value - ignored", qt.Commentf("api should have been called with the correct value"))
+
+			// Test nil, nil is handled correctly
+			resp, err = method(context.Background(), &EncoreExampleParamsRequest{Payload: &ExampleParams{
+				Param1: "foobar",
+				Param2: "nil",
+			}})
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.IsNil, qt.Commentf("api should return nil"))
+			c.Assert(obj.calledWith, qt.Equals, "foobar - nil", qt.Commentf("api should have been called with the correct value"))
+
+			// Test error is returned correctly
+			resp, err = method(context.Background(), &EncoreExampleParamsRequest{Payload: &ExampleParams{
+				Param1: "error",
+				Param2: "test error value",
+			}})
+			c.Assert(err, qt.ErrorMatches, "test error value", qt.Commentf("api should return an error"))
+			c.Assert(resp, qt.IsNil, qt.Commentf("api should return nil"))
+			c.Assert(obj.calledWith, qt.Equals, "error - test error value", qt.Commentf("api should have been called with the correct value"))
+
+			// Test nil request is handled correctly
+			resp, err = method(context.Background(), &EncoreExampleParamsRequest{Payload: nil})
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.DeepEquals, &ExampleResponse{Value: "you gave me nil!"}, qt.Commentf("api should return the correct response"))
+			c.Assert(obj.calledWith, qt.Equals, "got nil", qt.Commentf("api should have been called with the correct value"))
+
+			// And finally test a nil Encore internal param is handled correctly
+			obj.calledWith = "<not called>"
+			resp, err = method(context.Background(), nil)
+			c.Assert(err, qt.IsNil, qt.Commentf("didn't expect an error form the api"))
+			c.Assert(resp, qt.DeepEquals, &ExampleResponse{Value: "you gave me nil!"}, qt.Commentf("api should return the correct response"))
+			c.Assert(obj.calledWith, qt.Equals, "got nil", qt.Commentf("api should have been called with the correct value"))
+		})
+	})
+}
+
+type ExampleMockService struct {
+	value      string
+	calledWith string
+}
+
+func (e *ExampleMockService) ExampleMethod(_ context.Context, p *ExampleParams) (*ExampleResponse, error) {
+	if p == nil {
+		e.calledWith = "got nil"
+		return &ExampleResponse{Value: "you gave me nil!"}, nil
+	}
+
+	e.calledWith = fmt.Sprintf("%s - %s", p.Param1, p.Param2)
+
+	if p.Param1 == "error" {
+		return nil, errors.New(p.Param2)
+	} else if p.Param2 == "nil" {
+		return nil, nil
+	}
+	return &ExampleResponse{Value: e.value}, nil
+}
+
+type EncoreEmptyReq struct{}
+
+type EncoreExampleParamsRequest struct {
+	Payload *ExampleParams
+}
+
+// Note: this is how Encore generates the request struct for an API
+//
+// The parameter type is always called `Payload` and placed first
+// then each path parameter is added in order after that
+type EncoreExampleWithPathParams struct {
+	Payload *ExampleParams
+	P0      string
+	P1      int
+	P2      []string
+}
+
+type ExampleParams struct {
+	Param1 string
+	Param2 string
+}
+
+type ExampleResponse struct {
+	Value string
+}

--- a/runtimes/go/appruntime/apisdk/api/registry.go
+++ b/runtimes/go/appruntime/apisdk/api/registry.go
@@ -4,8 +4,8 @@ package api
 
 import "reflect"
 
-func RegisterEndpoint(handler Handler) {
-	Singleton.registerEndpoint(handler)
+func RegisterEndpoint(handler Handler, function any) {
+	Singleton.registerEndpoint(handler, function)
 }
 
 func RegisterAuthHandler(handler AuthHandler) {

--- a/runtimes/go/appruntime/apisdk/api/server.go
+++ b/runtimes/go/appruntime/apisdk/api/server.go
@@ -312,14 +312,14 @@ func (s *Server) registerEndpoint(h Handler, function any) {
 		}
 	}
 
-	// Register the function mapped to the handler - this allows `et.MockAPI` to lookup the Handler
+	// Register the function mapped to the handler - this allows `et.MockEndpoint` to lookup the Handler
 	// for a given function
-	if reflect.TypeOf(function).Kind() == reflect.Func {
-		// reflect.TypeOf(function).PkgPath()
-		// reflect.TypeOf(function).Name()
-		s.functionsToHandlers[reflect.ValueOf(function).Pointer()] = h
-	} else {
-		s.rootLogger.Warn().Str("service", h.ServiceName()).Str("endpoint", h.EndpointName()).Msgf("not registering function as lookup for API handler as it is not a function: %T", function)
+	if s.static.Testing {
+		if reflect.TypeOf(function).Kind() == reflect.Func {
+			s.functionsToHandlers[reflect.ValueOf(function).Pointer()] = h
+		} else {
+			s.rootLogger.Warn().Str("service", h.ServiceName()).Str("endpoint", h.EndpointName()).Msgf("not registering function as lookup for API handler as it is not a function: %T", function)
+		}
 	}
 }
 

--- a/runtimes/go/appruntime/apisdk/api/singleton.go
+++ b/runtimes/go/appruntime/apisdk/api/singleton.go
@@ -12,6 +12,7 @@ import (
 	"encore.dev/appruntime/shared/logging"
 	"encore.dev/appruntime/shared/platform"
 	"encore.dev/appruntime/shared/reqtrack"
+	"encore.dev/appruntime/shared/testsupport"
 	"encore.dev/metrics"
 	"encore.dev/pubsub"
 )
@@ -19,6 +20,6 @@ import (
 var Singleton = NewServer(
 	appconf.Static, appconf.Runtime, reqtrack.Singleton, platform.Singleton,
 	encore.Singleton, pubsub.Singleton, logging.RootLogger, metrics.Singleton,
-	health.Singleton,
+	health.Singleton, testsupport.Singleton,
 	jsonapi.Default, clock.New(),
 )

--- a/runtimes/go/appruntime/exported/model/request.go
+++ b/runtimes/go/appruntime/exported/model/request.go
@@ -137,13 +137,39 @@ type TestData struct {
 	Current *testing.T         // The current test running
 	Parent  *Request           // The parent request (if we're looking at sub-tests)
 	Service string             // the service being tested, if any
+	Config  *TestConfig        // The test config (should always be set) and managed by the testsupport Manager
 
 	// UserID and AuthData are the test-level auth information,
 	// if overridden.
 	UserID   UID
 	AuthData any
 
+	ServiceInstancesMu sync.Mutex
+	ServiceInstances   map[string]any // The service instances isolated to this test
+
 	Wait sync.WaitGroup // If we're spun up async go routines, this wait allows to the test to wait for them to end
+}
+
+// TestConfig contains configuration for testing,
+//
+// It can either be the global test config, or a per-test config.
+type TestConfig struct {
+	// The parent test config, if any.
+	//
+	// If this is not set, then this test config exists at the global level.
+	Parent *TestConfig
+
+	// Lock for the below fields
+	Mu sync.RWMutex
+
+	ServiceMocks     map[string]any // The service mocks we want to use
+	APIMocks         map[string]map[string]ApiMock
+	IsolatedServices *bool // Whether to isolate services for this test
+}
+
+type ApiMock struct {
+	ID       uint64
+	Function any
 }
 
 type Response struct {

--- a/runtimes/go/appruntime/shared/testsupport/testconfig.go
+++ b/runtimes/go/appruntime/shared/testsupport/testconfig.go
@@ -1,0 +1,44 @@
+package testsupport
+
+import (
+	"sync/atomic"
+
+	"encore.dev/appruntime/exported/model"
+)
+
+type TestConfig = model.TestConfig
+
+var (
+	nextApiMockID atomic.Uint64
+)
+
+func newTestConfig(parent *model.TestConfig) *model.TestConfig {
+	return &model.TestConfig{
+		Parent:       parent,
+		ServiceMocks: make(map[string]any),
+		APIMocks:     make(map[string]map[string]model.ApiMock),
+	}
+}
+
+// walkConfig walks the test config hierarchy, starting from the given config, and calls the given function on each
+// until the function returns true.
+//
+// walkConfig takes care to lock and unlock the read mutex on the config hierarchy as it walks it.
+func walkConfig[T any](config *model.TestConfig, f func(*model.TestConfig) (value T, found bool)) (value T, found bool) {
+	exec := func(config *model.TestConfig) (value T, found bool) {
+		config.Mu.RLock()
+		defer config.Mu.RUnlock()
+		return f(config)
+	}
+
+	for config != nil {
+		value, found := exec(config)
+		if found {
+			return value, found
+		}
+
+		config = config.Parent
+	}
+
+	return value, false
+}

--- a/runtimes/go/et/manager_internal.go
+++ b/runtimes/go/et/manager_internal.go
@@ -1,17 +1,21 @@
 package et
 
 import (
+	"encore.dev/appruntime/apisdk/api"
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/shared/reqtrack"
+	"encore.dev/appruntime/shared/testsupport"
 )
 
 //publicapigen:drop
 type Manager struct {
-	static *config.Static
-	rt     *reqtrack.RequestTracker
+	static  *config.Static
+	rt      *reqtrack.RequestTracker
+	testMgr *testsupport.Manager
+	server  *api.Server
 }
 
 //publicapigen:drop
-func NewManager(static *config.Static, rt *reqtrack.RequestTracker) *Manager {
-	return &Manager{static, rt}
+func NewManager(static *config.Static, rt *reqtrack.RequestTracker, testMgr *testsupport.Manager, server *api.Server) *Manager {
+	return &Manager{static, rt, testMgr, server}
 }

--- a/runtimes/go/et/mocking.go
+++ b/runtimes/go/et/mocking.go
@@ -1,0 +1,69 @@
+//go:build encore_app
+
+package et
+
+import (
+	"fmt"
+)
+
+// MockAPI allows you to mock out an API in your tests; Any calls made to the API
+// during this test or any of its sub-tests will be routed to the mock you provide.
+//
+// Your mocked function must match the signature of the API you are mocking.
+//
+// For example, if you have an API defined as:
+//
+//	//encore:api public
+//	func MyAPI(ctx context.Context, req *MyAPIRequest) (*MyAPIResponse, error) {
+//		...
+//	}
+//
+// You can mock it out in your test as:
+//
+//	et.MockAPI("mysvc", "MyAPI", func(ctx context.Context, req *MyAPIRequest) (*MyAPIResponse, error) {
+//		...
+//	})
+//
+// Note: if you use [MockService] to mock a service and then use this function to mock
+// an API on that service, the API mock will take precedence over the service mock.
+//
+// Setting the mock to nil will remove the API mock
+func MockAPI(serviceName string, apiName string, mock any) {
+	if !Singleton.server.EndpointExists(serviceName, apiName) {
+		panic(fmt.Sprintf("cannot mock API %s.%s: API does not exist", serviceName, apiName))
+	}
+
+	Singleton.testMgr.SetAPIMock(serviceName, apiName, mock)
+}
+
+// MockService allows you to mock out a service in your tests; Any calls made to the service
+// during this test or any of its sub-tests will be routed to the mock you provide.
+//
+// Your mock must implement the all the API methods of the service which are used during the
+// test(s). If you do not implement a method, it will panic when that method is called.
+//
+// If you want to ensure compile time safety, you can use the Interface type generated for
+// the service, which will ensure that you implement all the methods. For example:
+//
+//	package svca
+//
+//	import (
+//		"testing"
+//		"encore.dev/et"
+//
+//		"encore.app/svcb"
+//	)
+//
+//	func TestServiceA(t *testing.T) {
+//		et.MockService[svcb.Interface]("svcb", &myMockType{})
+//		SomeFuncInThisPackageWhichUltimatelyCallsServiceB()
+//	}
+//
+// Setting the mock to nil will remove the service mock
+func MockService[T any](serviceName string, mock T) {
+	if !Singleton.server.ServiceExists(serviceName) {
+		panic(fmt.Sprintf("cannot mock service %s: service does not exist", serviceName))
+	}
+
+	Singleton.testMgr.SetServiceMock(serviceName, mock)
+}

--- a/runtimes/go/et/pkgfn.go
+++ b/runtimes/go/et/pkgfn.go
@@ -26,3 +26,16 @@ import (
 func OverrideAuthInfo(uid auth.UID, data any) {
 	Singleton.OverrideAuthInfo(uid, data)
 }
+
+// EnableServiceInstanceIsolation will causes all Service singletons to be isolated to each test
+// from this test and on any of its sub-tests. (Calling this in a TestMain has the impact
+// of isolating all tests in the package.)
+//
+// By default, Service singletons are shared across all tests and initialized on
+// the first call to that service by any test, which results in faster tests as you
+// are not re-initializing the service for each test, however if your service structs
+// contain state that is not reset between tests, this can cause issues. In that case,
+// you can call this function to isolate the services for the impacted tests.
+func EnableServiceInstanceIsolation() {
+	Singleton.testMgr.SetIsolatedServices(true)
+}

--- a/runtimes/go/et/singleton_internal.go
+++ b/runtimes/go/et/singleton_internal.go
@@ -3,9 +3,11 @@
 package et
 
 import (
+	"encore.dev/appruntime/apisdk/api"
 	"encore.dev/appruntime/shared/appconf"
 	"encore.dev/appruntime/shared/reqtrack"
+	"encore.dev/appruntime/shared/testsupport"
 )
 
 //publicapigen:drop
-var Singleton = NewManager(appconf.Static, reqtrack.Singleton)
+var Singleton = NewManager(appconf.Static, reqtrack.Singleton, testsupport.Singleton, api.Singleton)

--- a/v2/app/validate_apis.go
+++ b/v2/app/validate_apis.go
@@ -97,6 +97,11 @@ func (d *Desc) validateAPIs(pc *parsectx.Context, fw *apiframework.AppDesc, resu
 			for _, usage := range result.Usages(ep) {
 				switch usage := usage.(type) {
 				case *api.ReferenceUsage:
+					if usage.File.TestFile {
+						// Ignore test files as we allow the MockAPI function to reference the API
+						continue
+					}
+
 					// API's can only be referenced
 					isValid := result.ResourceConstructorContaining(usage).Contains(func(res resource.Resource) bool {
 						switch res := res.(type) {

--- a/v2/app/validate_servicestructs.go
+++ b/v2/app/validate_servicestructs.go
@@ -20,7 +20,7 @@ func (d *Desc) validateServiceStructs(pc *parsectx.Context, result *parser.Resul
 						refText = fmt.Sprintf("referenced in service %q", useSvc.Name)
 					}
 
-					if !use.DeclaredIn().FSPath.HasPrefix(svc.FSRoot) {
+					if !use.DeclaredIn().FSPath.HasPrefix(svc.FSRoot) && !use.DeclaredIn().TestFile {
 						pc.Errs.Add(
 							servicestruct.ErrServiceStructReferencedInAnotherService.
 								AtGoNode(use, errors.AsError(refText)).

--- a/v2/codegen/apigen/endpointgen/endpointgen.go
+++ b/v2/codegen/apigen/endpointgen/endpointgen.go
@@ -132,9 +132,11 @@ func registerHandlers(appDesc *app.Desc, file *codegen.File, handlers []*handler
 	f := file.Jen
 	f.Func().Id("init").Params().BlockFunc(func(g *Group) {
 		for _, h := range handlers {
-			g.Qual("encore.dev/appruntime/apisdk/api", "RegisterEndpoint").Call(
-				h.desc.Qual(),
-			)
+			g.Qual("encore.dev/appruntime/apisdk/api", "RegisterEndpoint").CallFunc(func(g *Group) {
+				g.Add(h.desc.Qual())
+
+				g.Add(Id(h.ep.Name))
+			})
 		}
 	})
 }

--- a/v2/codegen/apigen/endpointgen/request.go
+++ b/v2/codegen/apigen/endpointgen/request.go
@@ -36,6 +36,9 @@ func (d *requestDesc) TypeDecl() *Statement {
 		if d.ep.Request != nil {
 			g.Id(d.reqDataPayloadName()).Add(d.gu.Type(d.ep.Request))
 		}
+		// Note: the path parameter order is important and must match the order of the segments as defined
+		// as the parameters of the user's endpoint function. This behaviour is expected by the mocking
+		// system - see runtimes/go/appruntime/apisdk/api/reflection.go.
 		for i, seg := range d.ep.Path.Params() {
 			g.Id(d.pathParamFieldName(i)).Add(d.gu.Builtin(d.ep.Decl.AST.Pos(), seg.ValueType))
 		}
@@ -156,6 +159,8 @@ func (d *requestDesc) reqDataExpr() *Statement {
 
 // reqDataPayloadName returns the name of the payload field in the reqData struct.
 func (d *requestDesc) reqDataPayloadName() string {
+	// Note: this hardcoded value is used by reflection during mocking.
+	// If you change this, update runtimes/go/appruntime/apisdk/api/reflection.go as well.
 	return "Payload"
 }
 

--- a/v2/codegen/apigen/endpointgen/testdata/api_call.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/api_call.txt
@@ -26,14 +26,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 

--- a/v2/codegen/apigen/endpointgen/testdata/api_call.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/api_call.txt
@@ -20,9 +20,25 @@ func Baz(ctx context.Context) error { return svca.Foo(ctx) }
 
 package svca
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+
+	Bar(ctx context.Context) error
+}
 -- want:svca/encore_internal__api.go --
 package svca
 
@@ -35,8 +51,8 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Bar)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Bar, Bar)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/api_call_servicestruct.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/api_call_servicestruct.txt
@@ -34,6 +34,18 @@ func Foo(ctx context.Context) error {
 	}
 	return svc.Foo(ctx)
 }
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:svca/encore_internal__api.go --
 package svca
 
@@ -46,7 +58,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/api_call_servicestruct.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/api_call_servicestruct.txt
@@ -35,14 +35,10 @@ func Foo(ctx context.Context) error {
 	return svc.Foo(ctx)
 }
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/basic.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/basic.txt
@@ -11,9 +11,23 @@ func Foo(ctx context.Context) error { return nil }
 
 package basic
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:encore_internal__api.go --
 package basic
 
@@ -26,7 +40,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/basic.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/basic.txt
@@ -17,14 +17,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/complex_omitempty.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/complex_omitempty.txt
@@ -29,14 +29,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, p *Params) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/complex_omitempty.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/complex_omitempty.txt
@@ -23,9 +23,23 @@ func Foo(ctx context.Context, p *Params) error { return nil }
 
 package basic
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, p *Params) error
+}
 -- want:encore_internal__api.go --
 package basic
 
@@ -40,7 +54,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/fallback_path.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/fallback_path.txt
@@ -10,9 +10,23 @@ func Foo(ctx context.Context, fallback string) error { return nil }
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, fallback string) error
+}
 -- want:encore_internal__api.go --
 package code
 
@@ -27,7 +41,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/fallback_path.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/fallback_path.txt
@@ -16,14 +16,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, fallback string) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/path_params.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/path_params.txt
@@ -22,14 +22,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, id int, baz string, p *Params) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/path_params.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/path_params.txt
@@ -16,9 +16,23 @@ func Foo(ctx context.Context, id int, baz string, p *Params) error { return nil 
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, id int, baz string, p *Params) error
+}
 -- want:encore_internal__api.go --
 package code
 
@@ -33,7 +47,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/raw_endpoint.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/raw_endpoint.txt
@@ -29,14 +29,10 @@ func Bar(ctx context.Context, req *http.Request) (*http.Response, error) {
 	return nil, errors.New("encore: calling raw endpoints is not yet supported")
 }
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface{}
 -- want:encore_internal__api.go --
 package code

--- a/v2/codegen/apigen/endpointgen/testdata/raw_endpoint.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/raw_endpoint.txt
@@ -28,6 +28,16 @@ import (
 func Bar(ctx context.Context, req *http.Request) (*http.Response, error) {
 	return nil, errors.New("encore: calling raw endpoints is not yet supported")
 }
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface{}
 -- want:encore_internal__api.go --
 package code
 
@@ -40,8 +50,8 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Bar)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Bar, Bar)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/recursive.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/recursive.txt
@@ -28,9 +28,23 @@ func Foo(ctx context.Context, p *Recursive) (*Recursive, error) { return p, nil 
 
 package basic
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, p *Recursive) (*Recursive, error)
+}
 -- want:encore_internal__api.go --
 package basic
 
@@ -46,7 +60,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/recursive.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/recursive.txt
@@ -34,14 +34,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, p *Recursive) (*Recursive, error)
 }

--- a/v2/codegen/apigen/endpointgen/testdata/request_headers.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/request_headers.txt
@@ -17,9 +17,23 @@ func Foo(ctx context.Context, p *Params) error { return nil }
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, p *Params) error
+}
 -- want:encore_internal__api.go --
 package code
 
@@ -34,7 +48,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/request_headers.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/request_headers.txt
@@ -23,14 +23,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, p *Params) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/request_params.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/request_params.txt
@@ -17,9 +17,23 @@ func Foo(ctx context.Context, p *Params) error { return nil }
 
 package basic
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, p *Params) error
+}
 -- want:encore_internal__api.go --
 package basic
 
@@ -34,7 +48,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/request_params.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/request_params.txt
@@ -23,14 +23,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, p *Params) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/request_query.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/request_query.txt
@@ -17,9 +17,23 @@ func Foo(ctx context.Context, p *Params) error { return nil }
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context, p *Params) error
+}
 -- want:encore_internal__api.go --
 package code
 
@@ -33,7 +47,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct {

--- a/v2/codegen/apigen/endpointgen/testdata/request_query.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/request_query.txt
@@ -23,14 +23,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context, p *Params) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/response_headers.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/response_headers.txt
@@ -16,9 +16,23 @@ func Foo(ctx context.Context) (*Params, error) { return nil, nil }
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) (*Params, error)
+}
 -- want:encore_internal__api.go --
 package code
 
@@ -32,7 +46,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/response_headers.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/response_headers.txt
@@ -22,14 +22,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) (*Params, error)
 }

--- a/v2/codegen/apigen/endpointgen/testdata/response_params.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/response_params.txt
@@ -16,9 +16,23 @@ func Foo(ctx context.Context) (*Params, error) { return nil, nil }
 
 package basic
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) (*Params, error)
+}
 -- want:encore_internal__api.go --
 package basic
 
@@ -34,7 +48,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/response_params.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/response_params.txt
@@ -22,14 +22,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) (*Params, error)
 }

--- a/v2/codegen/apigen/endpointgen/testdata/service_struct.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/service_struct.txt
@@ -27,14 +27,10 @@ func Foo(ctx context.Context) error {
 	return svc.Foo(ctx)
 }
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/endpointgen/testdata/service_struct.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/service_struct.txt
@@ -26,6 +26,18 @@ func Foo(ctx context.Context) error {
 	}
 	return svc.Foo(ctx)
 }
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:encore_internal__api.go --
 package basic
 
@@ -38,7 +50,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/endpointgen/testdata/unexported.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/unexported.txt
@@ -21,14 +21,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) (*Response, error)
 }

--- a/v2/codegen/apigen/endpointgen/testdata/unexported.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/unexported.txt
@@ -15,9 +15,23 @@ func Foo(ctx context.Context) (*Response, error) { return nil, nil }
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) (*Response, error)
+}
 -- want:encore_internal__api.go --
 package code
 
@@ -33,7 +47,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/maingen/testdata/auth_handler.txt
+++ b/v2/codegen/apigen/maingen/testdata/auth_handler.txt
@@ -24,14 +24,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/maingen/testdata/auth_handler.txt
+++ b/v2/codegen/apigen/maingen/testdata/auth_handler.txt
@@ -18,9 +18,23 @@ func AuthHandler(context.Context, string) (auth.UID, *MyAuthData, error) {
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:encore_internal/main/main.go --
 package main
 
@@ -44,7 +58,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/maingen/testdata/basic.txt
+++ b/v2/codegen/apigen/maingen/testdata/basic.txt
@@ -10,9 +10,23 @@ func Foo(ctx context.Context) error { return nil }
 
 package code
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:encore_internal/main/main.go --
 package main
 
@@ -36,7 +50,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/maingen/testdata/basic.txt
+++ b/v2/codegen/apigen/maingen/testdata/basic.txt
@@ -16,14 +16,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/maingen/testdata/multiple_services.txt
+++ b/v2/codegen/apigen/maingen/testdata/multiple_services.txt
@@ -17,9 +17,23 @@ func Bar(ctx context.Context) error { return nil }
 
 package bar
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Bar(ctx context.Context) error
+}
 -- want:bar/encore_internal__api.go --
 package bar
 
@@ -32,7 +46,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Bar)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Bar, Bar)
 }
 
 type EncoreInternal_BarReq struct{}
@@ -114,9 +128,23 @@ func main() {
 
 package foo
 
+import "context"
+
 // These functions are automatically generated and maintained by Encore
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:foo/encore_internal__api.go --
 package foo
 
@@ -129,7 +157,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/maingen/testdata/multiple_services.txt
+++ b/v2/codegen/apigen/maingen/testdata/multiple_services.txt
@@ -23,14 +23,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Bar(ctx context.Context) error
 }
@@ -134,14 +130,10 @@ import "context"
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/maingen/testdata/service_struct.txt
+++ b/v2/codegen/apigen/maingen/testdata/service_struct.txt
@@ -29,6 +29,18 @@ func Foo(ctx context.Context) error {
 	}
 	return svc.Foo(ctx)
 }
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	Foo(ctx context.Context) error
+}
 -- want:encore_internal/main/main.go --
 package main
 
@@ -52,7 +64,7 @@ import (
 )
 
 func init() {
-	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo)
+	__api.RegisterEndpoint(EncoreInternal_api_APIDesc_Foo, Foo)
 }
 
 type EncoreInternal_FooReq struct{}

--- a/v2/codegen/apigen/maingen/testdata/service_struct.txt
+++ b/v2/codegen/apigen/maingen/testdata/service_struct.txt
@@ -30,14 +30,10 @@ func Foo(ctx context.Context) error {
 	return svc.Foo(ctx)
 }
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	Foo(ctx context.Context) error
 }

--- a/v2/codegen/apigen/userfacinggen/testdata/service_struct.txt
+++ b/v2/codegen/apigen/userfacinggen/testdata/service_struct.txt
@@ -6,6 +6,8 @@ import ("context"; "net/http")
 //encore:service
 type Service struct{}
 
+// Foo is an amazing API which does
+// x, y and z - it's really cool!
 //encore:api public
 func (s *Service) Foo(ctx context.Context) error { return nil }
 
@@ -23,6 +25,17 @@ func (s *Service) WithResp(context.Context) (*Data, error) { return nil, nil }
 //encore:api public
 func (s *Service) WithReqResp(context.Context, *Data) (*Data, error) { return nil, nil }
 
+//encore:api public path=/pathing/:name/:age/*other
+func (s *Service) WithPathParams(ctx context.Context, name string, age int, other string) error { return nil }
+
+//encore:api public path=/fallback/!url
+func (s *Service) WithFallback(ctx context.Context, url string) error { return nil }
+
+// This API doesn't
+// exist on the service struct, but should still
+// appear
+//
+// on the service Interface
 //encore:api public
 func NoServiceStruct(context.Context) error { return nil }
 -- want:encore.gen.go --
@@ -40,6 +53,8 @@ import (
 // to simplify calling them from other services, as they were implemented as methods.
 // They are automatically updated by Encore whenever your API endpoints change.
 
+// Foo is an amazing API which does
+// x, y and z - it's really cool!
 func Foo(ctx context.Context) error {
 	svc, err := EncoreInternal_svcstruct_Service.Get()
 	if err != nil {
@@ -74,6 +89,53 @@ func WithReqResp(ctx context.Context, p *Data) (*Data, error) {
 		return (*Data)(nil), err
 	}
 	return svc.WithReqResp(ctx, p)
+}
+
+func WithPathParams(ctx context.Context, name string, age int, other string) error {
+	svc, err := EncoreInternal_svcstruct_Service.Get()
+	if err != nil {
+		return err
+	}
+	return svc.WithPathParams(ctx, name, age, other)
+}
+
+func WithFallback(ctx context.Context, url string) error {
+	svc, err := EncoreInternal_svcstruct_Service.Get()
+	if err != nil {
+		return err
+	}
+	return svc.WithFallback(ctx, url)
+}
+
+// Interface represents the entire API service area for this service; both API's defined as
+// methods on the service struct, and API's defined as package functions.
+//
+// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
+// within an Encore application.
+//
+// Currently this interface exists to allow you to generate mocks for the entire service, using
+// your favorite mocking library.
+type Interface interface {
+	// Foo is an amazing API which does
+	// x, y and z - it's really cool!
+	Foo(ctx context.Context) error
+
+	WithReq(ctx context.Context, p *Data) error
+
+	WithResp(ctx context.Context) (*Data, error)
+
+	WithReqResp(ctx context.Context, p *Data) (*Data, error)
+
+	WithPathParams(ctx context.Context, name string, age int, other string) error
+
+	WithFallback(ctx context.Context, url string) error
+
+	// This API doesn't
+	// exist on the service struct, but should still
+	// appear
+	//
+	// on the service Interface
+	NoServiceStruct(ctx context.Context) error
 }
 -- want:encore_internal__svcstruct.go --
 package basic

--- a/v2/codegen/apigen/userfacinggen/testdata/service_struct.txt
+++ b/v2/codegen/apigen/userfacinggen/testdata/service_struct.txt
@@ -107,14 +107,10 @@ func WithFallback(ctx context.Context, url string) error {
 	return svc.WithFallback(ctx, url)
 }
 
-// Interface represents the entire API service area for this service; both API's defined as
-// methods on the service struct, and API's defined as package functions.
+// Interface defines the service's API surface area, primarily for mocking purposes.
 //
-// Note: Raw endpoints are not included in this interface, as calls to them are not supported from
-// within an Encore application.
-//
-// Currently this interface exists to allow you to generate mocks for the entire service, using
-// your favorite mocking library.
+// Raw endpoints are currently excluded from this interface, as Encore does not yet
+// support service-to-service API calls to raw endpoints.
 type Interface interface {
 	// Foo is an amazing API which does
 	// x, y and z - it's really cool!

--- a/v2/codegen/apigen/userfacinggen/userfacinggen.go
+++ b/v2/codegen/apigen/userfacinggen/userfacinggen.go
@@ -50,14 +50,10 @@ func genUserFacing(gen *codegen.Generator, svc *apiframework.ServiceDesc, withIm
 
 	// Generate the service interface (this is useful for mocking)
 	if len(svc.Endpoints) > 0 {
-		f.Jen.Comment("Interface represents the entire API service area for this service; both API's defined as")
-		f.Jen.Comment("methods on the service struct, and API's defined as package functions.")
+		f.Jen.Comment("Interface defines the service's API surface area, primarily for mocking purposes.")
 		f.Jen.Comment("")
-		f.Jen.Comment("Note: Raw endpoints are not included in this interface, as calls to them are not supported from")
-		f.Jen.Comment("within an Encore application.")
-		f.Jen.Comment("")
-		f.Jen.Comment("Currently this interface exists to allow you to generate mocks for the entire service, using")
-		f.Jen.Comment("your favorite mocking library.")
+		f.Jen.Comment("Raw endpoints are currently excluded from this interface, as Encore does not yet")
+		f.Jen.Comment("support service-to-service API calls to raw endpoints.")
 		f.Jen.Type().Id("Interface").InterfaceFunc(func(g *Group) {
 			for _, ep := range svc.Endpoints {
 				if !ep.Raw {

--- a/v2/parser/apis/api/usage.go
+++ b/v2/parser/apis/api/usage.go
@@ -50,7 +50,7 @@ func ResolveEndpointUsage(data usage.ResolveData, ep *Endpoint) usage.Usage {
 		}
 	case *usage.FuncArg:
 		// If this is a test file and we're calling `et.MockAPI` this is allowed.
-		if pkg, ok := expr.PkgFunc.Get(); ok && expr.DeclaredIn().TestFile && pkg.PkgPath == "encore.dev/et" && pkg.Name == "MockAPI" {
+		if pkg, ok := expr.PkgFunc.Get(); ok && expr.DeclaredIn().TestFile && pkg.PkgPath == "encore.dev/et" && pkg.Name == "MockEndpoint" {
 			return &ReferenceUsage{
 				Base: usage.Base{
 					File: expr.File,

--- a/v2/parser/apis/api/usage.go
+++ b/v2/parser/apis/api/usage.go
@@ -49,7 +49,7 @@ func ResolveEndpointUsage(data usage.ResolveData, ep *Endpoint) usage.Usage {
 			Ref:      expr.BindRef,
 		}
 	case *usage.FuncArg:
-		// If this is a test file and we're calling `et.MockAPI` this is allowed.
+		// If this is a test file and we're calling `et.MockEndpoint` this is allowed.
 		if pkg, ok := expr.PkgFunc.Get(); ok && expr.DeclaredIn().TestFile && pkg.PkgPath == "encore.dev/et" && pkg.Name == "MockEndpoint" {
 			return &ReferenceUsage{
 				Base: usage.Base{

--- a/v2/parser/apis/api/usage.go
+++ b/v2/parser/apis/api/usage.go
@@ -48,6 +48,19 @@ func ResolveEndpointUsage(data usage.ResolveData, ep *Endpoint) usage.Usage {
 			Endpoint: ep,
 			Ref:      expr.BindRef,
 		}
+	case *usage.FuncArg:
+		// If this is a test file and we're calling `et.MockAPI` this is allowed.
+		if pkg, ok := expr.PkgFunc.Get(); ok && expr.DeclaredIn().TestFile && pkg.PkgPath == "encore.dev/et" && pkg.Name == "MockAPI" {
+			return &ReferenceUsage{
+				Base: usage.Base{
+					File: expr.File,
+					Bind: expr.Bind,
+					Expr: expr,
+				},
+				Endpoint: ep,
+				Ref:      expr.ASTExpr(),
+			}
+		}
 	}
 
 	// Check if the resource is referenced in a permissible location.

--- a/v2/v2builder/v2builder.go
+++ b/v2/v2builder/v2builder.go
@@ -357,15 +357,15 @@ func (i BuilderImpl) GenUserFacing(ctx context.Context, p builder.GenUserFacingP
 				// Service structs are not needed if there is no implementation to be generated
 				svcStruct := option.None[*codegen.VarDecl]()
 
+				buf.Reset()
 				if f, ok := userfacinggen.Gen(gg, svc, svcStruct).Get(); ok {
-					buf.Reset()
 					if err := f.Render(&buf); err != nil {
 						errs.Addf(token.NoPos, "unable to render userfacing go code: %v", err)
 						continue
 					}
-					dst := svc.FSRoot.Join("encore.gen.go")
-					i.writeOrDeleteFile(errs, buf.Bytes(), dst)
 				}
+
+				i.writeOrDeleteFile(errs, buf.Bytes(), svc.FSRoot.Join("encore.gen.go"))
 			}
 
 			// Generate the user-facing CUE code.


### PR DESCRIPTION
This PR implements three new features into the `et` (Encore Testing) package.

- `et.MockEndpoint` allows you to replace a specific endpoint during a test with another implementation.
- `et.MockService` allows you to replace entire services during a test with either a different instance of the service struct or with a wholly mocked-out object.
- `et.EnableServiceInstanceIsolation` allows you to force a test to have it's own isolated instance of any service struct that is accessed during that test.

All three of these functions can be called in the test entry point (`TestMain`) or in your tests themselves. They all cascade their behaviour down from the point called to any sub-tests as well.