### PR TITLE
set level for all targets prefixed with encore_

### DIFF
--- a/runtimes/core/src/log/mod.rs
+++ b/runtimes/core/src/log/mod.rs
@@ -40,7 +40,7 @@ pub fn root() -> &'static Logger {
                     // Otherwise use ENCORE_RUNTIME_LOG to set the Encore runtime log level,
                     // which defaults
                     let level = std::env::var("ENCORE_RUNTIME_LOG").unwrap_or("debug".to_string());
-                    format!("encore_runtime_core={}", level)
+                    format!("encore_={level}")
                 });
                 env_logger::filter::Builder::new().parse(&level).build()
             };


### PR DESCRIPTION
Since we have several targets prefixed with `encore_`, like `encore_runtime_core` and `encore_js_runtime`.

We could also specify them all rather that use the prefix if we want more control.