### PR TITLE
runtimes/js: Re-use runtime in workers

### DIFF
--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -44,7 +44,6 @@ impl ServiceRegistry {
         deploy_id: String,
         http_client: reqwest::Client,
         tracer: Tracer,
-        is_worker: bool,
     ) -> anyhow::Result<Self> {
         let mut base_urls = HashMap::with_capacity(sd.services.len());
         let mut service_auth = HashMap::with_capacity(sd.services.len());
@@ -76,7 +75,7 @@ impl ServiceRegistry {
                     service_auth.insert(svc, auth_method);
                 }
             }
-        } else if !hosted_services.is_empty() && !is_worker {
+        } else if !hosted_services.is_empty() {
             // This shouldn't happen if things are configured correctly.
             ::log::error!(
                 "internal encore error: cannot host services without provided own address"

--- a/runtimes/core/src/lib.rs
+++ b/runtimes/core/src/lib.rs
@@ -167,7 +167,7 @@ impl RuntimeBuilder {
         let cfg = self.cfg.context("runtime config not provided")?;
         let md = self.md.context("metadata not provided")?;
 
-        Runtime::new(cfg, md, self.test_mode, self.is_worker)
+        Runtime::new(cfg, md, self.test_mode)
     }
 }
 
@@ -190,7 +190,6 @@ impl Runtime {
         mut cfg: runtimepb::RuntimeConfig,
         md: metapb::Data,
         testing: bool,
-        is_worker: bool,
     ) -> anyhow::Result<Self> {
         // Initialize OpenSSL system root certificates, so that libraries can find them.
         openssl_probe::init_ssl_cert_env_vars();
@@ -293,7 +292,6 @@ impl Runtime {
             platform_validator,
             pubsub_push_registry: pubsub.push_registry(),
             runtime: tokio_rt.handle().clone(),
-            is_worker,
         }
         .build()
         .context("unable to initialize api manager")?;

--- a/runtimes/js/encore.dev/internal/runtime/mod.ts
+++ b/runtimes/js/encore.dev/internal/runtime/mod.ts
@@ -1,9 +1,7 @@
-import { isMainThread } from "node:worker_threads";
 import { Runtime } from "./napi/napi.cjs";
 
 export * from "./napi/napi.cjs";
 
 export const RT = new Runtime({
   testMode: process.env.NODE_ENV === "test",
-  isWorker: !isMainThread,
 });

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -28,6 +28,23 @@ pub struct RuntimeOptions {
     pub test_mode: Option<bool>,
 }
 
+fn init_runtime(test_mode: bool) -> napi::Result<encore_runtime_core::Runtime> {
+    // Initialize logging.
+    encore_runtime_core::log::init();
+
+    encore_runtime_core::Runtime::builder()
+        .with_test_mode(test_mode)
+        .with_meta_autodetect()
+        .with_runtime_config_from_env()
+        .build()
+        .map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("failed to initialize runtime: {:?}", e),
+            )
+        })
+}
+
 #[napi]
 impl Runtime {
     #[napi(constructor)]
@@ -37,35 +54,24 @@ impl Runtime {
             .test_mode
             .unwrap_or(std::env::var("NODE_ENV").is_ok_and(|val| val == "test"));
 
+        if test_mode {
+            let runtime = Arc::new(init_runtime(test_mode)?);
+            // If we're running tests, there's no specific entrypoint so
+            // start the runtime in the background immediately.
+            if test_mode {
+                let runtime = runtime.clone();
+                thread::spawn(move || {
+                    runtime.run_blocking();
+                });
+            }
+
+            return Ok(Self { runtime });
+        }
+
         let runtime = RUNTIME
-            .get_or_init(|| {
-                // Initialize logging.
-                encore_runtime_core::log::init();
-
-                let runtime = encore_runtime_core::Runtime::builder()
-                    .with_test_mode(test_mode)
-                    .with_meta_autodetect()
-                    .with_runtime_config_from_env()
-                    .build()
-                    .map_err(|e| {
-                        Error::new(
-                            Status::GenericFailure,
-                            format!("failed to initialize runtime: {:?}", e),
-                        )
-                    })?;
-
-                Ok(Arc::new(runtime))
-            })
+            .get_or_init(|| Ok(Arc::new(init_runtime(false)?)))
             .clone()?;
 
-        // If we're running tests, there's no specific entrypoint so
-        // start the runtime in the background immediately.
-        if test_mode {
-            let runtime = runtime.clone();
-            thread::spawn(move || {
-                runtime.run_blocking();
-            });
-        }
         Ok(Self { runtime })
     }
 

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -11,8 +11,10 @@ use encore_runtime_core::EncoreName;
 use napi::bindgen_prelude::*;
 use napi::{Error, Status};
 use napi_derive::napi;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::thread;
+
+static RUNTIME: OnceLock<napi::Result<Arc<encore_runtime_core::Runtime>>> = OnceLock::new();
 
 #[napi]
 pub struct Runtime {
@@ -23,7 +25,6 @@ pub struct Runtime {
 #[derive(Default)]
 pub struct RuntimeOptions {
     pub test_mode: Option<bool>,
-    pub is_worker: Option<bool>,
 }
 
 #[napi]
@@ -31,26 +32,30 @@ impl Runtime {
     #[napi(constructor)]
     pub fn new(options: Option<RuntimeOptions>) -> napi::Result<Self> {
         let options = options.unwrap_or_default();
-        // Initialize logging.
-        encore_runtime_core::log::init();
-
         let test_mode = options
             .test_mode
             .unwrap_or(std::env::var("NODE_ENV").is_ok_and(|val| val == "test"));
-        let is_worker = options.is_worker.unwrap_or(false);
-        let runtime = encore_runtime_core::Runtime::builder()
-            .with_test_mode(test_mode)
-            .with_meta_autodetect()
-            .with_runtime_config_from_env()
-            .with_worker(is_worker)
-            .build()
-            .map_err(|e| {
-                Error::new(
-                    Status::GenericFailure,
-                    format!("failed to initialize runtime: {:?}", e),
-                )
-            })?;
-        let runtime = Arc::new(runtime);
+
+        let runtime = RUNTIME
+            .get_or_init(|| {
+                // Initialize logging.
+                encore_runtime_core::log::init();
+
+                let runtime = encore_runtime_core::Runtime::builder()
+                    .with_test_mode(test_mode)
+                    .with_meta_autodetect()
+                    .with_runtime_config_from_env()
+                    .build()
+                    .map_err(|e| {
+                        Error::new(
+                            Status::GenericFailure,
+                            format!("failed to initialize runtime: {:?}", e),
+                        )
+                    })?;
+
+                Ok(Arc::new(runtime))
+            })
+            .clone()?;
 
         // If we're running tests, there's no specific entrypoint so
         // start the runtime in the background immediately.
@@ -60,7 +65,6 @@ impl Runtime {
                 runtime.run_blocking();
             });
         }
-
         Ok(Self { runtime })
     }
 

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -14,6 +14,7 @@ use napi_derive::napi;
 use std::sync::{Arc, OnceLock};
 use std::thread;
 
+// TODO: remove storing of result after `get_or_try_init` is stabilized
 static RUNTIME: OnceLock<napi::Result<Arc<encore_runtime_core::Runtime>>> = OnceLock::new();
 
 #[napi]

--- a/tsparser/src/builder/templates/entrypoints/combined/main.handlebars
+++ b/tsparser/src/builder/templates/entrypoints/combined/main.handlebars
@@ -1,4 +1,5 @@
 import { registerGateways, registerHandlers, run, type Handler } from "encore.dev/internal/codegen/appinit";
+import { isMainThread } from "node:worker_threads";
 
 {{#each gateways}}
 import { {{bind_name}} as {{encoreNameToIdent encore_name}}GW } from {{toJSON import_path}};
@@ -28,7 +29,8 @@ const handlers: Handler[] = [
 {{/each}}
 ];
 
-registerGateways(gateways);
-registerHandlers(handlers);
-
-await run();
+if (isMainThread) {
+    registerGateways(gateways);
+    registerHandlers(handlers);
+    await run();
+}

--- a/tsparser/src/builder/templates/entrypoints/gateways/main.handlebars
+++ b/tsparser/src/builder/templates/entrypoints/gateways/main.handlebars
@@ -1,4 +1,5 @@
 import { registerGateways, run } from "encore.dev/internal/codegen/appinit";
+import { isMainThread } from "node:worker_threads";
 
 {{#each gateways}}
 import { {{bind_name}} as {{encoreNameToIdent encore_name}}Impl } from {{toJSON import_path}};
@@ -10,6 +11,7 @@ const gateways = [
 {{/each}}
 ];
 
-registerGateways(gateways);
-
-await run();
+if (isMainThread) {
+    registerGateways(gateways);
+    await run();
+}

--- a/tsparser/src/builder/templates/entrypoints/services/main.handlebars
+++ b/tsparser/src/builder/templates/entrypoints/services/main.handlebars
@@ -1,4 +1,6 @@
 import { registerHandlers, run, type Handler } from "encore.dev/internal/codegen/appinit";
+import { isMainThread } from "node:worker_threads";
+
 {{#each endpoints}}
 import { {{name}} as {{name}}Impl } from {{toJSON import_path}};
 {{/each}}
@@ -17,5 +19,7 @@ const handlers: Handler[] = [
 {{/each}}
 ];
 
-registerHandlers(handlers);
-await run();
+if (isMainThread) {
+    registerHandlers(handlers);
+    await run();
+}


### PR DESCRIPTION
Store the runtime globally, and reference to the same runtime from workers (as an alternative to #1332)

This allows api calls from workers