### PR TITLE
Fix User-Agent for generated client in JS and TS

### DIFF
--- a/internal/clientgen/javascript.go
+++ b/internal/clientgen/javascript.go
@@ -477,8 +477,14 @@ class BaseClient {`)
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "` + userAgent + `",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "` + userAgent + `";
+        }
+
         this.requestInit = options.requestInit ?? {}
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/testdata/expected_baseauth_javascript.js
+++ b/internal/clientgen/testdata/expected_baseauth_javascript.js
@@ -104,8 +104,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "app-Generated-JS-Client (Encore/devel)",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "app-Generated-JS-Client (Encore/devel)";
+        }
+
         this.requestInit = options.requestInit ?? {}
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/testdata/expected_baseauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_baseauth_typescript.ts
@@ -169,8 +169,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "app-Generated-TS-Client (Encore/devel)",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "app-Generated-TS-Client (Encore/devel)";
+        }
+
         this.requestInit = options.requestInit ?? {};
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/testdata/expected_javascript.js
+++ b/internal/clientgen/testdata/expected_javascript.js
@@ -272,8 +272,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "app-Generated-JS-Client (Encore/devel)",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "app-Generated-JS-Client (Encore/devel)";
+        }
+
         this.requestInit = options.requestInit ?? {}
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/testdata/expected_noauth_javascript.js
+++ b/internal/clientgen/testdata/expected_noauth_javascript.js
@@ -88,8 +88,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "app-Generated-JS-Client (Encore/devel)",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "app-Generated-JS-Client (Encore/devel)";
+        }
+
         this.requestInit = options.requestInit ?? {}
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/testdata/expected_noauth_typescript.ts
+++ b/internal/clientgen/testdata/expected_noauth_typescript.ts
@@ -131,8 +131,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "app-Generated-TS-Client (Encore/devel)",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "app-Generated-TS-Client (Encore/devel)";
+        }
+
         this.requestInit = options.requestInit ?? {};
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/testdata/expected_typescript.ts
+++ b/internal/clientgen/testdata/expected_typescript.ts
@@ -461,8 +461,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "app-Generated-TS-Client (Encore/devel)",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "app-Generated-TS-Client (Encore/devel)";
+        }
+
         this.requestInit = options.requestInit ?? {};
 
         // Setup what fetch function we'll be using in the base client

--- a/internal/clientgen/typescript.go
+++ b/internal/clientgen/typescript.go
@@ -704,8 +704,14 @@ class BaseClient {
         this.baseURL = baseURL
         this.headers = {
             "Content-Type": "application/json",
-            "User-Agent":   "` + userAgent + `",
         }
+
+        // Add User-Agent header if the script is running in the server
+        // because browsers do not allow setting User-Agent headers to requests
+        if (typeof window === "undefined") {
+            this.headers["User-Agent"] = "` + userAgent + `";
+        }
+
         this.requestInit = options.requestInit ?? {};
 
         // Setup what fetch function we'll be using in the base client


### PR DESCRIPTION
It adds the User-Agent header to the requests only if the global `window` is undefined, which means the client is running on node.  

Fixes #1020. 