### PR TITLE
docs: fix typos

### DIFF
--- a/docs/other/vs-heroku.md
+++ b/docs/other/vs-heroku.md
@@ -42,7 +42,7 @@ This can be a major distraction for application developers, because it forces th
 
 All this effort takes time away from product development and slows down onboarding time for new developers.
 
-**When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev envioronments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
+**When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev environments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
 
 This greatly speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 

--- a/docs/other/vs-heroku.md
+++ b/docs/other/vs-heroku.md
@@ -44,7 +44,7 @@ All this effort takes time away from product development and slows down onboardi
 
 **When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev envioronments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
 
-This greately speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
+This greatly speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 
 ## Encore provides an end-to-end purpose-built workflow for cloud backend developement
 

--- a/docs/other/vs-heroku.md
+++ b/docs/other/vs-heroku.md
@@ -46,7 +46,7 @@ All this effort takes time away from product development and slows down onboardi
 
 This greatly speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 
-## Encore provides an end-to-end purpose-built workflow for cloud backend developement
+## Encore provides an end-to-end purpose-built workflow for cloud backend development
 
 Encore does a lot more than just automate infrastructure provisioning and configuration. It's designed as a purpose-built tool for cloud backend development and comes with out-of-the-box tooling for both development and DevOps.
 

--- a/docs/other/vs-heroku.md
+++ b/docs/other/vs-heroku.md
@@ -34,7 +34,7 @@ You get the same, easy to use, "push to deploy" workflow that many developers ap
 
 ## Encore's local development workflow lets application developers focus
 
-When using PaaS service like Heroku to deploy your application, you're not at all solving for an efficient local development workflow.
+When using a PaaS service like Heroku to deploy your application, you're not at all solving for an efficient local development workflow.
 
 This means, with Heroku, developers need to manually set up and maintain their local environment and observability tools, in order to facilitate local development and testing.
 

--- a/docs/other/vs-supabase.md
+++ b/docs/other/vs-supabase.md
@@ -77,7 +77,7 @@ Unlike BaaS platforms like Supabase and Firebase, Encore has extensive support f
 
 For example, Encore lets you [define APIs](/docs/primitives/services-and-apis) using regular functions and enables cross-service type-safety with IDE auto-complete when making API calls between services.
 
-With Encore's [Backend SDK](/docs/primitives), you can build event-driven systems by defining Pub/Sub topcis and subscriptions as type-safe objects in your application.
+With Encore's [Backend SDK](/docs/primitives), you can build event-driven systems by defining Pub/Sub topics and subscriptions as type-safe objects in your application.
 This gives you type-safety for Pub/Sub with compilation errors for any type-errors.
 
 ## Encore's local development workflow lets application developers focus

--- a/docs/other/vs-supabase.md
+++ b/docs/other/vs-supabase.md
@@ -90,7 +90,7 @@ This can be a major distraction for application developers, because it forces th
 
 All this effort takes time away from product development and slows down onboarding time for new developers.
 
-**When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev envioronments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
+**When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev environments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
 
 This greately speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 

--- a/docs/other/vs-supabase.md
+++ b/docs/other/vs-supabase.md
@@ -82,7 +82,7 @@ This gives you type-safety for Pub/Sub with compilation errors for any type-erro
 
 ## Encore's local development workflow lets application developers focus
 
-When using BaaS service like Supabase to handle your infrastructure, you're not at all solving for local development.
+When using a BaaS service like Supabase to handle your infrastructure, you're not at all solving for local development.
 
 This means, with Supabase, developers need to manually set up and maintain their local environment in order to facilitate local development and testing.
 

--- a/docs/other/vs-supabase.md
+++ b/docs/other/vs-supabase.md
@@ -92,7 +92,7 @@ All this effort takes time away from product development and slows down onboardi
 
 **When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev environments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
 
-This greately speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
+This greatly speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 
 ## Encore provides an end-to-end purpose-built workflow for cloud backend development
 

--- a/docs/other/vs-supabase.md
+++ b/docs/other/vs-supabase.md
@@ -9,7 +9,7 @@ Supabase and Firebase are two popular _Backend as a Service_ providers, that pro
 
 This can be a great way of getting off the ground quickly. But as many developers have come to learn, you risk finding yourself boxed into a corner if you're not in full control of your own backend when new use cases arise.
 
