### PR TITLE
runtimes/go: add support for running middleware in mock

### DIFF
--- a/runtimes/go/appruntime/exported/model/request.go
+++ b/runtimes/go/appruntime/exported/model/request.go
@@ -168,14 +168,20 @@ type TestConfig struct {
 	// Lock for the below fields
 	Mu sync.RWMutex
 
-	ServiceMocks     map[string]any // The service mocks we want to use
+	ServiceMocks     map[string]ServiceMock
 	APIMocks         map[string]map[string]ApiMock
 	IsolatedServices *bool // Whether to isolate services for this test
 }
 
+type ServiceMock struct {
+	Service       any
+	RunMiddleware bool
+}
+
 type ApiMock struct {
-	ID       uint64
-	Function any
+	ID            uint64
+	Function      any
+	RunMiddleware bool
 }
 
 type Response struct {

--- a/runtimes/go/appruntime/shared/testsupport/testconfig.go
+++ b/runtimes/go/appruntime/shared/testsupport/testconfig.go
@@ -15,7 +15,7 @@ var (
 func newTestConfig(parent *model.TestConfig) *model.TestConfig {
 	return &model.TestConfig{
 		Parent:       parent,
-		ServiceMocks: make(map[string]any),
+		ServiceMocks: make(map[string]model.ServiceMock),
 		APIMocks:     make(map[string]map[string]model.ApiMock),
 	}
 }

--- a/runtimes/go/appruntime/shared/testsupport/testsupport.go
+++ b/runtimes/go/appruntime/shared/testsupport/testsupport.go
@@ -269,28 +269,31 @@ func (mgr *Manager) GetIsolatedServices() bool {
 }
 
 // SetServiceMock allows us to set a mock for a service for the current test
-func (mgr *Manager) SetServiceMock(service string, mock any) {
+func (mgr *Manager) SetServiceMock(service string, mock any, runMiddleware bool) {
 	service = strings.TrimSpace(strings.ToLower(service))
 
 	cfg := mgr.currentConfig()
 	cfg.Mu.Lock()
 	defer cfg.Mu.Unlock()
-	cfg.ServiceMocks[service] = mock
+	cfg.ServiceMocks[service] = model.ServiceMock{
+		Service:       mock,
+		RunMiddleware: runMiddleware,
+	}
 }
 
 // GetServiceMock allows us to get a mock for a service for the current test
 // or any parent tests - returning the lowest level mock available.
-func (mgr *Manager) GetServiceMock(service string) (any, bool) {
+func (mgr *Manager) GetServiceMock(service string) (model.ServiceMock, bool) {
 	service = strings.TrimSpace(strings.ToLower(service))
 
-	return walkConfig(mgr.currentConfig(), func(cfg *TestConfig) (value any, found bool) {
+	return walkConfig(mgr.currentConfig(), func(cfg *TestConfig) (value model.ServiceMock, found bool) {
 		value, found = cfg.ServiceMocks[service]
 		return
 	})
 }
 
 // SetAPIMock allows us to set a mock for an API for the current test
-func (mgr *Manager) SetAPIMock(service string, api string, mock any) {
+func (mgr *Manager) SetAPIMock(service string, api string, mock any, runMiddleware bool) {
 	service = strings.TrimSpace(strings.ToLower(service))
 	api = strings.TrimSpace(strings.ToLower(api))
 
@@ -302,8 +305,9 @@ func (mgr *Manager) SetAPIMock(service string, api string, mock any) {
 		cfg.APIMocks[service] = make(map[string]model.ApiMock)
 	}
 	cfg.APIMocks[service][api] = model.ApiMock{
-		ID:       nextApiMockID.Add(1),
-		Function: mock,
+		ID:            nextApiMockID.Add(1),
+		Function:      mock,
+		RunMiddleware: runMiddleware,
 	}
 }
 

--- a/v2/parser/apis/api/usage.go
+++ b/v2/parser/apis/api/usage.go
@@ -49,7 +49,7 @@ func ResolveEndpointUsage(data usage.ResolveData, ep *Endpoint) usage.Usage {
 			Ref:      expr.BindRef,
 		}
 	case *usage.FuncArg:
-		// If this is a test file and we're calling `et.MockEndpoint` this is allowed.
+		// If this is a test file and we're calling `et.MockEndpoint[WithMiddleware]` this is allowed.
 		if pkg, ok := expr.PkgFunc.Get(); ok && expr.DeclaredIn().TestFile && pkg.PkgPath == "encore.dev/et" && pkg.Name == "MockEndpoint" {
 			return &ReferenceUsage{
 				Base: usage.Base{


### PR DESCRIPTION
This extends the `encore.dev/et` package with the ability
to run middleware prior to invoking a mock.

Thanks to Bill Kennedy for the suggestion.