### PR TITLE
clientgen: skip streaming endpoints in unsupported langs

### DIFF
--- a/internal/clientgen/golang.go
+++ b/internal/clientgen/golang.go
@@ -336,6 +336,11 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service) error 
 			continue
 		}
 
+		// streaming endpoints not supported yet
+		if rpc.StreamingRequest || rpc.StreamingResponse {
+			continue
+		}
+
 		// Add the documentation for the API to the interface method
 		if rpc.Doc != nil && !g.skipDocs {
 			// Add a newline if this is not the first method
@@ -365,6 +370,11 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service) error 
 	// The API functions
 	for _, rpc := range service.Rpcs {
 		if rpc.AccessType == meta.RPC_PRIVATE {
+			continue
+		}
+
+		// streaming endpoints not supported yet
+		if rpc.StreamingRequest || rpc.StreamingResponse {
 			continue
 		}
 

--- a/internal/clientgen/openapi/openapi.go
+++ b/internal/clientgen/openapi/openapi.go
@@ -78,6 +78,11 @@ func (g *Generator) Generate(p clientgentypes.GenerateParams) (err error) {
 
 func (g *Generator) addService(svc *meta.Service) error {
 	for _, rpc := range svc.Rpcs {
+		// streaming endpoints not supported yet
+		if rpc.StreamingRequest || rpc.StreamingResponse {
+			continue
+		}
+
 		if err := g.addRPC(rpc); err != nil {
 			return err
 		}


### PR DESCRIPTION
Streaming endpoints are not yet supported in go client and openapi