### PR TITLE
parser: keep case for query paramters in typescript

### DIFF
--- a/internal/clientgen/testdata/tsapp/expected_list_of_union_javascript.js
+++ b/internal/clientgen/testdata/tsapp/expected_list_of_union_javascript.js
@@ -48,7 +48,7 @@ class SvcServiceClient {
     async dummy(params) {
         // Convert our params into the objects we need for the request
         const query = makeRecord({
-            "list_of_union": params.listOfUnion.map((v) => String(v)),
+            listOfUnion: params.listOfUnion.map((v) => String(v)),
         })
 
         await this.baseClient.callAPI("GET", `/dummy`, undefined, {query})

--- a/internal/clientgen/testdata/tsapp/expected_list_of_union_typescript.ts
+++ b/internal/clientgen/testdata/tsapp/expected_list_of_union_typescript.ts
@@ -75,7 +75,7 @@ export namespace svc {
         public async dummy(params: Request): Promise<void> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
-                "list_of_union": params.listOfUnion.map((v) => String(v)),
+                listOfUnion: params.listOfUnion.map((v) => String(v)),
             })
 
             await this.baseClient.callAPI("GET", `/dummy`, undefined, {query})

--- a/internal/clientgen/testdata/tsapp/expected_stream_javascript.js
+++ b/internal/clientgen/testdata/tsapp/expected_stream_javascript.js
@@ -92,7 +92,7 @@ class SvcServiceClient {
         })
 
         const query = makeRecord({
-            "path_param": params.pathParam,
+            pathParam:    params.pathParam,
             "some-query": params.queryValue,
         })
 

--- a/internal/clientgen/testdata/tsapp/expected_stream_typescript.ts
+++ b/internal/clientgen/testdata/tsapp/expected_stream_typescript.ts
@@ -165,7 +165,7 @@ export namespace svc {
             })
 
             const query = makeRecord<string, string | string[]>({
-                "path_param": params.pathParam,
+                pathParam:    params.pathParam,
                 "some-query": params.queryValue,
             })
 


### PR DESCRIPTION
Only default to snake case in go apps