### PR TITLE
eject: make sure the go binary is executable on windows

### DIFF
--- a/pkg/dockerbuild/tarcopy.go
+++ b/pkg/dockerbuild/tarcopy.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -240,8 +241,8 @@ func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInf
 		header.ChangeTime = t
 	}
 
-	// make sure the binary is executable (e.g when cross compiling from windows)
-	if fi.Name() == build.BinaryName {
+	// HACK: make the linux binary executable when cross compiling from windows as the unix permissions gets lost.
+	if runtime.GOOS == "windows" && fi.Name() == build.BinaryName {
 		header.Mode = 0755
 	}
 

--- a/pkg/dockerbuild/tarcopy.go
+++ b/pkg/dockerbuild/tarcopy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"encr.dev/v2/compiler/build"
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -239,6 +240,11 @@ func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInf
 		header.ChangeTime = t
 	}
 
+	// make sure the binary is executable (e.g when cross compiling from windows)
+	if fi.Name() == build.BinaryName {
+		header.Mode = 0755
+	}
+
 	header.Name = filepath.ToSlash(dstPath.String())
 	if err := tc.tw.WriteHeader(header); err != nil {
 		return errors.Wrap(err, "write tar header")
@@ -290,5 +296,5 @@ func (tc *tarCopier) WriteFile(dstPath string, mode fs.FileMode, data []byte) (e
 	}
 
 	_, err = tc.tw.Write(data)
-	return errors.Wrap(err, "copy file")
+	return errors.Wrap(err, "write file")
 }

--- a/v2/compiler/build/build.go
+++ b/v2/compiler/build/build.go
@@ -330,7 +330,7 @@ func (b *builder) writeStaticConfig(ldflags *strings.Builder) {
 	ldflags.WriteByte('\'')
 }
 
-const binaryName = "encore_app_out"
+const BinaryName = "encore_app_out"
 
 func (b *builder) exe() string {
 	goos := b.cfg.Ctx.Build.GOOS
@@ -344,7 +344,7 @@ func (b *builder) exe() string {
 }
 
 func (b *builder) binaryPath() paths.FS {
-	return b.workdir.Join(binaryName + b.exe())
+	return b.workdir.Join(BinaryName + b.exe())
 }
 
 // convertCompileErrors goes through the errors and converts basic compiler errors into


### PR DESCRIPTION
When ejecting from windows, the cross compiled linux binary does not get executable