### PR TITLE
tsparser: treat SQLDatabase.named as reference

### DIFF
--- a/tsparser/src/parser/resources/infra/sqldb.rs
+++ b/tsparser/src/parser/resources/infra/sqldb.rs
@@ -113,7 +113,7 @@ pub const SQLDB_PARSER: ResourceParser = ResourceParser {
                         name: r.resource_name,
                     }),
                     object,
-                    kind: BindKind::Create,
+                    kind: BindKind::Reference,
                     ident: r.bind_name,
                 });
             }


### PR DESCRIPTION
Otherwise we end up with duplicate database definitions.
