### PR TITLE
Add ability to disable color in test log output

### DIFF
--- a/cli/cmd/encore/test.go
+++ b/cli/cmd/encore/test.go
@@ -24,6 +24,7 @@ var testCmd = &cobra.Command{
 		var (
 			traceFile    string
 			codegenDebug bool
+			noColor      bool
 		)
 		// Support specific args but otherwise let all args be passed on to "go test"
 		for i := 0; i < len(args); i++ {
@@ -52,15 +53,19 @@ var testCmd = &cobra.Command{
 				codegenDebug = true
 				args = slices.Delete(args, i, i+1)
 				i--
+			} else if arg == "--no-color" {
+				noColor = true
+				args = slices.Delete(args, i, i+1)
+				i--
 			}
 		}
 
 		appRoot, relPath := determineAppRoot()
-		runTests(appRoot, relPath, args, traceFile, codegenDebug)
+		runTests(appRoot, relPath, args, traceFile, codegenDebug, noColor)
 	},
 }
 
-func runTests(appRoot, testDir string, args []string, traceFile string, codegenDebug bool) {
+func runTests(appRoot, testDir string, args []string, traceFile string, codegenDebug bool, noColor bool) {
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
 
@@ -70,7 +75,9 @@ func runTests(appRoot, testDir string, args []string, traceFile string, codegenD
 		cancel()
 	}()
 
-	converter := convertJSONLogs()
+	converter := convertJSONLogs(func(clo *convertLogOptions) {
+		clo.Color = !noColor
+	})
 	if slices.Contains(args, "-json") {
 		converter = convertTestEventOutputOnly(converter)
 	}


### PR DESCRIPTION
This adds the ability to pass a `--no-color` flag to `encore test` to disable color output in zerolog. This is useful when displaying output in windows which don't support colors. This is the case for VSCode test output:

The current output of those runs look like this, which makes debugging failed tests extremely difficult:

<img width="1211" alt="image" src="https://github.com/encoredev/encore/assets/169475/c18c74f3-1cf6-4e38-9fd7-a9acda2c2a4c">


WARNING: This is not tested, as I couldn't quickly figure out how to do that. Building the binary and attempting to use it caused a daemon version mismatch error though both cli and daemon report the same version (I assume there's some hash checking). 