### PR TITLE
fix(dash): Init httpRequestSpec's Body properly if rawPayload is not empty

### DIFF
--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -644,7 +644,7 @@ func newHTTPRequestSpec() *httpRequestSpec {
 // directly to the request object itself.
 func addToRequest(req *httpRequestSpec, rawPayload []byte, params map[string][]*encoding.ParameterEncoding) error {
 	if len(rawPayload) > 0 {
-		req.Body = make(map[string]json.RawMessage, 0)
+		req.Body = make(map[string]json.RawMessage)
 	}
 
 	payload, err := hujson.Parse(rawPayload)

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -643,6 +643,10 @@ func newHTTPRequestSpec() *httpRequestSpec {
 // The body argument is where body parameters are added; other parameter locations are added
 // directly to the request object itself.
 func addToRequest(req *httpRequestSpec, rawPayload []byte, params map[string][]*encoding.ParameterEncoding) error {
+	if len(rawPayload) > 0 {
+		req.Body = make(map[string]json.RawMessage, 0)
+	}
+
 	payload, err := hujson.Parse(rawPayload)
 	if err != nil {
 		return fmt.Errorf("invalid payload: %v", err)


### PR DESCRIPTION
## Problem
1. Given a POST API with body payload, e.g:
```
//encore:api public method=POST path=/hello/:name
func World(ctx context.Context, name string, params *RequestType) (*Response, error) {
   // ... 
}

type RequestType struct {
	AlternativeName *string `json:"alternativeName,omitempty" encore:"optional"` // Some description for AlternativeName
	Mambo           string  `json:"mambo,omitempty"`                             // Some description for Mambo
}
```
2. On the local dashboard when we try this endpoint, leave the body empty:
```
{ }
```
3. Getting error:
```
HTTP 400 Bad Request: { "code": "invalid_argument", "message": "decode request: request_body: missing request body: missing request body", "details": null }
```
<img width="726" alt="Screenshot 2024-03-27 at 10 17 24" src="https://github.com/encoredev/encore/assets/766068/c42e3055-047d-4ae9-840c-ffac10dd3032">

## Cause
In cli/daemon/dash/dash.go, addToRequest function we initialize the Body field on the *httpRequestSpec type only if there's content in the processed (hujson) payload, otherwise nil.

## Solution
Initialize properly the Body field on the *httpRequestSpec type when the **raw**Payload is not empty
