### PR TITLE
cli/daemon: resolve local apps for client gen

### DIFF
--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -87,7 +87,7 @@ func (s *Server) GenClient(ctx context.Context, params *daemonpb.GenClientReques
 	var md *meta.Data
 	if params.EnvName == "local" {
 		// Determine the app root
-		app, err := s.apps.FindLatestByPlatformID(params.AppId)
+		app, err := s.apps.FindLatestByPlatformOrLocalID(params.AppId)
 		if errors.Is(err, apps.ErrNotFound) {
 			return nil, status.Errorf(codes.FailedPrecondition, "the app %s must be run locally before generating a client for the 'local' environment.",
 				params.AppId)


### PR DESCRIPTION
The client generation code path wasn't supporting local app ids.
Fix this.

Thanks Frank Schröder for the report.
