### PR TITLE
fix: increase timeout for api client generation

### DIFF
--- a/cli/cmd/encore/gen.go
+++ b/cli/cmd/encore/gen.go
@@ -75,7 +75,7 @@ To further narrow down the services to generate, use the '--services' flag.
 				lang = string(l)
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
 			daemon := setupDaemon(ctx)


### PR DESCRIPTION
We have recently had problems with timing out the api client generation. This increases the timeout from 5 to 15 seconds.