### PR TITLE
runtimes/js: flush headers on early close

### DIFF
--- a/runtimes/js/encore.dev/internal/api/node_http.ts
+++ b/runtimes/js/encore.dev/internal/api/node_http.ts
@@ -191,6 +191,7 @@ export class RawResponse extends stream.Writable {
   }
 
   _final(callback: (error?: Error | null | undefined) => void): void {
+    this._writeHeaderIfNeeded();
     this.w.close(undefined, callback);
   }
 


### PR DESCRIPTION
If you immediately called close() on a raw response writer,
the runtime wouldn't pick up any changes to the status code
made by assigning directly to `resp.statusCode`.
