### PR TITLE
Support configurable body limit

### DIFF
--- a/proto/encore/parser/meta/v1/meta.proto
+++ b/proto/encore/parser/meta/v1/meta.proto
@@ -95,6 +95,10 @@ message RPC {
   // Whether the endpoint is exposed to the public, keyed by gateway.
   map<string, ExposeOptions> expose = 14;
 
+  // The maximum size of the request body in bytes.
+  // If not set, defaults to no limit.
+  optional uint64 body_limit = 15;
+
   enum AccessType {
     PRIVATE = 0;
     PUBLIC = 1;

--- a/runtimes/core/src/trace/eventbuf.rs
+++ b/runtimes/core/src/trace/eventbuf.rs
@@ -180,8 +180,8 @@ impl EventBuffer {
         // Note: Rust's duration type is for positive durations only, so we only consider
         // the positive range of i64 here.
         let nanos = duration.as_nanos();
-        let nanos: i64 = if nanos > std::i64::MAX as u128 {
-            std::i64::MAX
+        let nanos: i64 = if nanos > i64::MAX as u128 {
+            i64::MAX
         } else {
             nanos as i64
         };

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -24,10 +24,47 @@ export type Query<
 > = TypeOrName extends string ? string : TypeOrName;
 
 export interface APIOptions {
+  /**
+   * The HTTP method(s) to match for this endpoint.
+   * Use "*" to match any method.
+   */
   method?: Method | Method[] | "*";
+
+  /**
+   * The request path to match for this endpoint.
+   *
+   * Use `:` to define single-segment parameters, e.g. `/users/:id`.
+   * Use `*` to match any number of segments, e.g. `/files/*path`.
+   *
+   * If not specified, it defaults to `/<service-name>.<endpoint-name>`.
+   */
   path?: string;
+
+  /**
+   * Whether or not to make this endpoint publicly accessible.
+   * If false, the endpoint is only accessible from the internal network.
+   *
+   * Defaults to false if not specified.
+   */
   expose?: boolean;
+
+  /**
+   * Whether or not the request must contain valid authentication credentials.
+   * If set to true and the request is not authenticated,
+   * Encore returns a 401 Unauthorized error.
+   *
+   * Defaults to false if not specified.
+   */
   auth?: boolean;
+
+  /**
+   * The maximum body size, in bytes. If the request body exceeds this value,
+   * Encore stops request processing and returns an error.
+   *
+   * If left unspecified it defaults to a reasonable default (currently 2MiB).
+   * If set to `null`, the body size is unlimited.
+   **/
+  bodyLimit?: number | null;
 }
 
 type HandlerFn<Params, Response> = Params extends void

--- a/tsparser/src/builder/transpiler.rs
+++ b/tsparser/src/builder/transpiler.rs
@@ -36,6 +36,7 @@ pub struct TranspileParams<'a> {
     pub cwd: &'a Path,
 
     /// The Encore CLI runtime version
+    #[allow(dead_code)]
     pub runtime_version: &'a String,
 
     /// The services and gateways to transpile.
@@ -51,6 +52,7 @@ pub(super) trait OutputTranspiler {
     fn transpile(&self, params: TranspileParams) -> Result<TranspileResult>;
 }
 
+#[allow(dead_code)]
 pub struct EsbuildCompiler<'a> {
     pub node_modules_dir: &'a Path,
     pub external: ExternalPackages<'a>,
@@ -160,6 +162,7 @@ impl OutputTranspiler for EsbuildCompiler<'_> {
 }
 
 pub struct BunBuildCompiler<'a> {
+    #[allow(dead_code)]
     pub node_modules_dir: &'a Path,
     pub external: ExternalPackages<'a>,
 }

--- a/tsparser/src/legacymeta/mod.rs
+++ b/tsparser/src/legacymeta/mod.rs
@@ -150,6 +150,7 @@ impl<'a> MetaBuilder<'a> {
                         sensitive: false,
                         loc: Some(loc_from_range(self.app_root, &self.pc.file_set, ep.range)?),
                         allow_unauthenticated: !ep.require_auth,
+                        body_limit: ep.body_limit,
                         expose: {
                             let mut map = HashMap::new();
                             if ep.expose {

--- a/tsparser/src/parser/resources/parseutil.rs
+++ b/tsparser/src/parser/resources/parseutil.rs
@@ -114,6 +114,7 @@ impl<Config: LitParser, const NAME_IDX: usize, const CONFIG_IDX: usize> Referenc
 
 pub struct UnnamedClassResource<Config, const CONFIG_IDX: usize = 0> {
     pub range: Range,
+    #[allow(dead_code)]
     pub constructor_args: Vec<ast::ExprOrSpread>,
     pub doc_comment: Option<String>,
     pub bind_name: Option<ast::Ident>,
@@ -156,7 +157,9 @@ impl<Config: LitParser, const CONFIG_IDX: usize> ReferenceParser
 
 pub struct NamedStaticMethod<const NAME_IDX: usize = 0> {
     pub range: Range,
+    #[allow(dead_code)]
     pub constructor_args: Vec<ast::ExprOrSpread>,
+    #[allow(dead_code)]
     pub doc_comment: Option<String>,
     pub resource_name: String,
     pub bind_name: Option<ast::Ident>,

--- a/tsparser/src/parser/usageparser/mod.rs
+++ b/tsparser/src/parser/usageparser/mod.rs
@@ -499,6 +499,7 @@ export const Bar = 5;
                 expose: true,
                 raw: false,
                 require_auth: false,
+                body_limit: None,
                 encoding: EndpointEncoding {
                     default_method: Method::Post,
                     methods: Methods::Some(vec![Method::Post]),
@@ -578,6 +579,7 @@ export const Bar = 5;
                 expose: true,
                 raw: false,
                 require_auth: false,
+                body_limit: None,
                 encoding: EndpointEncoding {
                     default_method: Method::Post,
                     methods: Methods::Some(vec![Method::Post]),


### PR DESCRIPTION
This adds the ability to customize the request body limit in Encore.ts, using the `bodyLimit?: number | null` option.