### PR TITLE
tsparser: fix endpoint name collision in codegen

### DIFF
--- a/tsparser/src/builder/templates/entrypoints/combined/main.handlebars
+++ b/tsparser/src/builder/templates/entrypoints/combined/main.handlebars
@@ -4,7 +4,7 @@ import { registerGateways, registerHandlers, run, type Handler } from "encore.de
 import { {{bind_name}} as {{encoreNameToIdent encore_name}}GW } from {{toJSON import_path}};
 {{/each}}
 {{#each endpoints}}
-import { {{name}} as {{name}}Impl } from {{toJSON import_path}};
+import { {{name}} as {{service_name}}_{{name}}Impl } from {{toJSON import_path}};
 {{/each}}
 
 
@@ -19,7 +19,7 @@ const handlers: Handler[] = [
     {
         service: {{toJSON service_name}},
         name:    {{toJSON name}},
-        handler: {{name}}Impl,
+        handler: {{service_name}}_{{name}}Impl,
     },
 {{/each}}
 ];


### PR DESCRIPTION
If two services exposed an endpoint with the same name,
the 'combined' entrypoint would have a name conflict.
This led to only one of the handlers being registered.

Fix this by prefixing the local name with the service name.

Thanks Tucker Hawkinson for the report.