### PR TITLE
tsparser: go tag pairs should be separated by colon

### DIFF
--- a/tsparser/src/legacymeta/schema.rs
+++ b/tsparser/src/legacymeta/schema.rs
@@ -304,7 +304,7 @@ impl<'a, 'b> BuilderCtx<'a, 'b> {
                 .iter()
                 .map(|tag| {
                     let mut s = tag.key.clone();
-                    s.push('=');
+                    s.push(':');
                     s.push('"');
                     s.push_str(&tag.name);
                     for opt in &tag.options {


### PR DESCRIPTION
Fix client generation from go to ts when we add go tags