-**Encore is not a _Backend as a Service_, it's a platform _for_ backend development**. It gives you many of the same benefits that Supabase and Firebase offer, like not needing to manually provision your [databases](/docs/primitives/databases) (or any other infrastructure for that matter). The key difference is, **Encore provisions your infrastructure in your own cloud account on AWS/GCP.** This also lets you easily use any cloud service offered by the major cloud providers, and you don't risk being limited by the platform and and having to start over from scratch.
+**Encore is not a _Backend as a Service_, it's a platform _for_ backend development**. It gives you many of the same benefits that Supabase and Firebase offer, like not needing to manually provision your [databases](/docs/primitives/databases) (or any other infrastructure for that matter). The key difference is, **Encore provisions your infrastructure in your own cloud account on AWS/GCP.** This also lets you easily use any cloud service offered by the major cloud providers, and you don't risk being limited by the platform and having to start over from scratch.
 
 Let's take a look at how Encore compares to BaaS platforms like Supabase and Firebase:
 

--- a/docs/other/vs-supabase.md
+++ b/docs/other/vs-supabase.md
@@ -94,7 +94,7 @@ All this effort takes time away from product development and slows down onboardi
 
 This greately speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 
-## Encore provides an end-to-end purpose-built workflow for cloud backend developement
+## Encore provides an end-to-end purpose-built workflow for cloud backend development
 
 Encore does a lot more than just automate infrastructure provisioning and configuration. It's designed as a purpose-built tool for cloud backend development and comes with out-of-the-box tooling for both development and DevOps.
 

--- a/docs/other/vs-terraform.md
+++ b/docs/other/vs-terraform.md
@@ -53,7 +53,7 @@ When using IaC tools like Terraform, you must always assign explicit permissions
 
 When using Encore, IAM identities and policies are automatically defined according to best practices for least privilege security. This is possible because Encore parses your source code and builds a graph of the logical architecture, it then uses this to define the infrastructure needs. This means Encore knows exactly which services needs access to which infrastructure for your application to function as expected.
 
-## Encore provides an end-to-end purpose-built workflow for cloud backend developement
+## Encore provides an end-to-end purpose-built workflow for cloud backend development
 
 Encore does a lot more than just automate infrastructure provisioning and configuration. It's designed as a purpose-built tool for cloud backend development and comes with out-of-the-box tooling for both development and DevOps.
 

--- a/docs/other/vs-terraform.md
+++ b/docs/other/vs-terraform.md
@@ -49,7 +49,7 @@ This greatly speeds up development iterations as developers can start using new 
 
 ## Encore ensures your cloud environments are secure by automating IAM
 
-When using IaC tools like Terraform, you must always assign explicit permissions using IAM idenities and IAM policies. This can be very time consuming when developing a large-scale distributed systems, and when you get it wrong it can lead to glaring security holes or unexpected system behavior.
+When using IaC tools like Terraform, you must always assign explicit permissions using IAM identities and IAM policies. This can be very time consuming when developing a large-scale distributed systems, and when you get it wrong it can lead to glaring security holes or unexpected system behavior.
 
 When using Encore, IAM identities and policies are automatically defined according to best practices for least privilege security. This is possible because Encore parses your source code and builds a graph of the logical architecture, it then uses this to define the infrastructure needs. This means Encore knows exactly which services needs access to which infrastructure for your application to function as expected.
 

--- a/docs/other/vs-terraform.md
+++ b/docs/other/vs-terraform.md
@@ -45,7 +45,7 @@ All this effort takes time away from product development and slows down onboardi
 
 **When using Encore, your local and cloud environments are both defined by the same code base: your application code.** This means developers only need to use `encore run` to start their local dev environments. Encore's Open Source CLI takes care of setting up local version of all infrastructure and provides a [local development dashboard](/docs/observability/dev-dash) with built-in observability tools.
 
-This greately speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
+This greatly speeds up development iterations as developers can start using new infrastructure immediately, which makes building new services and event-driven systems extremely efficient.
 
 ## Encore ensures your cloud environments are secure by automating IAM
 


### PR DESCRIPTION
Fixes a couple of typos I spotted when reading through the docs in the `other` directory 😊