### PR TITLE
runtimes/core: set x-encore-deploy-id

### DIFF
--- a/runtimes/core/src/trace/log.rs
+++ b/runtimes/core/src/trace/log.rs
@@ -77,6 +77,10 @@ impl Reporter {
                 HeaderValue::from_str(&self.config.env_id).unwrap(),
             );
             headers.insert(
+                "X-Encore-Deploy-Id",
+                HeaderValue::from_str(&self.config.deploy_id).unwrap(),
+            );
+            headers.insert(
                 "X-Encore-App-Commit",
                 HeaderValue::from_str(&self.config.app_commit).unwrap(),
             );


### PR DESCRIPTION
It's required for the platform to record stats correctly
