### PR TITLE
cli/cmd/encore: fix watch mode

### DIFF
--- a/cli/cmd/encore/run.go
+++ b/cli/cmd/encore/run.go
@@ -54,7 +54,9 @@ func init() {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			appRoot, wd := determineAppRoot()
-			if !cmd.Flag("watch").Changed && debug.Value != "none" {
+			// If the user didn't explicitly set --watch and we're in debug mode, disable watching
+			// as we typically don't want to swap the process when the user is debugging.
+			if !cmd.Flag("watch").Changed && debug.Value != "" {
 				watch = false
 			}
 			runApp(appRoot, wd)


### PR DESCRIPTION
We changed the default value of debug to "", but the code was still
checking for "none". This led to watch mode being disabled even
when debugging is disabled.
