### PR TITLE
runtimes/js: don't set worker mode in tests

### DIFF
--- a/runtimes/js/encore.dev/internal/runtime/mod.ts
+++ b/runtimes/js/encore.dev/internal/runtime/mod.ts
@@ -3,7 +3,9 @@ import { Runtime } from "./napi/napi.cjs";
 
 export * from "./napi/napi.cjs";
 
+const testMode = process.env.NODE_ENV === "test";
+
 export const RT = new Runtime({
-  testMode: process.env.NODE_ENV === "test",
-  isWorker: !isMainThread,
+  testMode,
+  isWorker: !isMainThread && !testMode,
 });


### PR DESCRIPTION
Variable `isMainThread` is `false` in tests, causing the runtime to setup incorrectly.
