### PR TITLE
Update pingora with windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,15 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,17 +962,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim 0.8.0",
+ "clap_derive",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1200,7 +1215,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 2.0.47",
 ]
 
@@ -1980,18 +1995,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2947,6 +2959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,9 +3226,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingora"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f12ec271706862433e71690f733309a9f4a71c767bb23aa0d8b3a1d2334e38"
+checksum = "9144f4950d87291365ca24e41b9a149bd38515d562a7464a6fd27ac12ca0874e"
 dependencies = [
  "pingora-cache",
  "pingora-core",
@@ -3222,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "pingora-cache"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05660ef5cb66ecb70053c9d90523c2f4ab2bee4b5cd0e430d033f4a1d0b9be03"
+checksum = "dbe55bddb694583a9db101e5ae5b31f570f2ccce312ac7d64c2e4a430510c4b3"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3256,15 +3274,16 @@ dependencies = [
 
 [[package]]
 name = "pingora-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d1c4588a28df9cff6f923a4ca89f2e3d38ad4a6a97a3e3914a84c9a5adabfe"
+checksum = "51dbd9509e3bb25a699bee76ba1befbffb4e733694d7e682d4bfe35a1a48cbb4"
 dependencies = [
  "ahash",
  "async-trait",
  "brotli",
  "bytes",
  "chrono",
+ "clap",
  "daemonize",
  "flate2",
  "futures",
@@ -3294,7 +3313,8 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sfv",
  "socket2",
- "structopt",
+ "strum",
+ "strum_macros",
  "thread_local",
  "tokio",
  "tokio-test",
@@ -3304,15 +3324,15 @@ dependencies = [
 
 [[package]]
 name = "pingora-error"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fab5d4c342ee9afedd3f037d7ed63e6371c1d54b2115215d59743dc24810b70"
+checksum = "8e39924926e498ddb0e64a642b6c5df56627afc0989b0f7be197eb096f998f0f"
 
 [[package]]
 name = "pingora-header-serde"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613872eb18f8af39895010b673829df2cda4767024c1e1303d4917bf50134d49"
+checksum = "37a4c91b93ffaf066443aca3ac669909695b7e93049482bb6c32125ba3366571"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3326,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "pingora-http"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf82e49fac35fab2e0accf87b3b761cff8ea768210408f0671fdf03e1eeaec48"
+checksum = "88243a433347f328442842d9596dfde5b8b171daaee4a3b16cbe74db033ef4cd"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3337,18 +3357,18 @@ dependencies = [
 
 [[package]]
 name = "pingora-ketama"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721784df91d49082c3c633eb62f51498d9c871009ea1e90c034b6023daec74b3"
+checksum = "324f14c8f90a534ce55c11dcbc88428f60a2540265f50b5ee7010561f45dd006"
 dependencies = [
  "crc32fast",
 ]
 
 [[package]]
 name = "pingora-load-balancing"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9a0889bcf7d6cc57ecbe2357ae05aa62ad25035338b0475cff0dc448e26344"
+checksum = "d58b52ccfec1b55d8d903d3f78d9bb7f96115fae78065f500cb126758cc85f41"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3366,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "pingora-lru"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18804829a254e9e929657bf5fce975e328ac13a150f35ca32d7cfd831f6cecc9"
+checksum = "9bb8f0df84b4b9afd63742c78e6c4b39413554f857e7d41502825e4ff9798e3e"
 dependencies = [
  "arrayvec",
  "hashbrown 0.14.3",
@@ -3378,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "pingora-openssl"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a799d7d6434d1c0e41daff965d8b7a26c2f2459bd120ae5294018749f70f63be"
+checksum = "4bbfc0c9d7f066a6e284dfef736e3bbfee07f1cc6e27c7a6bbd2ea6a45862932"
 dependencies = [
  "foreign-types",
  "libc",
@@ -3392,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "pingora-pool"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2009859df7d9db0e67622a54cb91caf8b3510c8016d4cea04c568b3cb2d35a1f"
+checksum = "7d10a7b0e4115c8098e454d77a96d8ac3d89cc9a95910a6ef10f2656160d463a"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -3407,12 +3427,13 @@ dependencies = [
 
 [[package]]
 name = "pingora-proxy"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b42eedf1f3cab0497a7f63ddc1f57bb0ee3d8ba8ccbcd338e6b2e86712c9ca"
+checksum = "333b96aff8d7c30f04f21e3e338ba5854d66df00a7cbe437dbb35a857b84e298"
 dependencies = [
  "async-trait",
  "bytes",
+ "clap",
  "futures",
  "h2 0.4.5",
  "http 1.0.0",
@@ -3424,15 +3445,14 @@ dependencies = [
  "pingora-http",
  "pingora-timeout",
  "regex",
- "structopt",
  "tokio",
 ]
 
 [[package]]
 name = "pingora-runtime"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b3220ffd0b1ccb1f65765318615a7c9358ba79c90fe52860f09f8899b499ea"
+checksum = "2f1c3302dec37b0e8916b0f637852f1e56450b7dafe6042f014343bc3cf12995"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -3442,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "pingora-timeout"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced7494c265909172e9bd7d61ceb0098abde8ec4f1744cdc555a24d084517829"
+checksum = "56f54daa3e32391201cfabde4dc1c2ecdfa60b4d6695ef47df56f42c55792ee3"
 dependencies = [
  "futures",
  "once_cell",
@@ -4758,38 +4778,27 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
+name = "strum"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
-name = "structopt-derive"
-version = "0.4.18"
+name = "strum_macros"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "rustversion",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -5194,12 +5203,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -5885,12 +5891,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,17 +29,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.11",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
@@ -968,7 +957,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2004,9 +1993,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2014,7 +2000,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.9",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -3252,7 +3238,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pingora"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "pingora-cache",
  "pingora-core",
@@ -3265,9 +3251,9 @@ dependencies = [
 [[package]]
 name = "pingora-cache"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
- "ahash 0.8.9",
+ "ahash",
  "async-trait",
  "blake2",
  "bytes",
@@ -3298,9 +3284,9 @@ dependencies = [
 [[package]]
 name = "pingora-core"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
- "ahash 0.8.9",
+ "ahash",
  "async-trait",
  "brotli",
  "bytes",
@@ -3341,18 +3327,19 @@ dependencies = [
  "tokio",
  "tokio-test",
  "unicase",
+ "windows-sys 0.59.0",
  "zstd",
 ]
 
 [[package]]
 name = "pingora-error"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 
 [[package]]
 name = "pingora-header-serde"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3367,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "pingora-http"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3377,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "pingora-ketama"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "crc32fast",
 ]
@@ -3385,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "pingora-load-balancing"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3399,25 +3386,25 @@ dependencies = [
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.4.6",
+ "rand 0.7.3",
  "tokio",
 ]
 
 [[package]]
 name = "pingora-lru"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "arrayvec",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "parking_lot",
- "rand 0.4.6",
+ "rand 0.7.3",
 ]
 
 [[package]]
 name = "pingora-openssl"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "foreign-types",
  "libc",
@@ -3430,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -3444,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "pingora-proxy"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3466,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "pingora-runtime"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -3477,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "pingora-timeout"
 version = "0.3.0"
-source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
+source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -4913,7 +4900,7 @@ name = "swc_cached"
 version = "0.3.18"
 source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#dad9dabc235999da20d6e7d1b29429943b555c4f"
 dependencies = [
- "ahash 0.8.9",
+ "ahash",
  "anyhow",
  "dashmap",
  "once_cell",
@@ -6111,7 +6098,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6129,7 +6116,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6149,17 +6145,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6170,9 +6167,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6182,9 +6179,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6194,9 +6191,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6206,9 +6209,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6218,9 +6221,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6230,9 +6233,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6242,9 +6245,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,17 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.11",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
@@ -1281,6 +1292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2004,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1989,7 +2014,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash",
+ "ahash 0.8.9",
  "allocator-api2",
 ]
 
@@ -3227,8 +3252,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pingora"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9144f4950d87291365ca24e41b9a149bd38515d562a7464a6fd27ac12ca0874e"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "pingora-cache",
  "pingora-core",
@@ -3241,10 +3265,9 @@ dependencies = [
 [[package]]
 name = "pingora-cache"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe55bddb694583a9db101e5ae5b31f570f2ccce312ac7d64c2e4a430510c4b3"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
- "ahash",
+ "ahash 0.8.9",
  "async-trait",
  "blake2",
  "bytes",
@@ -3275,10 +3298,9 @@ dependencies = [
 [[package]]
 name = "pingora-core"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51dbd9509e3bb25a699bee76ba1befbffb4e733694d7e682d4bfe35a1a48cbb4"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
- "ahash",
+ "ahash 0.8.9",
  "async-trait",
  "brotli",
  "bytes",
@@ -3325,14 +3347,12 @@ dependencies = [
 [[package]]
 name = "pingora-error"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e39924926e498ddb0e64a642b6c5df56627afc0989b0f7be197eb096f998f0f"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 
 [[package]]
 name = "pingora-header-serde"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a4c91b93ffaf066443aca3ac669909695b7e93049482bb6c32125ba3366571"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3347,8 +3367,7 @@ dependencies = [
 [[package]]
 name = "pingora-http"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88243a433347f328442842d9596dfde5b8b171daaee4a3b16cbe74db033ef4cd"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3358,8 +3377,7 @@ dependencies = [
 [[package]]
 name = "pingora-ketama"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324f14c8f90a534ce55c11dcbc88428f60a2540265f50b5ee7010561f45dd006"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "crc32fast",
 ]
@@ -3367,40 +3385,39 @@ dependencies = [
 [[package]]
 name = "pingora-load-balancing"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58b52ccfec1b55d8d903d3f78d9bb7f96115fae78065f500cb126758cc85f41"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "derivative",
  "fnv",
  "futures",
+ "http 1.0.0",
  "log",
  "pingora-core",
  "pingora-error",
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.8.5",
+ "rand 0.4.6",
  "tokio",
 ]
 
 [[package]]
 name = "pingora-lru"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8f0df84b4b9afd63742c78e6c4b39413554f857e7d41502825e4ff9798e3e"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "arrayvec",
- "hashbrown 0.14.3",
+ "hashbrown 0.12.3",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.4.6",
 ]
 
 [[package]]
 name = "pingora-openssl"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbfc0c9d7f066a6e284dfef736e3bbfee07f1cc6e27c7a6bbd2ea6a45862932"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "foreign-types",
  "libc",
@@ -3413,8 +3430,7 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d10a7b0e4115c8098e454d77a96d8ac3d89cc9a95910a6ef10f2656160d463a"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -3428,8 +3444,7 @@ dependencies = [
 [[package]]
 name = "pingora-proxy"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333b96aff8d7c30f04f21e3e338ba5854d66df00a7cbe437dbb35a857b84e298"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3451,8 +3466,7 @@ dependencies = [
 [[package]]
 name = "pingora-runtime"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1c3302dec37b0e8916b0f637852f1e56450b7dafe6042f014343bc3cf12995"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -3463,10 +3477,8 @@ dependencies = [
 [[package]]
 name = "pingora-timeout"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f54daa3e32391201cfabde4dc1c2ecdfa60b4d6695ef47df56f42c55792ee3"
+source = "git+https://github.com/fredr/pingora.git?branch=fredr/windows#c3e1739d23d43f3d2f5d07fe39e2a113c9f5bc8d"
 dependencies = [
- "futures",
  "once_cell",
  "parking_lot",
  "pin-project-lite",
@@ -4901,7 +4913,7 @@ name = "swc_cached"
 version = "0.3.18"
 source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#dad9dabc235999da20d6e7d1b29429943b555c4f"
 dependencies = [
- "ahash",
+ "ahash 0.8.9",
  "anyhow",
  "dashmap",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,7 +3238,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pingora"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "pingora-cache",
  "pingora-core",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "pingora-cache"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "pingora-core"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "ahash",
  "async-trait",
@@ -3334,12 +3334,12 @@ dependencies = [
 [[package]]
 name = "pingora-error"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 
 [[package]]
 name = "pingora-header-serde"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "pingora-http"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "bytes",
  "http 1.0.0",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "pingora-ketama"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "crc32fast",
 ]
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "pingora-load-balancing"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3386,25 +3386,25 @@ dependencies = [
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.7.3",
+ "rand 0.4.6",
  "tokio",
 ]
 
 [[package]]
 name = "pingora-lru"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "arrayvec",
  "hashbrown 0.14.3",
  "parking_lot",
- "rand 0.7.3",
+ "rand 0.4.6",
 ]
 
 [[package]]
 name = "pingora-openssl"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "foreign-types",
  "libc",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "pingora-pool"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "crossbeam-queue",
  "log",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "pingora-proxy"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "pingora-runtime"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -3464,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "pingora-timeout"
 version = "0.3.0"
-source = "git+https://github.com/encoredev/pingora?branch=windows#46b130401e6df424164b8ee905e3ae1fd716b413"
+source = "git+https://github.com/encoredev/pingora?branch=windows#dcc761b14104f926d7781dd9c2ffc70cd24d09c5"
 dependencies = [
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ swc_atoms = { git = "https://github.com/encoredev/swc", branch = "node-resolve-e
 swc_common = { git = "https://github.com/encoredev/swc", branch = "node-resolve-exports" }
 swc_ecma_loader = { git = "https://github.com/encoredev/swc", branch = "node-resolve-exports" }
 swc_ecma_visit = { git = "https://github.com/encoredev/swc", branch = "node-resolve-exports" }
+pingora = { git = "https://github.com/encoredev/pingora", branch = "windows" }

--- a/runtimes/core/Cargo.toml
+++ b/runtimes/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-pingora = { version = "0.2", features = [ "lb" ] }
+pingora = { version = "0.3", features = [ "lb" ] }
 anyhow = "1.0.76"
 base64 = "0.21.5"
 gjson = "0.8.1"

--- a/runtimes/core/src/api/gateway/mod.rs
+++ b/runtimes/core/src/api/gateway/mod.rs
@@ -120,7 +120,13 @@ impl Gateway {
         proxy.add_tcp(listen_addr);
 
         let (_tx, rx) = watch::channel(false);
-        proxy.start_service(None, rx).await;
+        proxy
+            .start_service(
+                #[cfg(unix)]
+                None,
+                rx,
+            )
+            .await;
 
         Ok(())
     }


### PR DESCRIPTION
Updates to latest version of pingora (0.3.0) and patches it with windows support from https://github.com/cloudflare/pingora/pull/344

Tested on windows with the typescript hello world app