### PR TITLE
runtimes/go: add et.NewTestDatabase

### DIFF
--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -229,9 +229,12 @@ func (c *Cluster) initDB(encoreName string) *DB {
 
 	dbCtx, cancel := context.WithCancel(c.Ctx)
 	db := &DB{
-		DriverName: driverName,
 		EncoreName: encoreName,
 		Cluster:    c,
+		driverName: driverName,
+
+		// Use a template database when running tests.
+		template: c.ID.Type == Test,
 
 		Ctx:    dbCtx,
 		cancel: cancel,

--- a/cli/daemon/sqldb/proxy.go
+++ b/cli/daemon/sqldb/proxy.go
@@ -185,7 +185,7 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 			})
 			return nil
 		case <-time.After(60 * time.Second):
-			cm.log.Error().Str("db", db.DriverName).Msg("dbproxy: timed out waiting for database to come online")
+			cm.log.Error().Str("db", db.ApplicationCloudName()).Msg("dbproxy: timed out waiting for database to come online")
 			_ = cl.Backend.Send(&pgproto3.ErrorResponse{
 				Severity: "FATAL",
 				Code:     "08006",
@@ -230,7 +230,7 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 		// If it doesn't the cluster will return an SQL error to the client.
 		startup.Database = dbname
 	} else {
-		startup.Database = db.DriverName
+		startup.Database = db.ApplicationCloudName()
 	}
 	fe, err := pgproxy.SetupServer(server, &pgproxy.ServerConfig{
 		TLS:     nil,
@@ -360,7 +360,7 @@ func (cm *ClusterManager) PreauthProxyConn(client net.Conn, id ClusterID) error 
 	admin, _ := info.Encore.First(RoleAdmin, RoleSuperuser)
 	startup.Username = admin.Username
 	startup.Password = admin.Password
-	startup.Database = db.DriverName
+	startup.Database = db.ApplicationCloudName()
 	fe, err := pgproxy.SetupServer(server, &pgproxy.ServerConfig{
 		TLS:     nil,
 		Startup: startup,

--- a/runtimes/go/appruntime/exported/model/request.go
+++ b/runtimes/go/appruntime/exported/model/request.go
@@ -171,7 +171,8 @@ type TestConfig struct {
 
 	ServiceMocks     map[string]ServiceMock
 	APIMocks         map[string]map[string]ApiMock
-	IsolatedServices *bool // Whether to isolate services for this test
+	IsolatedServices *bool                // Whether to isolate services for this test
+	EndCallbacks     []func(t *testing.T) // Callbacks to run when the test ends
 }
 
 type ServiceMock struct {

--- a/runtimes/go/et/manager_internal.go
+++ b/runtimes/go/et/manager_internal.go
@@ -5,6 +5,7 @@ import (
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/shared/reqtrack"
 	"encore.dev/appruntime/shared/testsupport"
+	"encore.dev/storage/sqldb"
 )
 
 //publicapigen:drop
@@ -13,9 +14,10 @@ type Manager struct {
 	rt      *reqtrack.RequestTracker
 	testMgr *testsupport.Manager
 	server  *api.Server
+	db      *sqldb.Manager
 }
 
 //publicapigen:drop
-func NewManager(static *config.Static, rt *reqtrack.RequestTracker, testMgr *testsupport.Manager, server *api.Server) *Manager {
-	return &Manager{static, rt, testMgr, server}
+func NewManager(static *config.Static, rt *reqtrack.RequestTracker, testMgr *testsupport.Manager, server *api.Server, db *sqldb.Manager) *Manager {
+	return &Manager{static, rt, testMgr, server, db}
 }

--- a/runtimes/go/et/pkgfn.go
+++ b/runtimes/go/et/pkgfn.go
@@ -3,7 +3,10 @@
 package et
 
 import (
+	"context"
+
 	"encore.dev/beta/auth"
+	"encore.dev/storage/sqldb"
 )
 
 // OverrideAuthInfo overrides the auth information for the current request.
@@ -38,4 +41,23 @@ func OverrideAuthInfo(uid auth.UID, data any) {
 // you can call this function to isolate the services for the impacted tests.
 func EnableServiceInstanceIsolation() {
 	Singleton.testMgr.SetIsolatedServices(true)
+}
+
+//publicapigen:keep
+type stringLiteral string
+
+// NewTestDatabase creates a new, fresh database for the database with the given name.
+// The database name must be a database known to Encore (via `sqldb.NewDatabase`),
+// otherwise it reports an error.
+//
+// The new database is cloned from a template database that has had all migrations applied to it,
+// but excludes any of the changes applied to the given db.
+//
+// The returned database is isolated to the current test and any sub-tests,
+// and is automatically dropped at the end of the test, and any
+// open connections are automatically closed.
+//
+// The provided name must be a constant string literal (like "mydb").
+func NewTestDatabase(ctx context.Context, name stringLiteral) (*sqldb.Database, error) {
+	return Singleton.db.NewTestDatabase(ctx, string(name))
 }

--- a/runtimes/go/et/singleton_internal.go
+++ b/runtimes/go/et/singleton_internal.go
@@ -7,7 +7,8 @@ import (
 	"encore.dev/appruntime/shared/appconf"
 	"encore.dev/appruntime/shared/reqtrack"
 	"encore.dev/appruntime/shared/testsupport"
+	"encore.dev/storage/sqldb"
 )
 
 //publicapigen:drop
-var Singleton = NewManager(appconf.Static, reqtrack.Singleton, testsupport.Singleton, api.Singleton)
+var Singleton = NewManager(appconf.Static, reqtrack.Singleton, testsupport.Singleton, api.Singleton, sqldb.Singleton)

--- a/runtimes/go/et/sqldb.go
+++ b/runtimes/go/et/sqldb.go
@@ -1,0 +1,11 @@
+package et
+
+import (
+	"context"
+
+	"encore.dev/storage/sqldb"
+)
+
+func (mgr *Manager) NewTestDatabase(ctx context.Context, name string) (*sqldb.Database, error) {
+	return mgr.db.NewTestDatabase(ctx, name)
+}

--- a/runtimes/go/storage/sqldb/sqldb_test.go
+++ b/runtimes/go/storage/sqldb/sqldb_test.go
@@ -73,7 +73,7 @@ func TestDBConf(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		cfg, err := dbConf(test.Srv, test.DB)
+		cfg, err := dbConf(test.Srv, test.DB, "")
 		if err != nil {
 			t.Fatalf("test %d: unexpected error: %v", i, err)
 		}

--- a/runtimes/go/storage/sqldb/test_db.go
+++ b/runtimes/go/storage/sqldb/test_db.go
@@ -1,0 +1,40 @@
+package sqldb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/xid"
+)
+
+func (mgr *Manager) NewTestDatabase(ctx context.Context, name string) (*Database, error) {
+	db := mgr.GetDB(name)
+	if db.noopDB {
+		return nil, fmt.Errorf("et: unknown database name: %q", name)
+	}
+
+	dbName := db.origName + "_" + xid.New().String()
+	templateName := db.origName + "_template"
+	if _, err := db.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s",
+		pgx.Identifier{dbName}.Sanitize(),
+		pgx.Identifier{templateName}.Sanitize(),
+	)); err != nil {
+		return nil, err
+	}
+
+	clone := &Database{
+		name:     dbName,
+		origName: db.origName,
+		mgr:      mgr,
+	}
+
+	mgr.ts.AddEndCallback(func(t *testing.T) {
+		// Shut down the connection pools and attempt to drop the database.
+		clone.shutdown()
+		_, _ = db.Exec(ctx, fmt.Sprintf("DROP DATABASE %s WITH (FORCE)",
+			pgx.Identifier{dbName}.Sanitize()))
+	})
+	return clone, nil
+}


### PR DESCRIPTION
This adds the ability to create fresh, temporary databases for tests.

It changes the test database setup to first create a template database, run the migrations against that, and then uses that as the basis for creating a clone. This is much faster than running the migrations again.