### PR TITLE
Add Clarification about Time Zone Handling in Cron Expressions (Closes #1059)

### DIFF
--- a/docs/primitives/cron-jobs.md
+++ b/docs/primitives/cron-jobs.md
@@ -78,7 +78,7 @@ the `Every` field is not expressive enough.
 For these use cases, Encore provides full support for [Cron expressions](https://en.wikipedia.org/wiki/Cron) by using the `Schedule` field
 instead of the `Every` field.
 
-Cron expressions allow you to define precise schedules for your tasks, including specific days of the week, specific months, and more. When using Cron expressions in Encore, it's important to note that they operate based on Coordinated Universal Time (UTC). Therefore, when defining Cron expressions, ensure that you account for the time zone offset if necessary.
+Cron expressions allow you to define precise schedules for your tasks, including specific days of the week, specific hours of the day, and more. Note that all times are expressed in UTC.
 
 For example:
 


### PR DESCRIPTION
This PR adds a brief clarification to the documentation regarding the handling of time zones in Cron expressions used in Encore's Cron Jobs.