### PR TITLE
clientgen/typescript: Add parentheses when lists element type is union

### DIFF
--- a/internal/clientgen/typescript.go
+++ b/internal/clientgen/typescript.go
@@ -1018,7 +1018,17 @@ func (ts *typescript) writeTyp(ns string, typ *schema.Type, numIndents int) {
 		}
 	case *schema.Type_List:
 		elem := typ.List.Elem
+		union, isUnion := elem.Typ.(*schema.Type_Union)
+		paren := isUnion && len(union.Union.Types) > 1
+
+		if paren {
+			ts.WriteString("(")
+		}
 		ts.writeTyp(ns, elem, numIndents)
+		if paren {
+			ts.WriteString(")")
+		}
+
 		ts.WriteString("[]")
 
 	case *schema.Type_Map:


### PR DESCRIPTION
Fixes wrapping list of unions with parentheses

```ts
interface Response {
  message: string;
  item?: Item;
}

interface X {
  a: string;
}
interface Y {
  b: (keyof X)[];
}

type Thing = { a: string; b: number };
type Item = {
  keys: (keyof Thing)[];
  otherField: ((X & Y) | X | Y)[];
};

```

Now generates the following type:

```ts
export interface Item {
    keys: ("a" | "b")[]
    otherField: ({
        a: string
        b: "a"[]
    } | X | Y)[]
}
```