### PR TITLE
TS Database Docs: Fix example database query for single row

### DIFF
--- a/docs/ts/primitives/databases.md
+++ b/docs/ts/primitives/databases.md
@@ -137,14 +137,14 @@ Or to query a single todo item by id:
 
 ```ts
 async function getTodoTitle(id: number): string | undefined {
-  const row = await db.query`SELECT title FROM todo_item WHERE id = ${id}`;
+  const row = await db.queryRow`SELECT title FROM todo_item WHERE id = ${id}`;
   return row?.title;
 }
 ```
 
 ### Inserting data
 
-To insert data, or to make database queryies that don't return any rows, use `db.exec`.
+To insert data, or to make database queries that don't return any rows, use `db.exec`.
 
 For example:
 


### PR DESCRIPTION
The database docs call out using `queryRow` to query a single row, but the example uses `query`.  This led to confusion when I was getting up to speed with the database section since `query` didn't work for a single row.

This PR changes the docs to use `queryRow` in the example.

Also fixes a small typo I found a couple lines below! 😄
