### PR TITLE
Quality of Life improvements to local development dashboard

### DIFF
--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/golang/protobuf/proto"
 	"github.com/rs/zerolog/log"
 	"go4.org/syncutil"
 
@@ -21,6 +22,7 @@ import (
 	"encr.dev/pkg/appfile"
 	"encr.dev/pkg/fns"
 	"encr.dev/pkg/watcher"
+	meta "encr.dev/proto/encore/parser/meta/v1"
 )
 
 var ErrNotFound = errors.New("app not found")
@@ -264,6 +266,9 @@ type Instance struct {
 	watchMu     sync.Mutex
 	nextWatchID WatchSubscriptionID
 	watchers    map[WatchSubscriptionID]*watchSubscription
+
+	mdMu     sync.Mutex
+	cachedMd *meta.Data
 }
 
 func NewInstance(root, localID, platformID string) *Instance {
@@ -301,6 +306,16 @@ func (i *Instance) PlatformOrLocalID() string {
 		return id
 	}
 	return i.localID
+}
+
+// Name returns the platform ID for the app, or if there isn't one
+// it returns the folder name the app is in.
+func (i *Instance) Name() string {
+	if id := i.PlatformID(); id != "" {
+		return id
+	}
+
+	return filepath.Base(i.root)
 }
 
 func (i *Instance) fetchPlatformID() (string, error) {
@@ -417,6 +432,80 @@ func (i *Instance) beginWatch() error {
 
 		return nil
 	})
