### PR TITLE
Update sqlc booking-system.md

### DIFF
--- a/docs/tutorials/booking-system.md
+++ b/docs/tutorials/booking-system.md
@@ -213,7 +213,7 @@ CREATE TABLE booking (
 🥐 Next, install the sqlc library:
 
 ```shell
-$ go get github.com/sqlc-dev/sqlc/cmd/sqlc
+$ go install github.com/sqlc-dev/sqlc/cmd/sqlc
 ```
 
 🥐 Next, we need to configure sqlc. Add the following contents to `sqlc.yaml`:


### PR DESCRIPTION
This commit updates the doc to use `go install` instead of `go get` to install `sqlc` in the booking tutorial.

When going through the tutorial, using `go get` would not install the binary of `sqlc`.