### PR TITLE
Cleanup unused cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,29 +688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
-dependencies = [
- "axum 0.7.5",
- "axum-core 0.4.3",
- "bytes",
- "cookie",
- "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "serde",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "backoff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,7 +812,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1067,17 +1044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,7 +1138,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "typenum",
 ]
 
@@ -1364,8 +1330,6 @@ dependencies = [
  "chrono",
  "encore-runtime-core",
  "futures",
- "indexmap 2.2.6",
- "lazy_static",
  "log",
  "mappable-rc",
  "napi",
@@ -1373,7 +1337,6 @@ dependencies = [
  "napi-derive",
  "prost",
  "prost-types",
- "serde",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -1389,26 +1352,21 @@ dependencies = [
  "aws-sdk-sns",
  "aws-sdk-sqs",
  "axum 0.7.5",
- "axum-extra",
  "backtrace",
  "base32",
  "base64 0.21.5",
  "bb8",
  "bb8-postgres",
- "byteorder",
  "bytes",
  "chrono",
  "colored",
  "duct",
  "env_logger 0.10.1",
- "fallible-iterator",
  "flate2",
  "form_urlencoded",
  "futures",
  "futures-core",
  "futures-util",
- "generic-array 1.0.0",
- "geo-types",
  "gjson",
  "google-cloud-gax",
  "google-cloud-googleapis",
@@ -1424,13 +1382,11 @@ dependencies = [
  "jsonwebtoken 9.2.0",
  "log",
  "matchit",
- "memchr",
  "mime",
  "native-tls",
  "once_cell",
  "openssl",
  "openssl-probe",
- "percent-encoding",
  "pingora",
  "postgres-native-tls",
  "postgres-protocol",
@@ -1441,18 +1397,14 @@ dependencies = [
  "radix_fmt",
  "rand 0.8.5",
  "reqwest 0.12.4",
- "ring 0.17.7",
  "rsa",
- "self_cell",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "serde_with",
  "sha2",
  "sha3",
- "socket2",
  "subtle",
- "sync_wrapper 0.1.2",
  "tokio",
  "tokio-nsq",
  "tokio-postgres",
@@ -1472,7 +1424,6 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "assert_matches",
- "bytes",
  "chrono",
  "clean-path",
  "convert_case",
@@ -1487,17 +1438,12 @@ dependencies = [
  "litparser-derive",
  "log",
  "once_cell",
- "os_pipe",
- "pathdiff",
  "prost",
  "prost-build",
  "regex",
- "rustc-hash",
- "self_cell",
  "serde",
  "serde_json",
  "serde_yaml 0.9.32",
- "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_loader",
@@ -1506,7 +1452,6 @@ dependencies = [
  "swc_ecma_visit",
  "symlink",
  "tempdir",
- "thiserror",
  "tracing",
  "tracing-subscriber",
  "txtar",
@@ -1756,15 +1701,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "generic-array"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -2559,13 +2495,9 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_loader",
  "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_visit",
  "syn 2.0.47",
 ]
 
@@ -4330,12 +4262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba"
-
-[[package]]
 name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5118,9 +5044,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "sync_wrapper"

--- a/runtimes/core/Cargo.toml
+++ b/runtimes/core/Cargo.toml
@@ -25,14 +25,9 @@ tokio-postgres = { version = "0.7.10", features = [
     "with-uuid-1",
     "with-chrono-0_4",
 ] }
-fallible-iterator = "0.2.0"
 tokio-util = "0.7.10"
-byteorder = "1.5.0"
-memchr = "2.6.4"
 futures-util = "0.3.30"
-socket2 = "0.5.5"
 rand = "0.8.5"
-percent-encoding = { version = "2.3.1", features = [] }
 env_logger = "0.10.1"
 google-cloud-pubsub = "0.22.1"
 google-cloud-googleapis = "0.12.0"
@@ -41,13 +36,11 @@ http-body-util = "0.1.0"
 http = "1.0.0"
 matchit = "0.7.3"
 axum = { version = "0.7.5", features = ["ws"] }
-axum-extra = { version = "0.9.1", features = ["cookie"] }
 chrono = { version = "0.4.31", features = ["serde"] }
 once_cell = "1.19.0"
 colored = "2.1.0"
 backtrace = "0.3.69"
 serde_with = "3.4.0"
-self_cell = "1.0.3"
 mime = "0.3.17"
 futures = "0.3.30"
 native-tls = "0.2.11"
@@ -57,17 +50,14 @@ url = "2.5.0"
 futures-core = { version = "0.3.30", features = [] }
 serde_urlencoded = "0.7.1"
 form_urlencoded = "1.2.1"
-ring = "0.17.7"
 httpdate = "1.0.3"
 hmac = "0.12.1"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
-generic-array = { version = "1.0.0", features = ["alloc"] }
 hex = "0.4.3"
 subtle = "2.5.0"
 radix_fmt = "1.0.0"
 indexmap = { version = "2.2.1", features = ["serde"] }
-sync_wrapper = { version = "0.1.2", features = ["futures"] }
 tower-service = "0.3.2"
 duct = "0.13.7"
 base32 = "0.4.0"
@@ -76,7 +66,6 @@ base32 = "0.4.0"
 openssl = { version = "0.10.57", features = ["vendored"] }
 bb8 = "0.8.3"
 bb8-postgres = "0.8.1"
-geo-types = "0.7.12"
 uuid = "1.7.0"
 openssl-probe = "0.1.5"
 jsonwebtoken = "9.2.0"

--- a/runtimes/js/Cargo.toml
+++ b/runtimes/js/Cargo.toml
@@ -16,11 +16,9 @@ napi = { version = "2.12.2", default-features = false, features = [
 ] }
 napi-derive = "2.12.2"
 encore-runtime-core = { path = "../core" }
-lazy_static = { version = "1.4.0", features = [] }
 axum = { version = "0.7.5" }
 tokio = "1.35.1"
 log = "0.4.20"
-serde = "1.0.194"
 serde_json = { version = "1.0.111", features = [] }
 anyhow = "1.0.76"
 bytes = "1.5.0"
@@ -30,7 +28,6 @@ futures = "0.3.30"
 mappable-rc = "0.1.1"
 tokio-util = { version = "0.7.10", features = ["io"] }
 chrono = "0.4.38"
-indexmap = { version = "2.2.6", features = ["serde"] }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/tsparser/Cargo.toml
+++ b/tsparser/Cargo.toml
@@ -14,12 +14,9 @@ swc_ecma_ast = "0.110.9"
 swc_ecma_visit = { version = "0.96.9", features = ["path"] }
 swc_ecma_transforms_base = "0.134.30"
 swc_ecma_loader = { version = "0.45.9", features = ["node", "tsc"] }
-swc_atoms = "0.6.4"
 swc_common = { version = "0.33.8", features = ["tty-emitter"] }
 walkdir = "2"
 anyhow = { version = "1.0.75", features = ["backtrace"] }
-rustc-hash = "1.1.0"
-thiserror = "1.0.48"
 clean-path = "0.2.1"
 log = "0.4.20"
 env_logger = "0.10.0"
@@ -27,7 +24,6 @@ txtar = { version = "1.0.0", path = "./txtar" }
 litparser = { version = "0.1.0", path = "./litparser" }
 litparser-derive = { version = "0.1.0", path = "./litparser-derive" }
 prost = "0.12.1"
-bytes = "1"
 tempdir = "0.3.7"
 cron-parser = "0.8.0"
 chrono = "0.4.31"
@@ -37,12 +33,9 @@ handlebars = { version = "4.4.0", features = ["no_logging"] }
 serde = { version = "1.0.188", features = ["rc"] }
 serde_json = "1.0.107"
 url = "2.4.1"
-self_cell = "1.0.1"
 convert_case = "0.6.0"
 itertools = "0.12.0"
-pathdiff = "0.2.1"
 duct = "0.13.6"
-os_pipe = "1.1.4"
 indexmap = { version = "2.1.0", features = ["serde"] }
 serde_yaml = "0.9.32"
 symlink = "0.1.0"

--- a/tsparser/litparser-derive/Cargo.toml
+++ b/tsparser/litparser-derive/Cargo.toml
@@ -16,10 +16,6 @@ anyhow = "1.0"
 litparser = { version = "0.1.0", path = "../litparser" }
 swc_ecma_parser = { version = "0.141.21", features = ["typescript"] }
 swc_ecma_ast = "0.110.9"
-swc_ecma_visit = { version = "0.96.9", features = ["path"] }
-swc_ecma_transforms_base = "0.134.30"
-swc_ecma_loader = { version = "0.45.9", features = ["node", "tsc"] }
-swc_atoms = "0.6.4"
 swc_common = { version = "0.33.8", features = ["tty-emitter"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Noticed that we have a bunch of dependencies that are not in use, so thought it would be good to clean up a bit (with the help of cargo machete).

I left `openssl` in core due to the comment here: https://github.com/encoredev/encore/blob/4b15a2eed29ea6d616bab85ab9822728349249af/runtimes/core/Cargo.toml#L65-L66
I assume that should be left in there?