### PR TITLE
docs: fix typo

### DIFF
--- a/docs/develop/auth-keys.md
+++ b/docs/develop/auth-keys.md
@@ -14,7 +14,7 @@ Pre-authentication keys (“auth keys” for short) let you authenticate the Enc
 
 - **Reusable Keys** for authenticating more than one machine.
 
-- **Ephemeral Keys** - Machines authenticated by this key will be automatically logged out after one our.
+- **Ephemeral Keys** - Machines authenticated by this key will be automatically logged out after one hour.
 
 <Callout type="important">
 


### PR DESCRIPTION
Changed `our` to `hour` in `auth-keys.md`.