### PR TITLE
tsparser: error when auth handler have unsupported fields

### DIFF
--- a/tsparser/src/parser/resources/apis/authhandler.rs
+++ b/tsparser/src/parser/resources/apis/authhandler.rs
@@ -56,9 +56,9 @@ pub const AUTHHANDLER_PARSER: ResourceParser = ResourceParser {
 
             let fields = iface_fields(pass.type_checker, &request)?;
 
-            for (k, v) in fields {
+            for (_, v) in fields {
                 if !v.is_custom() {
-                    HANDLER.with(|handler| handler.span_err(r.range.to_span(), &format!("authHandler parameter type can only consist of Query and Header fields, found field named {k} of type {}", v.type_name())));
+                    HANDLER.with(|handler| handler.span_err(v.range().to_span(), "authHandler parameter type can only consist of Query and Header fields"));
                 }
             }
 

--- a/tsparser/src/parser/resources/apis/authhandler.rs
+++ b/tsparser/src/parser/resources/apis/authhandler.rs
@@ -58,7 +58,7 @@ pub const AUTHHANDLER_PARSER: ResourceParser = ResourceParser {
 
             for (_, v) in fields {
                 if !v.is_custom() {
-                    HANDLER.with(|handler| handler.span_err(v.range().to_span(), "authHandler parameter type can only consist of Query and Header fields"));
+                    HANDLER.with(|handler| handler.span_err(v.range(), "authHandler parameter type can only consist of Query and Header fields"));
                 }
             }
 

--- a/tsparser/src/parser/resources/apis/authhandler.rs
+++ b/tsparser/src/parser/resources/apis/authhandler.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use swc_common::errors::HANDLER;
 use swc_common::sync::Lrc;
 use swc_ecma_ast as ast;
 use swc_ecma_ast::TsTypeParamInstantiation;
@@ -12,8 +13,9 @@ use crate::parser::resources::parseutil::{
     extract_bind_name, iter_references, ReferenceParser, TrackedNames,
 };
 use crate::parser::resources::Resource;
-
 use crate::parser::{FilePath, Range};
+
+use super::encoding::iface_fields;
 
 #[derive(Debug, Clone)]
 pub struct AuthHandler {
@@ -51,6 +53,14 @@ pub const AUTHHANDLER_PARSER: ResourceParser = ResourceParser {
             let r = r?;
             let request = pass.type_checker.resolve_type(module.clone(), &r.request);
             let response = pass.type_checker.resolve_type(module.clone(), &r.response);
+
+            let fields = iface_fields(pass.type_checker, &request)?;
+
+            for (k, v) in fields {
+                if !v.is_custom() {
+                    HANDLER.with(|handler| handler.span_err(r.range.to_span(), &format!("authHandler parameter type can only consist of Query and Header fields, found field named {k} of type {}", v.type_name())));
+                }
+            }
 
             let object = pass
                 .type_checker

--- a/tsparser/src/parser/resources/apis/encoding.rs
+++ b/tsparser/src/parser/resources/apis/encoding.rs
@@ -321,7 +321,42 @@ pub struct Field {
     custom: Option<CustomType>,
 }
 
-fn iface_fields<'a>(tc: &'a TypeChecker, typ: &'a Type) -> Result<FieldMap> {
+impl Field {
+    pub fn is_custom(&self) -> bool {
+        self.custom.is_some()
+    }
+    pub fn type_name(&self) -> &str {
+        match self.typ {
+            Type::Basic(basic) => match basic {
+                Basic::Any => "any",
+                Basic::String => "string",
+                Basic::Boolean => "boolean",
+                Basic::Number => "number",
+                Basic::Object => "object",
+                Basic::BigInt => "biging",
+                Basic::Symbol => "symbol",
+                Basic::Undefined => "undefined",
+                Basic::Null => "null",
+                Basic::Void => "void",
+                Basic::Unknown => "unknown",
+                Basic::Never => "never",
+            },
+            Type::Array(_) => "array",
+            Type::Interface(_) => "interface",
+            Type::Union(_) => "union",
+            Type::Tuple(_) => "tuple",
+            Type::Literal(_) => "literal",
+            Type::Class(_) => "class",
+            Type::Enum(_) => "enum",
+            Type::Named(_) => "named",
+            Type::Optional(_) => "optional",
+            Type::This => "this",
+            Type::Generic(_) => "generic",
+        }
+    }
+}
+
+pub(crate) fn iface_fields<'a>(tc: &'a TypeChecker, typ: &'a Type) -> Result<FieldMap> {
     fn to_fields(state: &ResolveState, iface: &Interface) -> Result<FieldMap> {
         let mut map = HashMap::new();
         for f in &iface.fields {

--- a/tsparser/src/parser/resources/apis/encoding.rs
+++ b/tsparser/src/parser/resources/apis/encoding.rs
@@ -9,6 +9,7 @@ use crate::parser::types::{
     drop_empty_or_void, unwrap_promise, Basic, FieldName, Interface, InterfaceField, ResolveState,
     Type, TypeChecker,
 };
+use crate::parser::Range;
 
 /// Describes how an API endpoint can be encoded on the wire.
 #[derive(Debug, Clone)]
@@ -319,40 +320,16 @@ pub struct Field {
     typ: Type,
     optional: bool,
     custom: Option<CustomType>,
+    range: Range,
 }
 
 impl Field {
     pub fn is_custom(&self) -> bool {
         self.custom.is_some()
     }
-    pub fn type_name(&self) -> &str {
-        match self.typ {
-            Type::Basic(basic) => match basic {
-                Basic::Any => "any",
-                Basic::String => "string",
-                Basic::Boolean => "boolean",
-                Basic::Number => "number",
-                Basic::Object => "object",
-                Basic::BigInt => "biging",
-                Basic::Symbol => "symbol",
-                Basic::Undefined => "undefined",
-                Basic::Null => "null",
-                Basic::Void => "void",
-                Basic::Unknown => "unknown",
-                Basic::Never => "never",
-            },
-            Type::Array(_) => "array",
-            Type::Interface(_) => "interface",
-            Type::Union(_) => "union",
-            Type::Tuple(_) => "tuple",
-            Type::Literal(_) => "literal",
-            Type::Class(_) => "class",
-            Type::Enum(_) => "enum",
-            Type::Named(_) => "named",
-            Type::Optional(_) => "optional",
-            Type::This => "this",
-            Type::Generic(_) => "generic",
-        }
+
+    pub fn range(&self) -> Range {
+        self.range
     }
 }
 
@@ -486,6 +463,7 @@ fn rewrite_custom_type_field(
         typ: field.typ.clone(),
         optional: field.optional,
         custom: None,
+        range: field.range,
     };
     let Type::Named(named) = &field.typ else {
         return Ok(standard_field);


### PR DESCRIPTION
Adds an error if the authHandler parameter type consist of unsupported fields types. Errors out like:
```
error: authHandler parameter type can only consist of Query and Header fields
  --> /home/fredr/projects/encore-apps/hellots/hello/hello.ts:47:3
   |
47 |   userID: string;
   |   ^^^^^^^^^^^^^^^
```
