### PR TITLE
Only include non-private endpoints in OpenAPI spec output

### DIFF
--- a/internal/clientgen/openapi/openapi.go
+++ b/internal/clientgen/openapi/openapi.go
@@ -83,6 +83,11 @@ func (g *Generator) addService(svc *meta.Service) error {
 			continue
 		}
 
+		// Skip non-public RPCs
+		if rpc.AccessType == meta.RPC_PRIVATE {
+			continue
+		}
+
 		if err := g.addRPC(rpc); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, the OpenAPI spec includes private endpoints, which aren't accessible outside of the server. This change removes private endpoints from the spec.