### PR TITLE
tsparser: fall back to junction points on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ dependencies = [
  "indexmap 2.2.6",
  "insta",
  "itertools 0.12.1",
+ "junction",
  "litparser",
  "litparser-derive",
  "log",
@@ -2513,6 +2514,16 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "junction"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/tsparser/Cargo.toml
+++ b/tsparser/Cargo.toml
@@ -41,6 +41,7 @@ serde_yaml = "0.9.32"
 symlink = "0.1.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+junction = "1.2.0"
 
 [build-dependencies]
 prost-build = { version = "0.12.1" }


### PR DESCRIPTION
Windows requires Developer Mode to be enabled to use
symlinks without admin permissions. This isn't always enabled,
so fall back to using junction points if symlink creation fails.

This is for example what rustup does already.
See rust-lang/rustup#3687 for example.
