### PR TITLE
 docs: update service name to a valid literal

### DIFF
--- a/docs/ts/primitives/services.mdx
+++ b/docs/ts/primitives/services.mdx
@@ -14,13 +14,15 @@ To create an Encore service, add a file named `encore.service.ts` in a directory
 
 The file must export a service instance, by calling `new Service`, imported from `encore.dev/service`.
 
+> NOTE: While declaring the service name, use string literals which are valid while declaring a variable. Otherwise the `encore run` might throw a compile error. 
+
 For example:
 
 ```ts
 
 import { Service } from "encore.dev/service";
 
-export default new Service("my-service");
+export default new Service("my_service");
 ```
 
 That's it! Encore will consider this directory and all its subdirectories as part of the service.


### PR DESCRIPTION
## Changes

- Previously used `-` throws an error when the encore generates files as it acts as an import string.
- Changed to `_` which ensures that no error occurs when generating the file

## Screenshots

![image](https://github.com/user-attachments/assets/20dd759e-0ba7-453f-9c5d-6a00da40e4c7)
> Here it's prevalent that due to adding the `-` which is an invalid token while naming a variable we are facing an error.