### PR TITLE
runtimes/core: Remove temporary bind of gateway listener

### DIFF
--- a/runtimes/core/src/api/gateway/mod.rs
+++ b/runtimes/core/src/api/gateway/mod.rs
@@ -109,7 +109,7 @@ impl Gateway {
         self.inner.shared.auth.as_ref()
     }
 
-    pub async fn serve(self, listen_addr: String) -> anyhow::Result<()> {
+    pub async fn serve(self, listen_addr: &str) -> anyhow::Result<()> {
         let conf = Arc::new(
             ServerConf::new_with_opt_override(&Opt {
                 upgrade: false,
@@ -122,7 +122,7 @@ impl Gateway {
         );
         let mut proxy = http_proxy_service(&conf, self);
 
-        proxy.add_tcp(&listen_addr);
+        proxy.add_tcp(listen_addr);
 
         let (_tx, rx) = watch::channel(false);
         proxy.start_service(None, rx).await;

--- a/runtimes/core/src/log/mod.rs
+++ b/runtimes/core/src/log/mod.rs
@@ -40,7 +40,7 @@ pub fn root() -> &'static Logger {
                     // Otherwise use ENCORE_RUNTIME_LOG to set the Encore runtime log level,
                     // which defaults
                     let level = std::env::var("ENCORE_RUNTIME_LOG").unwrap_or("debug".to_string());
-                    format!("encore_={level}")
+                    format!("encore_={level},pingora_core::listeners=warn,pingora_core::services::listening=warn")
                 });
                 env_logger::filter::Builder::new().parse(&level).build()
             };


### PR DESCRIPTION
The downside of this is that pingora will silently fail if the address in not bindable (or it will log out that it is trying to bind, and after 30 tries it will log out that is has failed, but we currently filter out those logs)