### PR TITLE
Log raw log line when json formatting fails

### DIFF
--- a/cli/cmd/encore/main.go
+++ b/cli/cmd/encore/main.go
@@ -205,7 +205,10 @@ func convertJSONLogs(opts ...convertLogOption) outputConverter {
 		logLineBuffer.Reset()
 
 		// Then convert the JSON log line to pretty formatted text
-		_, _ = cout.Write(line)
+		_, err := cout.Write(line)
+		if err != nil {
+			return line
+		}
 		out := make([]byte, len(logLineBuffer.Bytes()))
 		copy(out, logLineBuffer.Bytes())
 		return out


### PR DESCRIPTION
Log out the raw line if json decoding fails

E.g when using `console.log({ hello: "world"})` an event will be emitted with invalid json (key name not quoted)

Fixes #1308