### PR TITLE
runtimes/core: ignore empty fields for auth data

### DIFF
--- a/runtimes/core/src/api/schema/header.rs
+++ b/runtimes/core/src/api/schema/header.rs
@@ -16,8 +16,12 @@ impl Header {
     pub fn contains_any(&self, headers: &impl HTTPHeaders) -> bool {
         for (name, field) in self.schema.root().fields.iter() {
             let header_name = field.name_override.as_deref().unwrap_or(name.as_str());
-            if headers.contains_key(header_name) {
-                return true;
+
+            if let Some(val) = headers.get(header_name) {
+                // Only consider non-empty values to be present.
+                if !val.is_empty() {
+                    return true;
+                }
             }
         }
         return false;

--- a/runtimes/core/src/api/schema/query.rs
+++ b/runtimes/core/src/api/schema/query.rs
@@ -45,8 +45,9 @@ impl Query {
         }
 
         let parsed = form_urlencoded::parse(query);
-        for (key, _) in parsed {
-            if schema.contains_name(key.as_ref()) {
+        for (key, val) in parsed {
+            // Only consider non-empty values to be present.
+            if !val.is_empty() && schema.contains_name(key.as_ref()) {
                 return true;
             }
         }


### PR DESCRIPTION
This makes it so the auth handler isn't called when the
request values for the auth params are present but empty.

This mirrors the Go implementation.