+}
+
+// CachePath returns the path to the cache directory for this app.
+// It creates the directory if it does not exist.
+func (i *Instance) CachePath() (string, error) {
+	cacheDir, err := conf.CacheDir()
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get encore cache dir")
+	}
+
+	// we use local ID to be stable if the app is linked to the platform later
+	cacheDir = filepath.Join(cacheDir, i.localID)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return "", errors.Wrap(err, "unable to create app cache dir")
+	}
+
+	return cacheDir, nil
+}
+
+// CacheMetadata caches the metadata for this app onto the file system
+func (i *Instance) CacheMetadata(md *meta.Data) error {
+	i.mdMu.Lock()
+	defer i.mdMu.Unlock()
+
+	i.cachedMd = md
+
+	cacheDir, err := i.CachePath()
+	if err != nil {
+		return err
+	}
+
+	data, err := proto.Marshal(md)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal metadata")
+	}
+
+	err = os.WriteFile(filepath.Join(cacheDir, "metadata.pb"), data, 0644)
+	if err != nil {
+		return errors.Wrap(err, "unable to write metadata")
+	}
+
+	return nil
+}
+
+// CachedMetadata returns the cached metadata for this app, if any
+func (i *Instance) CachedMetadata() (*meta.Data, error) {
+	i.mdMu.Lock()
+	defer i.mdMu.Unlock()
+
+	if i.cachedMd != nil {
+		return i.cachedMd, nil
+	}
+
+	cacheDir, err := i.CachePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(filepath.Join(cacheDir, "metadata.pb"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "unable to read metadata")
+	}
+
+	md := &meta.Data{}
+	err = proto.Unmarshal(data, md)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to unmarshal metadata")
+	}
+
+	i.cachedMd = md
+	return md, nil
 }
 
 func (i *Instance) Close() error {

--- a/cli/daemon/common.go
+++ b/cli/daemon/common.go
@@ -20,6 +20,8 @@ import (
 // OnStart implements run.EventListener.
 func (s *Server) OnStart(r *run.Run) {}
 
+func (s *Server) OnCompileStart(r *run.Run) {}
+
 // OnReload implements run.EventListener.
 func (s *Server) OnReload(r *run.Run) {}
 

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -113,6 +113,10 @@ func (s *Server) GenClient(ctx context.Context, params *daemonpb.GenClientReques
 			return nil, status.Errorf(codes.InvalidArgument, "failed to parse app metadata: %v", err)
 		}
 		md = parse.Meta
+
+		if err := app.CacheMetadata(md); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to cache app metadata: %v", err)
+		}
 	} else {
 		envName := params.EnvName
 		if envName == "" {

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/golang/protobuf/jsonpb"
@@ -27,7 +28,7 @@ import (
 	"encr.dev/pkg/editors"
 	"encr.dev/pkg/errlist"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
-	v1 "encr.dev/proto/encore/parser/meta/v1"
+	meta "encr.dev/proto/encore/parser/meta/v1"
 )
 
 type handler struct {
@@ -66,21 +67,42 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 			ID      string `json:"id"`
 			Name    string `json:"name"`
 			AppRoot string `json:"app_root"`
+			Offline bool   `json:"offline,omitempty"`
 		}
-		runs := h.run.ListRuns()
+
 		apps := []app{} // prevent marshalling as null
-		seen := make(map[string]bool)
-		for _, r := range runs {
-			id := r.App.PlatformOrLocalID()
-			name := r.App.PlatformID()
-			if name == "" {
-				name = filepath.Base(r.App.Root())
-			}
-			if !seen[id] {
-				seen[id] = true
-				apps = append(apps, app{ID: id, Name: name, AppRoot: r.App.Root()})
-			}
+
+		// Load all the apps we know about
+		allApp, err := h.apps.List()
+		if err != nil {
+			return reply(ctx, nil, err)
 		}
+		for _, instance := range allApp {
+			data := app{
+				ID:      instance.PlatformOrLocalID(),
+				Name:    instance.Name(),
+				AppRoot: instance.Root(),
+				Offline: true,
+			}
+
+			if run := h.run.FindRunByAppID(instance.PlatformOrLocalID()); run != nil {
+				data.Offline = false
+			}
+
+			apps = append(apps, data)
+		}
+
+		// Sort the apps by offline status, then by name
+		slices.SortStableFunc(apps, func(a, b app) int {
+			if a.Offline == b.Offline {
+				return strings.Compare(a.Name, b.Name)
+			}
+			if a.Offline {
+				return 1
+			}
+			return -1
+		})
+
 		return reply(ctx, apps, nil)
 
 	case "traces/list":
@@ -148,44 +170,15 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 			}
 		}
 
-		type statusResponse struct {
-			Running     bool                  `json:"running"`
-			AppID       string                `json:"appID"`
-			PID         string                `json:"pid,omitempty"`
-			Meta        json.RawMessage       `json:"meta,omitempty"`
-			Addr        string                `json:"addr,omitempty"`
-			APIEncoding *encoding.APIEncoding `json:"apiEncoding,omitempty"`
-			AppRoot     string                `json:"appRoot"`
-		}
-
 		// Now find the running instance(s)
 		runInstance := h.run.FindRunByAppID(params.AppID)
-		proc := runInstance.ProcGroup()
-		if runInstance == nil || proc == nil {
-			return reply(ctx, statusResponse{
-				Running: false,
-				AppID:   app.PlatformOrLocalID(),
-				AppRoot: app.Root(),
-			}, nil)
-		}
-
-		m := &jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
-		str, err := m.MarshalToString(proc.Meta)
+		status, err := buildAppStatus(app, runInstance)
 		if err != nil {
-			log.Error().Err(err).Msg("dash: could not marshal app metadata")
+			log.Error().Err(err).Msg("dash: could not build app status")
 			return reply(ctx, nil, err)
 		}
 
-		apiEnc := encoding.DescribeAPI(proc.Meta)
-		return reply(ctx, statusResponse{
-			Running:     true,
-			AppID:       app.PlatformOrLocalID(),
-			PID:         runInstance.ID,
-			Meta:        json.RawMessage(str),
-			Addr:        runInstance.ListenAddr,
-			APIEncoding: apiEnc,
-			AppRoot:     app.Root(),
-		}, nil)
+		return reply(ctx, status, nil)
 
 	case "api-call":
 		var params apiCallParams
@@ -259,14 +252,15 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 }
 
 type apiCallParams struct {
-	AppID       string
-	Service     string
-	Endpoint    string
-	Path        string
-	Method      string
-	Payload     []byte
-	AuthPayload []byte `json:"auth_payload,omitempty"`
-	AuthToken   string `json:"auth_token,omitempty"`
+	AppID         string
+	Service       string
+	Endpoint      string
+	Path          string
+	Method        string
+	Payload       []byte
+	AuthPayload   []byte `json:"auth_payload,omitempty"`
+	AuthToken     string `json:"auth_token,omitempty"`
+	CorrelationID string `json:"correlation_id,omitempty"`
 }
 
 func (h *handler) apiCall(ctx context.Context, reply jsonrpc2.Replier, p *apiCallParams) error {
@@ -287,6 +281,10 @@ func (h *handler) apiCall(ctx context.Context, reply jsonrpc2.Replier, p *apiCal
 	if err != nil {
 		log.Error().Err(err).Msg("dash: unable to prepare request")
 		return reply(ctx, nil, err)
+	}
+
+	if p.CorrelationID != "" {
+		req.Header.Set("X-Correlation-ID", p.CorrelationID)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
@@ -360,11 +358,9 @@ var _ run.EventListener = (*Server)(nil)
 
 // OnStart notifies active websocket clients about the started run.
 func (s *Server) OnStart(r *run.Run) {
-	m := &jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
-	proc := r.ProcGroup()
-	str, err := m.MarshalToString(proc.Meta)
+	status, err := buildAppStatus(r.App, r)
 	if err != nil {
-		log.Error().Err(err).Msg("dash: could not marshal app meta")
+		log.Error().Err(err).Msg("dash: could not build app status")
 		return
 	}
 
@@ -375,49 +371,52 @@ func (s *Server) OnStart(r *run.Run) {
 		browser.Open(u)
 	}
 
-	apiEnc := encoding.DescribeAPI(proc.Meta)
 	s.notify(&notification{
 		Method: "process/start",
-		Params: map[string]interface{}{
-			"appID":       r.App.PlatformOrLocalID(),
-			"pid":         r.ID,
-			"addr":        r.ListenAddr,
-			"meta":        json.RawMessage(str),
-			"apiEncoding": apiEnc,
-		},
+		Params: status,
+	})
+}
+
+func (s *Server) OnCompileStart(r *run.Run) {
+	status, err := buildAppStatus(r.App, r)
+	if err != nil {
+		log.Error().Err(err).Msg("dash: could not build app status")
+		return
+	}
+
+	status.Compiling = true
+
+	s.notify(&notification{
+		Method: "process/compile-start",
+		Params: status,
 	})
 }
 
 // OnReload notifies active websocket clients about the reloaded run.
 func (s *Server) OnReload(r *run.Run) {
-	m := &jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
-	proc := r.ProcGroup()
-	str, err := m.MarshalToString(proc.Meta)
+	status, err := buildAppStatus(r.App, r)
 	if err != nil {
-		log.Error().Err(err).Msg("dash: could not marshal app meta")
+		log.Error().Err(err).Msg("dash: could not build app status")
 		return
 	}
 
-	apiEnc := encoding.DescribeAPI(proc.Meta)
 	s.notify(&notification{
 		Method: "process/reload",
-		Params: map[string]interface{}{
-			"appID":       r.App.PlatformOrLocalID(),
-			"pid":         r.ID,
-			"meta":        json.RawMessage(str),
-			"apiEncoding": apiEnc,
-		},
+		Params: status,
 	})
 }
 
 // OnStop notifies active websocket clients about the stopped run.
 func (s *Server) OnStop(r *run.Run) {
+	status, err := buildAppStatus(r.App, nil)
+	if err != nil {
+		log.Error().Err(err).Msg("dash: could not build app status")
+		return
+	}
+
 	s.notify(&notification{
 		Method: "process/stop",
-		Params: map[string]interface{}{
-			"appID": r.App.PlatformOrLocalID(),
-			"pid":   r.ID,
-		},
+		Params: status,
 	})
 }
 
@@ -432,9 +431,24 @@ func (s *Server) OnStderr(r *run.Run, out []byte) {
 }
 
 func (s *Server) OnError(r *run.Run, err *errlist.List) {
-	if err != nil {
-		s.onOutput(r, []byte(err.Error()))
+	if err == nil {
+		return
 	}
+
+	status, statusErr := buildAppStatus(r.App, nil)
+	if statusErr != nil {
+		log.Error().Err(statusErr).Msg("dash: could not build app status")
+		return
+	}
+
+	err.MakeRelative(r.App.Root(), "")
+
+	status.CompileError = err.Error()
+
+	s.notify(&notification{
+		Method: "process/compile-error",
+		Params: status,
+	})
 }
 
 func (s *Server) onOutput(r *run.Run, out []byte) {
@@ -453,7 +467,7 @@ func (s *Server) onOutput(r *run.Run, out []byte) {
 
 // findRPC finds the RPC with the given service and endpoint name.
 // If it cannot be found it reports nil.
-func findRPC(md *v1.Data, service, endpoint string) *v1.RPC {
+func findRPC(md *meta.Data, service, endpoint string) *meta.RPC {
 	for _, svc := range md.Svcs {
 		if svc.Name == service {
 			for _, rpc := range svc.Rpcs {
@@ -468,7 +482,7 @@ func findRPC(md *v1.Data, service, endpoint string) *v1.RPC {
 }
 
 // prepareRequest prepares a request for sending based on the given apiCallParams.
-func prepareRequest(ctx context.Context, baseURL string, md *v1.Data, p *apiCallParams) (*http.Request, error) {
+func prepareRequest(ctx context.Context, baseURL string, md *meta.Data, p *apiCallParams) (*http.Request, error) {
 	reqSpec := newHTTPRequestSpec()
 	rpc := findRPC(md, p.Service, p.Endpoint)
 	if rpc == nil {
@@ -535,7 +549,7 @@ func prepareRequest(ctx context.Context, baseURL string, md *v1.Data, p *apiCall
 	return req, nil
 }
 
-func handleResponse(md *v1.Data, p *apiCallParams, headers http.Header, body []byte) []byte {
+func handleResponse(md *meta.Data, p *apiCallParams, headers http.Header, body []byte) []byte {
 	rpc := findRPC(md, p.Service, p.Endpoint)
 	if rpc == nil {
 		return body
@@ -715,4 +729,69 @@ func makeProtoReplier(rep jsonrpc2.Replier) jsonrpc2.Replier {
 		jsonData, err := protoEncoder.Marshal(result)
 		return rep(ctx, json.RawMessage(jsonData), err)
 	}
+}
+
+// appStatus is the the shared data structure to communicate app status to the client.
+//
+// It is mirrored in the frontend at src/lib/client/dev-dash-client.ts as `AppStatus`.
+type appStatus struct {
+	Running      bool                  `json:"running"`
+	AppID        string                `json:"appID"`
+	PlatformID   string                `json:"platformID,omitempty"`
+	AppRoot      string                `json:"appRoot"`
+	PID          string                `json:"pid,omitempty"`
+	Meta         json.RawMessage       `json:"meta,omitempty"`
+	Addr         string                `json:"addr,omitempty"`
+	APIEncoding  *encoding.APIEncoding `json:"apiEncoding,omitempty"`
+	Compiling    bool                  `json:"compiling"`
+	CompileError string                `json:"compileError,omitempty"`
+}
+
+func buildAppStatus(app *apps.Instance, runInstance *run.Run) (s appStatus, err error) {
+	// Now try and grab latest metadata for the app
+	var md *meta.Data
+	if runInstance != nil {
+		proc := runInstance.ProcGroup()
+		if proc != nil {
+			md = proc.Meta
+		}
+	}
+
+	if md == nil {
+		md, err = app.CachedMetadata()
+		if err != nil {
+			return appStatus{}, err
+		}
+	}
+
+	// Convert the metadata into a format we can send to the client
+	mdStr := "null"
+	var apiEnc *encoding.APIEncoding
+	if md != nil {
+		m := &jsonpb.Marshaler{OrigName: true, EmitDefaults: true}
+
+		mdStr, err = m.MarshalToString(md)
+		if err != nil {
+			return appStatus{}, err
+		}
+
+		apiEnc = encoding.DescribeAPI(md)
+	}
+
+	// Build the response
+	resp := appStatus{
+		Running:     false,
+		AppID:       app.PlatformOrLocalID(),
+		PlatformID:  app.PlatformID(),
+		Meta:        json.RawMessage(mdStr),
+		AppRoot:     app.Root(),
+		APIEncoding: apiEnc,
+	}
+	if runInstance != nil {
+		resp.Running = true
+		resp.PID = runInstance.ID
+		resp.Addr = runInstance.ListenAddr
+	}
+
+	return resp, nil
 }

--- a/cli/daemon/export/export.go
+++ b/cli/daemon/export/export.go
@@ -70,6 +70,10 @@ func Docker(ctx context.Context, app *apps.Instance, req *daemonpb.ExportRequest
 	if err != nil {
 		return false, err
 	}
+	if err := app.CacheMetadata(parse.Meta); err != nil {
+		log.Info().Err(err).Msg("failed to cache metadata")
+		return false, errors.Wrap(err, "cache metadata")
+	}
 
 	log.Info().Msgf("compiling Encore application for %s/%s", req.Goos, req.Goarch)
 	result, err := bld.Compile(ctx, builder.CompileParams{

--- a/cli/daemon/run/check.go
+++ b/cli/daemon/run/check.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"runtime"
 
+	"github.com/cockroachdb/errors"
+
 	"encr.dev/cli/daemon/apps"
 	"encr.dev/pkg/builder"
 	"encr.dev/pkg/builder/builderimpl"
@@ -64,6 +66,9 @@ func (mgr *Manager) Check(ctx context.Context, p CheckParams) (buildDir string, 
 	})
 	if err != nil {
 		return "", err
+	}
+	if err := p.App.CacheMetadata(parse.Meta); err != nil {
+		return "", errors.Wrap(err, "cache metadata")
 	}
 
 	result, err := bld.Compile(ctx, builder.CompileParams{

--- a/cli/daemon/run/exec_script.go
+++ b/cli/daemon/run/exec_script.go
@@ -99,6 +99,9 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 		tracker.Fail(parseOp, err)
 		return err
 	}
+	if err := p.App.CacheMetadata(parse.Meta); err != nil {
+		return errors.Wrap(err, "cache metadata")
+	}
 	tracker.Done(parseOp, 500*time.Millisecond)
 	tracker.Done(topoOp, 300*time.Millisecond)
 

--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -37,6 +37,8 @@ type Manager struct {
 type EventListener interface {
 	// OnStart is called when a run starts.
 	OnStart(r *Run)
+	// OnCompileStart is called when a run starts compiling.
+	OnCompileStart(r *Run)
 	// OnReload is called when a run reloads.
 	OnReload(r *Run)
 	// OnStop is called when a run stops.

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -289,6 +289,10 @@ func (r *Run) buildAndStart(ctx context.Context, tracker *optracker.OpTracker, i
 		return err
 	}
 
+	for _, ln := range r.Mgr.listeners {
+		ln.OnCompileStart(r)
+	}
+
 	jobs := optracker.NewAsyncBuildJobs(ctx, r.App.PlatformOrLocalID(), tracker)
 
 	// Parse the app source code
@@ -329,6 +333,9 @@ func (r *Run) buildAndStart(ctx context.Context, tracker *optracker.OpTracker, i
 	if err != nil {
 		tracker.Fail(parseOp, err)
 		return err
+	}
+	if err := r.App.CacheMetadata(parse.Meta); err != nil {
+		return errors.Wrap(err, "cache metadata")
 	}
 	tracker.Done(parseOp, 500*time.Millisecond)
 	tracker.Done(topoOp, 300*time.Millisecond)

--- a/cli/daemon/run/tests.go
+++ b/cli/daemon/run/tests.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"runtime"
 
+	"github.com/cockroachdb/errors"
+
 	"encr.dev/cli/daemon/apps"
 	"encr.dev/cli/daemon/namespace"
 	"encr.dev/cli/daemon/run/infra"
@@ -86,6 +88,9 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 	})
 	if err != nil {
 		return err
+	}
+	if err := params.App.CacheMetadata(parse.Meta); err != nil {
+		return errors.Wrap(err, "cache metadata")
 	}
 
 	rm := infra.NewResourceManager(params.App, mgr.ClusterMgr, params.NS, nil, mgr.DBProxyPort, true)

--- a/cli/daemon/userfacing.go
+++ b/cli/daemon/userfacing.go
@@ -57,6 +57,10 @@ func (s *Server) genUserFacing(ctx context.Context, app *apps.Instance) error {
 		return errors.Wrap(err, "parse app")
 	}
 
+	if err := app.CacheMetadata(parse.Meta); err != nil {
+		return errors.Wrap(err, "cache metadata")
+	}
+
 	err = bld.GenUserFacing(ctx, builder.GenUserFacingParams{
 		App:   app,
 		Parse: parse,

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -72,6 +72,26 @@ func Dir() (string, error) {
 	return dir, nil
 }
 
+// CacheDir reports the base directory for storing data which can be cached
+// and deleted at any time by the user without affecting the Encore daemon.
+//
+// The directory may or may not exist already.
+func CacheDir() (string, error) {
+	dir := os.Getenv("ENCORE_CACHE_DIR")
+	if dir == "" {
+		d, err := os.UserCacheDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(d, defaultConfigDirectory, "cache")
+	}
+	if !filepath.IsAbs(dir) {
+		return "", fmt.Errorf("ENCORE_CACHE_DIR must be absolute, got %q", dir)
+	}
+
+	return dir, nil
+}
+
 // DataDir reports the base directory for storing data, like database volumes.
 // The directory may or may not exist already.
 func DataDir() (string, error) {


### PR DESCRIPTION
This PR adds the capability to view all Encore apps via the local dashboard, regardless of if they are currently running or not, as well as several other UI improvements to the dashboard;

- request logs are now displayed when an API call is made
- You get notified when the app is compiling
- You get notified when the app has just restarted (due to a hot-reload)
- You get notified of any compile errors and what they are

### Offline apps are greyed out on lists, but can still be navigated
![Screenshot 2024-01-25 at 14 05 04](https://github.com/encoredev/encore/assets/236641/b845401a-f950-4027-adfe-205d6df60b05)

![image](https://github.com/encoredev/encore/assets/236641/63acc351-e661-429a-87a9-277a5e047373)


### The API explorer now shows logs which were emitted during the API call
![image](https://github.com/encoredev/encore/assets/236641/fc0e402e-c6a2-4188-91a3-5c92c3180fd5)

### The dashboard now tells you when the app is compiling or just freshly restarted
![Screenshot 2024-01-25 at 14 14 22](https://github.com/encoredev/encore/assets/236641/e100700c-24f7-4f11-9591-bdf9f4869166)

![image](https://github.com/encoredev/encore/assets/236641/808d41ef-9bc1-45e0-8b4b-df9cbd32cea0)

### Compile errors are now shown on the dashboard
![image](https://github.com/encoredev/encore/assets/236641/0396bdca-ee48-4342-a13c-4eff91fe9563)
