### PR TITLE
tsparser: handle file extension substitutions for tsconfig aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,10 +2137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
 dependencies = [
  "console",
+ "globset",
  "lazy_static",
  "linked-hash-map",
  "serde",
  "similar",
+ "walkdir",
 ]
 
 [[package]]

--- a/tsparser/Cargo.toml
+++ b/tsparser/Cargo.toml
@@ -53,5 +53,5 @@ prost-build = { version = "0.12.1" }
 [dev-dependencies]
 assert_fs = "1.1.1"
 assert_matches = "1.5.0"
-insta = { version = "1.38.0", features = ["yaml"] }
+insta = { version = "1.38.0", features = ["yaml", "glob"] }
 once_cell = "1.19.0"

--- a/tsparser/src/bin/tsparser-encore.rs
+++ b/tsparser/src/bin/tsparser-encore.rs
@@ -33,9 +33,7 @@ fn main() -> Result<()> {
         {
             let pp = builder::PrepareParams {
                 js_runtime_root: &js_runtime_path,
-                runtime_version: &prepare.runtime_version,
                 app_root: &prepare.app_root,
-                use_local_runtime: prepare.use_local_runtime,
             };
 
             match builder.prepare(&pp) {

--- a/tsparser/src/builder/prepare.rs
+++ b/tsparser/src/builder/prepare.rs
@@ -7,9 +7,7 @@ use super::Builder;
 #[derive(Debug, Clone)]
 pub struct PrepareParams<'a> {
     pub js_runtime_root: &'a Path,
-    pub runtime_version: &'a str,
     pub app_root: &'a Path,
-    pub use_local_runtime: bool,
 }
 
 impl Builder<'_> {

--- a/tsparser/tests/common/mod.rs
+++ b/tsparser/tests/common/mod.rs
@@ -1,0 +1,8 @@
+use clean_path::Clean;
+use std::path::PathBuf;
+
+pub fn js_runtime_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../runtimes/js")
+        .clean()
+}

--- a/tsparser/tests/parse_tests.rs
+++ b/tsparser/tests/parse_tests.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::io::{BufRead, Write};
+use std::path::Path;
+
+use anyhow::Result;
+use insta::{assert_snapshot, glob};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+use swc_common::{Globals, GLOBALS};
+use tempdir::TempDir;
+
+use encore_tsparser::builder;
+use encore_tsparser::builder::{Builder, ParseResult};
+use encore_tsparser::parser::parser::ParseContext;
+
+use crate::common::js_runtime_path;
+
+mod common;
+
+#[test]
+fn test_parser() {
+    env_logger::init();
+    glob!("testdata/*.txt", |path| {
+        let input = fs::read_to_string(path).unwrap();
+        let ar = txtar::from_str(&input);
+        let tmp_dir = TempDir::new("parse").unwrap();
+        ar.materialize(&tmp_dir).unwrap();
+        let _parse = parse_txtar(tmp_dir.path()).unwrap();
+    });
+}
+
+fn parse_txtar(app_root: &Path) -> Result<ParseResult> {
+    let globals = Globals::new();
+    GLOBALS.set(&globals, || -> Result<ParseResult> {
+        let builder = Builder::new()?;
+        let js_runtime_path = js_runtime_path();
+
+        let pc = ParseContext::new(app_root.to_path_buf(), &js_runtime_path)?;
+
+        let app = builder::App {
+            root: app_root.to_path_buf(),
+            platform_id: None,
+            local_id: "test".to_string(),
+        };
+        let pp = builder::ParseParams {
+            app: &app,
+            pc: &pc,
+            working_dir: app_root,
+            parse_tests: false,
+        };
+
+        builder.parse(&pp)
+    })
+}

--- a/tsparser/tests/testdata/tsconfig.txt
+++ b/tsparser/tests/testdata/tsconfig.txt
@@ -1,0 +1,27 @@
+-- foo/foo.ts --
+import { api } from "encore.dev/api";
+import { blah } from "@bar/bar";
+
+export const ping = api<void, void>({}, () => {});
+
+-- bar/bar.ts --
+
+export const blah = 5;
+
+-- package.json --
+{
+  "type": "module",
+  "dependencies": {
+    "encore.dev": "^1.35.0"
+  }
+}
+
+-- tsconfig.json --
+{
+  "compilerOptions": {
+    "paths": {
+      "~encore/*": ["./encore.gen/*"],
+      "@bar/*": ["./bar/*"]
+    }
+  }
+}


### PR DESCRIPTION
When `tsconfig.json` contains path aliases, we need to perform file extension substitution, as per the official docs [1].

[1]: https://www.typescriptlang.org/docs/handbook/modules/reference.html#file-extension-substitution

Thanks José Souza for the report!