### PR TITLE
daemon: set a default log level in tests

### DIFF
--- a/cli/daemon/test.go
+++ b/cli/daemon/test.go
@@ -67,12 +67,14 @@ func (s *Server) Test(req *daemonpb.TestRequest, stream daemonpb.Daemon_TestServ
 			}
 		}()
 
+		testEnv := append([]string{"ENCORE_RUNTIME_LOG=error", "ENCORE_LOG=error"}, req.Environ...)
+
 		tp := run.TestParams{
 			TestSpecParams: &run.TestSpecParams{
 				App:          app,
 				NS:           ns,
 				WorkingDir:   req.WorkingDir,
-				Environ:      req.Environ,
+				Environ:      testEnv,
 				Args:         req.Args,
 				Secrets:      secrets,
 				CodegenDebug: req.CodegenDebug,
@@ -126,11 +128,13 @@ func (s *Server) TestSpec(ctx context.Context, req *daemonpb.TestSpecRequest) (r
 		}
 	}()
 
+	testEnv := append([]string{"ENCORE_RUNTIME_LOG=error", "ENCORE_LOG=error"}, req.Environ...)
+
 	spec, err := s.mgr.TestSpec(ctx, run.TestSpecParams{
 		App:        app,
 		NS:         ns,
 		WorkingDir: req.WorkingDir,
-		Environ:    req.Environ,
+		Environ:    testEnv,
 		Args:       req.Args,
 		Secrets:    secrets,
 	})

--- a/cli/daemon/test.go
+++ b/cli/daemon/test.go
@@ -67,7 +67,7 @@ func (s *Server) Test(req *daemonpb.TestRequest, stream daemonpb.Daemon_TestServ
 			}
 		}()
 
-		testEnv := append([]string{"ENCORE_RUNTIME_LOG=error", "ENCORE_LOG=error"}, req.Environ...)
+		testEnv := append([]string{"ENCORE_RUNTIME_LOG=error"}, req.Environ...)
 
 		tp := run.TestParams{
 			TestSpecParams: &run.TestSpecParams{
@@ -128,7 +128,7 @@ func (s *Server) TestSpec(ctx context.Context, req *daemonpb.TestSpecRequest) (r
 		}
 	}()
 
-	testEnv := append([]string{"ENCORE_RUNTIME_LOG=error", "ENCORE_LOG=error"}, req.Environ...)
+	testEnv := append([]string{"ENCORE_RUNTIME_LOG=error"}, req.Environ...)
 
 	spec, err := s.mgr.TestSpec(ctx, run.TestSpecParams{
 		App:        app,


### PR DESCRIPTION
Set a default log level for both runtime logs and encore log to error so that tests doesn't emit unnecessary logs

Can still be overridden by setting them when running the tests:
```
ENCORE_LOG=trace ENCORE_RUNTIME_LOG=trace encore test
```