### PR TITLE
runtimes/core: coerce strings for query params

### DIFF
--- a/runtimes/core/src/api/schema/body.rs
+++ b/runtimes/core/src/api/schema/body.rs
@@ -1,6 +1,7 @@
 use axum::http::HeaderValue;
 
 use crate::api;
+use crate::api::jsonschema::DecodeConfig;
 use crate::api::schema::{JSONPayload, ToOutgoingRequest};
 use crate::api::{jsonschema, APIResult};
 use http_body_util::BodyExt;
@@ -29,7 +30,12 @@ impl Body {
             .to_bytes();
 
         let mut jsonde = serde_json::Deserializer::from_slice(&bytes);
-        let value = serde::de::DeserializeSeed::deserialize(&self.schema, &mut jsonde)
+        let cfg = DecodeConfig {
+            coerce_strings: false,
+        };
+        let value = self
+            .schema
+            .deserialize(&mut jsonde, cfg)
             .map_err(|e| api::Error::invalid_argument("unable to decode request body", e))?;
         Ok(Some(value))
     }

--- a/runtimes/core/src/api/schema/query.rs
+++ b/runtimes/core/src/api/schema/query.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::api::jsonschema::DecodeConfig;
 use crate::api::schema::{JSONPayload, ToOutgoingRequest};
 use crate::api::{jsonschema, APIResult};
 use serde::de::DeserializeSeed;
@@ -27,8 +28,13 @@ impl Query {
     ) -> APIResult<Option<serde_json::Map<String, serde_json::Value>>> {
         let parsed = form_urlencoded::parse(query.unwrap_or_default().as_bytes());
         let de = serde_urlencoded::Deserializer::new(parsed);
+        let cfg = DecodeConfig {
+            coerce_strings: true,
+        };
 
-        let decoded = DeserializeSeed::deserialize(&self.schema, de)
+        let decoded = self
+            .schema
+            .deserialize(de, cfg)
             .map_err(|e| api::Error::invalid_argument("unable to decode query string", e))?;
 
         Ok(Some(decoded))


### PR DESCRIPTION
Query parameters are always received as strings,
so we need to coerce them into the appropriate basic type.
