### PR TITLE
runtimes/js: remove jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,8 +1190,6 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
- "tikv-jemalloc-sys",
- "tikv-jemallocator",
  "tokio",
  "tokio-util",
 ]
@@ -4371,26 +4369,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.47",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/runtimes/js/Cargo.toml
+++ b/runtimes/js/Cargo.toml
@@ -32,9 +32,5 @@ tokio-util = { version = "0.7.10", features = ["io"] }
 chrono = "0.4.38"
 indexmap = { version = "2.2.6", features = ["serde"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.5" }
-tikv-jemalloc-sys = { version = "0.5", features = ["disable_initial_exec_tls"] }
-
 [build-dependencies]
 napi-build = "2.0.1"

--- a/runtimes/js/src/lib.rs
+++ b/runtimes/js/src/lib.rs
@@ -13,10 +13,3 @@ mod secret;
 mod sqldb;
 mod stream;
 mod threadsafe_function;
-
-#[cfg(not(target_env = "msvc"))]
-use tikv_jemallocator::Jemalloc;
-
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;


### PR DESCRIPTION
Can't get it working correctly in all environments at the moment. We'll try to reintroduce it later.