### PR TITLE
runtimes/core: handle worker mode

### DIFF
--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -44,6 +44,7 @@ impl ServiceRegistry {
         deploy_id: String,
         http_client: reqwest::Client,
         tracer: Tracer,
+        is_worker: bool,
     ) -> anyhow::Result<Self> {
         let mut base_urls = HashMap::with_capacity(sd.services.len());
         let mut service_auth = HashMap::with_capacity(sd.services.len());
@@ -75,7 +76,7 @@ impl ServiceRegistry {
                     service_auth.insert(svc, auth_method);
                 }
             }
-        } else if !hosted_services.is_empty() {
+        } else if !hosted_services.is_empty() && !is_worker {
             // This shouldn't happen if things are configured correctly.
             ::log::error!(
                 "internal encore error: cannot host services without provided own address"

--- a/runtimes/core/src/api/manager.rs
+++ b/runtimes/core/src/api/manager.rs
@@ -39,6 +39,7 @@ pub struct ManagerConfig<'a> {
     pub platform_validator: Arc<platform::RequestValidator>,
     pub pubsub_push_registry: pubsub::PushHandlerRegistry,
     pub runtime: tokio::runtime::Handle,
+    pub is_worker: bool,
 }
 
 pub struct Manager {
@@ -56,14 +57,14 @@ pub struct Manager {
 
 impl ManagerConfig<'_> {
     pub fn build(mut self) -> anyhow::Result<Manager> {
-        let gateway_listen_addr = if !self.hosted_gateway_rids.is_empty() {
+        let gateway_listen_addr = if !self.hosted_gateway_rids.is_empty() && !self.is_worker {
             // We have a gateway. Have the gateway listen on the provided listen_addr.
             Some(listen_addr())
         } else {
             None
         };
 
-        let api_listener = if !self.hosted_services.is_empty() {
+        let api_listener = if !self.hosted_services.is_empty() && !self.is_worker {
             // If we already have a gateway, it's listening on the externally provided listen addr.
             // Use a random local port in that case.
             let addr = if gateway_listen_addr.is_some() {
@@ -128,11 +129,12 @@ impl ManagerConfig<'_> {
             self.deploy_id.clone(),
             self.http_client.clone(),
             self.tracer.clone(),
+            self.is_worker,
         )
         .context("unable to create service registry")?;
         let service_registry = Arc::new(service_registry);
 
-        let api_server = if !hosted_services.is_empty() {
+        let api_server = if !hosted_services.is_empty() && !self.is_worker {
             let server = server::Server::new(
                 endpoints.clone(),
                 hosted_endpoints,
@@ -163,6 +165,9 @@ impl ManagerConfig<'_> {
         );
 
         for gw in &self.meta.gateways {
+            if self.is_worker {
+                continue;
+            }
             let Some(gw_cfg) = hosted_gateways.get(gw.encore_name.as_str()) else {
                 continue;
             };

--- a/runtimes/js/encore.dev/internal/runtime/mod.ts
+++ b/runtimes/js/encore.dev/internal/runtime/mod.ts
@@ -1,5 +1,9 @@
+import { isMainThread } from "node:worker_threads";
 import { Runtime } from "./napi/napi.cjs";
 
 export * from "./napi/napi.cjs";
 
-export const RT = new Runtime();
+export const RT = new Runtime({
+  testMode: process.env.NODE_ENV === "test",
+  isWorker: !isMainThread,
+});

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -19,18 +19,30 @@ pub struct Runtime {
     pub(crate) runtime: Arc<encore_runtime_core::Runtime>,
 }
 
+#[napi(object)]
+#[derive(Default)]
+pub struct RuntimeOptions {
+    pub test_mode: Option<bool>,
+    pub is_worker: Option<bool>,
+}
+
 #[napi]
 impl Runtime {
     #[napi(constructor)]
-    pub fn new() -> napi::Result<Self> {
+    pub fn new(options: Option<RuntimeOptions>) -> napi::Result<Self> {
+        let options = options.unwrap_or_default();
         // Initialize logging.
         encore_runtime_core::log::init();
 
-        let test_mode_enabled = std::env::var("NODE_ENV").is_ok_and(|val| val == "test");
+        let test_mode = options
+            .test_mode
+            .unwrap_or(std::env::var("NODE_ENV").is_ok_and(|val| val == "test"));
+        let is_worker = options.is_worker.unwrap_or(false);
         let runtime = encore_runtime_core::Runtime::builder()
-            .with_test_mode(test_mode_enabled)
+            .with_test_mode(test_mode)
             .with_meta_autodetect()
             .with_runtime_config_from_env()
+            .with_worker(is_worker)
             .build()
             .map_err(|e| {
                 Error::new(
@@ -42,7 +54,7 @@ impl Runtime {
 
         // If we're running tests, there's no specific entrypoint so
         // start the runtime in the background immediately.
-        if test_mode_enabled {
+        if test_mode {
             let runtime = runtime.clone();
             thread::spawn(move || {
                 runtime.run_blocking();


### PR DESCRIPTION
When the runtime starts up it by default begins listening to
HTTP requests and so on. But when running in a worker thread
this is undesirable. To support this use case, tell the runtime
on startup whether it's running in a worker or not and disable
listening for ports if that's the case.
