### PR TITLE
Revert "Only include non-private endpoints in OpenAPI spec output"

### DIFF
--- a/internal/clientgen/openapi/openapi.go
+++ b/internal/clientgen/openapi/openapi.go
@@ -83,11 +83,6 @@ func (g *Generator) addService(svc *meta.Service) error {
 			continue
 		}
 
-		// Skip non-public RPCs
-		if rpc.AccessType == meta.RPC_PRIVATE {
-			continue
-		}
-
 		if err := g.addRPC(rpc); err != nil {
 			return err
 		}


### PR DESCRIPTION
Reverts encoredev/encore#1419

This was done a bit hastily. There are valid use cases for documenting private endpoints. Filtering out private endpoints should be made an option, not the default.