### PR TITLE
tsparser: support string literal members

### DIFF
--- a/tsparser/src/parser/types/type_resolve.rs
+++ b/tsparser/src/parser/types/type_resolve.rs
@@ -417,6 +417,9 @@ impl<'a> Ctx<'a> {
                 ast::TsTypeElement::TsPropertySignature(p) => {
                     let name = match *p.key {
                         ast::Expr::Ident(ref i) => FieldName::String(i.sym.as_ref().to_string()),
+                        ast::Expr::Lit(ast::Lit::Str(ref str)) => {
+                            FieldName::String(str.value.to_string())
+                        }
                         _ => {
                             HANDLER.with(|handler| {
                                 handler.span_err(p.key.span(), "unsupported property key")


### PR DESCRIPTION
So that you can do e.g. `{"some-key": string}`.