### PR TITLE
Update booking-system.md

### DIFF
--- a/docs/tutorials/booking-system.md
+++ b/docs/tutorials/booking-system.md
@@ -214,7 +214,7 @@ CREATE TABLE booking (
 🥐 Next, install the sqlc library:
 
 ```shell
-$ go install github.com/sqlc-dev/sqlc/cmd/sqlc
+$ go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 ```
 
 🥐 Next, we need to configure sqlc. Add the following contents to `sqlc.yaml`:


### PR DESCRIPTION
When the version is not included you get the following error 

```
❯ go install github.com/sqlc-dev/sqlc/cmd/sqlc 
no required module provides package github.com/sqlc-dev/sqlc/cmd/sqlc; to add it:
        go get github.com/sqlc-dev/sqlc/cmd/sqlc
```

Adding `@latest` to the end fixes this and will install sqlc