### PR TITLE
tsparser: fix query/header single-arg parsing

### DIFF
--- a/tsparser/src/parser/types/mod.rs
+++ b/tsparser/src/parser/types/mod.rs
@@ -12,7 +12,8 @@ mod tests;
 
 pub use object::{Object, ObjectId, ObjectKind, ResolveState};
 pub use typ::{
-    Basic, ClassType, Generic, Interface, InterfaceField, Literal, Named, Type, TypeArgId,
+    Basic, ClassType, FieldName, Generic, Interface, InterfaceField, Literal, Named, Type,
+    TypeArgId,
 };
 pub use type_resolve::TypeChecker;
 pub use utils::*;

--- a/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@basic.ts.snap
+++ b/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@basic.ts.snap
@@ -8,21 +8,27 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Basic(
                         String,
                     ),
                 },
                 InterfaceField {
-                    name: "bar",
+                    name: String(
+                        "bar",
+                    ),
                     optional: false,
                     typ: Basic(
                         Number,
                     ),
                 },
                 InterfaceField {
-                    name: "optional",
+                    name: String(
+                        "optional",
+                    ),
                     optional: true,
                     typ: Basic(
                         Boolean,
@@ -51,7 +57,9 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Basic(
                         String,
@@ -66,14 +74,18 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Basic(
                         String,
                     ),
                 },
                 InterfaceField {
-                    name: "optional",
+                    name: String(
+                        "optional",
+                    ),
                     optional: true,
                     typ: Basic(
                         Boolean,
@@ -88,14 +100,18 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "bar",
+                    name: String(
+                        "bar",
+                    ),
                     optional: false,
                     typ: Basic(
                         Number,
                     ),
                 },
                 InterfaceField {
-                    name: "optional",
+                    name: String(
+                        "optional",
+                    ),
                     optional: true,
                     typ: Basic(
                         Boolean,
@@ -110,7 +126,9 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "optional",
+                    name: String(
+                        "optional",
+                    ),
                     optional: true,
                     typ: Basic(
                         Boolean,
@@ -125,21 +143,27 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: true,
                     typ: Basic(
                         String,
                     ),
                 },
                 InterfaceField {
-                    name: "bar",
+                    name: String(
+                        "bar",
+                    ),
                     optional: true,
                     typ: Basic(
                         Number,
                     ),
                 },
                 InterfaceField {
-                    name: "optional",
+                    name: String(
+                        "optional",
+                    ),
                     optional: true,
                     typ: Basic(
                         Boolean,
@@ -177,14 +201,18 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Basic(
                         String,
                     ),
                 },
                 InterfaceField {
-                    name: "bar",
+                    name: String(
+                        "bar",
+                    ),
                     optional: false,
                     typ: Basic(
                         Number,
@@ -199,7 +227,9 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Literal(
                         String(
@@ -216,7 +246,9 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Basic(
                         Never,
@@ -231,7 +263,9 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "foo",
+                    name: String(
+                        "foo",
+                    ),
                     optional: false,
                     typ: Literal(
                         String(
@@ -248,21 +282,27 @@ input_file: tsparser/src/parser/types/testdata/basic.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "a",
+                    name: String(
+                        "a",
+                    ),
                     optional: false,
                     typ: Basic(
                         Any,
                     ),
                 },
                 InterfaceField {
-                    name: "b",
+                    name: String(
+                        "b",
+                    ),
                     optional: false,
                     typ: Basic(
                         String,
                     ),
                 },
                 InterfaceField {
-                    name: "c",
+                    name: String(
+                        "c",
+                    ),
                     optional: false,
                     typ: Basic(
                         Never,

--- a/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@generics.ts.snap
+++ b/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@generics.ts.snap
@@ -8,7 +8,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "cond",
+                    name: String(
+                        "cond",
+                    ),
                     optional: false,
                     typ: Generic(
                         Conditional(
@@ -45,7 +47,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "value",
+                    name: String(
+                        "value",
+                    ),
                     optional: false,
                     typ: Generic(
                         TypeParam(
@@ -57,7 +61,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
                     ),
                 },
                 InterfaceField {
-                    name: "cond",
+                    name: String(
+                        "cond",
+                    ),
                     optional: false,
                     typ: Generic(
                         Conditional(
@@ -94,7 +100,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
         Interface {
             fields: [
                 InterfaceField {
-                    name: "one",
+                    name: String(
+                        "one",
+                    ),
                     optional: false,
                     typ: Named(
                         Named {
@@ -112,7 +120,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
                     ),
                 },
                 InterfaceField {
-                    name: "two",
+                    name: String(
+                        "two",
+                    ),
                     optional: false,
                     typ: Named(
                         Named {
@@ -132,7 +142,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
                     ),
                 },
                 InterfaceField {
-                    name: "three",
+                    name: String(
+                        "three",
+                    ),
                     optional: false,
                     typ: Named(
                         Named {
@@ -150,7 +162,9 @@ input_file: tsparser/src/parser/types/testdata/generics.ts
                     ),
                 },
                 InterfaceField {
-                    name: "four",
+                    name: String(
+                        "four",
+                    ),
                     optional: false,
                     typ: Named(
                         Named {

--- a/tsparser/tests/testdata/query_header.txt
+++ b/tsparser/tests/testdata/query_header.txt
@@ -1,0 +1,27 @@
+-- foo/foo.ts --
+import { api, Query, Header } from "encore.dev/api";
+
+interface Params {
+    q1: Query;
+    q2: Query<boolean>;
+    q3: Query<"my-query">;
+    q4: Query<boolean, "my-query">;
+
+    h1: Header;
+    h2: Header<boolean>;
+    h3: Header<"my-header">;
+    h4: Header<boolean, "my-header">;
+};
+
+export const t1 = api<Params, void>({}, () => {});
+export const t2 = api<void, Params>({}, () => {});
+export const t3 = api<Params, Params>({}, () => {});
+
+-- package.json --
+{
+  "name": "foo",
+  "type": "module",
+  "dependencies": {
+    "encore.dev": "^1.35.0"
+  }
+}


### PR DESCRIPTION
The parsing of the single-argument versions of
the Query and Header builtins didn't match the
TypeScript type definitions.
