### PR TITLE
docs: update cron job docs to reflect encore cloud free tier limits

### DIFF
--- a/docs/primitives/cron-jobs.md
+++ b/docs/primitives/cron-jobs.md
@@ -55,7 +55,7 @@ Cron Job executions across all your environments via the `Cron Jobs` menu item:
 A few important things to know:
 
 - Cron Jobs do not run when developing locally or in [Preview Environments](/docs/deploy/preview-environments); but you can always call the API manually to test the behavior.
-- Cron Jobs execution in Encore Cloud is capped at **once every hour** for users on the Free Tier; [deploy to your own cloud](/docs/deploy/own-cloud) or upgrade to the [Pro plan](/pricing) to use more frequent executions.
+- Cron Jobs execution in Encore Cloud is capped at **once every hour** and the minute is randomized within the hour that they run for users on the Free Tier; [deploy to your own cloud](/docs/deploy/own-cloud) or upgrade to the [Pro plan](/pricing) to use more frequent executions or to set the minute within the hour when the job runs.
 - Cron Jobs support both public and private APIs.
 - The API endpoints used in Cron Jobs should always be idempotent. It's possible they're called multiple times in some network conditions.
 - The API endpoints used in Cron Jobs must not take any request parameters. That is, their signatures must be `func(context.Context) error` or `func(context.Context) (*T, error)`.

--- a/docs/ts/primitives/cron-jobs.md
+++ b/docs/ts/primitives/cron-jobs.md
@@ -55,7 +55,7 @@ Cron Job executions across all your environments via the `Cron Jobs` menu item:
 A few important things to know:
 
 - Cron Jobs do not run when developing locally or in [Preview Environments](/docs/deploy/preview-environments); but you can always call the API manually to test the behavior.
-- Cron Jobs execution in Encore Cloud is capped at **once every hour** for users on the Free Tier; [deploy to your own cloud](/docs/deploy/own-cloud) or upgrade to the [Pro plan](/pricing) to use more frequent executions.
+- Cron Jobs execution in Encore Cloud is capped at **once every hour** and the minute is randomized within the hour that they run for users on the Free Tier; [deploy to your own cloud](/docs/deploy/own-cloud) or upgrade to the [Pro plan](/pricing) to use more frequent executions or to set the minute within the hour when the job runs.
 - Cron Jobs support both public and private APIs.
 - The API endpoints used in Cron Jobs should always be idempotent. It's possible they're called multiple times in some network conditions.
 - The API endpoints used in Cron Jobs must not take any request parameters.


### PR DESCRIPTION
update cron job docs to reflect encore cloud free tier limits.

Based on conversation in:
https://discord.com/channels/814482502336905216/1236076710122885241