### PR TITLE
test: Add Docker export test with mock builder implementation

### DIFF
--- a/cli/daemon/export/export_test.go
+++ b/cli/daemon/export/export_test.go
@@ -114,7 +114,7 @@ func TestDocker(t *testing.T) {
 				mb.On("ServiceConfigs", mock.Anything, mock.Anything).Return(builder.ServiceConfigsResult{}, nil)
 				mb.On("Compile", mock.Anything, mock.Anything).Return(&builder.CompileResult{}, nil)
 				mb.On("Close").Return(nil)
-				// You might need to mock GenUserFacing as well, depending on your logic
+				// We might need to mock GenUserFacing as well
 				mb.On("GenUserFacing", mock.Anything, mock.Anything).Return(builder.GenUserFacingParams{}, nil)
 			},
 			expectedResult: true,

--- a/cli/daemon/export/export_test.go
+++ b/cli/daemon/export/export_test.go
@@ -1,0 +1,152 @@
+package export
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"encore.dev/appruntime/exported/experiments"
+	"encr.dev/cli/daemon/apps"
+	"encr.dev/pkg/appfile"
+	"encr.dev/pkg/builder"
+	"encr.dev/pkg/builder/builderimpl"
+	daemonpb "encr.dev/proto/encore/daemon"
+)
+
+// MockBuilder is a mock implementation of the builder.Impl interface
+type MockBuilder struct {
+	mock.Mock
+}
+
+func (m *MockBuilder) Parse(ctx context.Context, params builder.ParseParams) (*builder.ParseResult, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*builder.ParseResult), args.Error(1)
+}
+
+func (m *MockBuilder) Compile(ctx context.Context, params builder.CompileParams) (*builder.CompileResult, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*builder.CompileResult), args.Error(1)
+}
+
+func (m *MockBuilder) ServiceConfigs(ctx context.Context, params builder.ServiceConfigsParams) (*builder.ServiceConfigsResult, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*builder.ServiceConfigsResult), args.Error(1)
+}
+
+func (m *MockBuilder) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockBuilder) GenUserFacing(ctx context.Context, params builder.GenUserFacingParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(1)
+}
+
+func (m *MockBuilder) NeedsMeta() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockBuilder) RunTests(ctx context.Context, params builder.RunTestsParams) error {
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (m *MockBuilder) TestSpec(ctx context.Context, params builder.TestSpecParams) (*builder.TestSpecResult, error) {
+	args := m.Called(ctx, params)
+	return args.Get(0).(*builder.TestSpecResult), args.Error(1)
+}
+
+func (m *MockBuilder) UseNewRuntimeConfig() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+// MockResolveFunc is a function type for mocking builderimpl.Resolve
+type MockResolveFunc func(appfile.Lang, *experiments.Set) builder.Impl
+
+// resolveBuilder is a variable that holds the function to resolve the builder.
+// We'll modify this variable in our tests instead of directly changing builderimpl.Resolve.
+var resolveBuilder = builderimpl.Resolve
+
+// SetMockResolve replaces the builderimpl.Resolve function with a mock
+func SetMockResolve(mock MockResolveFunc) func() {
+	original := resolveBuilder
+	resolveBuilder = mock
+	return func() {
+		resolveBuilder = original
+	}
+}
+
+func TestDocker(t *testing.T) {
+	// Setup
+	ctx := context.Background()
+	app := &apps.Instance{}
+	log := zerolog.New(zerolog.NewTestWriter(t))
+
+	// Test cases
+	tests := []struct {
+		name           string
+		req            *daemonpb.ExportRequest
+		setupMocks     func(*MockBuilder)
+		expectedResult bool
+		expectedError  error
+	}{
+		{
+			name: "Successful export",
+			req: &daemonpb.ExportRequest{
+				Format: &daemonpb.ExportRequest_Docker{
+					Docker: &daemonpb.DockerExportParams{
+						BaseImageTag:       "alpine:latest",
+						LocalDaemonTag:     "myapp:latest",
+						PushDestinationTag: "registry.example.com/myapp:latest",
+					},
+				},
+				Goos:   "linux",
+				Goarch: "amd64",
+			},
+			setupMocks: func(mb *MockBuilder) {
+				mb.On("Parse", mock.Anything, mock.Anything).Return(builder.ParseResult{}, nil)
+				mb.On("ServiceConfigs", mock.Anything, mock.Anything).Return(builder.ServiceConfigsResult{}, nil)
+				mb.On("Compile", mock.Anything, mock.Anything).Return(&builder.CompileResult{}, nil)
+				mb.On("Close").Return(nil)
+				// You might need to mock GenUserFacing as well, depending on your logic
+				mb.On("GenUserFacing", mock.Anything, mock.Anything).Return(builder.GenUserFacingParams{}, nil)
+			},
+			expectedResult: true,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mb := new(MockBuilder)
+			tt.setupMocks(mb)
+
+			// Set up the mock resolve function
+			restore := SetMockResolve(func(lang appfile.Lang, expSet *experiments.Set) builder.Impl {
+				return mb
+			})
+			defer restore()
+
+			// Run the test
+			result, err := Docker(ctx, app, tt.req, log)
+
+			// Assertions
+			assert.Equal(t, tt.expectedResult, result)
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Verify mocks
+			mb.AssertExpectations(t)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/jwalton/go-supportscolor v1.1.0
+	github.com/lib/pq v1.10.9
 	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/mattn/go-runewidth v0.0.15
 	github.com/mattn/go-sqlite3 v1.14.18
@@ -57,6 +58,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/sqlc-dev/sqlc v1.25.0
+	github.com/stretchr/testify v1.8.4
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	go.encore.dev/platform-sdk v1.1.0
 	go.uber.org/goleak v1.2.1
@@ -131,7 +133,6 @@ require (
 	github.com/klauspost/compress v1.17.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -156,6 +157,7 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20220801062533-2eaa32854a6c // indirect
 	github.com/pingcap/log v1.1.0 // indirect
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20231103154709-4f00ece106b1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220131092820-39736dd543b4 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
@@ -163,6 +165,7 @@ require (
 	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tetratelabs/wazero v1.6.0 // indirect
 	github.com/vbatts/tar-split v0.11.5 // indirect
 	github.com/wasilibs/go-pgquery v0.0.0-20231208014744-de63626a1e99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1284,6 +1284,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
It introduces a new file `export_test.go` with unit tests for the export functionality. The tests use a mock implementation of the `builder.Impl` interface called `MockBuilder`.

The commit also includes an update to the `go.mod` file, adding the `github.com/lib/pq` and `github.com/stretchr/testify` dependencies.

Lastly, the `go.sum` file is updated with the checksum for the `github.com/stretchr/objx` v0.5.0 dependency.

Related:
- #1316 