### PR TITLE
runtime: add build tags for metrics providers

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -18,7 +18,11 @@ import (
 	meta "encr.dev/proto/encore/parser/meta/v1"
 )
 
-var LocalBuildTags = []string{"encore_local", "encore_no_gcp", "encore_no_aws", "encore_no_azure"}
+var LocalBuildTags = []string{
+	"encore_local",
+	"encore_no_gcp", "encore_no_aws", "encore_no_azure",
+	"encore_no_datadog", "encore_no_prometheus",
+}
 
 type BuildInfo struct {
 	BuildTags          []string

--- a/runtimes/go/appruntime/infrasdk/metrics/datadog/datadog.go
+++ b/runtimes/go/appruntime/infrasdk/metrics/datadog/datadog.go
@@ -1,3 +1,5 @@
+//go:build !encore_no_datadog
+
 package datadog
 
 import (

--- a/runtimes/go/appruntime/infrasdk/metrics/datadog_exporter.go
+++ b/runtimes/go/appruntime/infrasdk/metrics/datadog_exporter.go
@@ -1,3 +1,5 @@
+//go:build !encore_no_datadog
+
 package metrics
 
 import (

--- a/runtimes/go/appruntime/infrasdk/metrics/prometheus/prometheus.go
+++ b/runtimes/go/appruntime/infrasdk/metrics/prometheus/prometheus.go
@@ -1,3 +1,5 @@
+//go:build !encore_no_prometheus
+
 package prometheus
 
 import (

--- a/runtimes/go/appruntime/infrasdk/metrics/prometheus_exporter.go
+++ b/runtimes/go/appruntime/infrasdk/metrics/prometheus_exporter.go
@@ -1,3 +1,5 @@
+//go:build !encore_no_prometheus
+
 package metrics
 
 import (


### PR DESCRIPTION
We've observed the datadog SDK in particular
taking a huge chunk of time spent building.

With such a large SDK it also impacts link time.

Fix this by not compiling in the datadog SDK
when running locally.
