### PR TITLE
encorebuild: only use zig when cross compiling or on release

### DIFF
--- a/pkg/encorebuild/compile/compile.go
+++ b/pkg/encorebuild/compile/compile.go
@@ -78,6 +78,8 @@ func RustBinary(cfg *buildconf.Config, artifactPath, outputPath string, cratePat
 		}
 	}
 
+	useZig := cfg.IsCross() || cfg.Release
+
 	envs := append(extraEnvVars, osPkg.Environ()...)
 	useCross := false
 	if cfg.IsCross() && runtime.GOOS == "darwin" {
@@ -85,10 +87,9 @@ func RustBinary(cfg *buildconf.Config, artifactPath, outputPath string, cratePat
 		_, err := exec.LookPath("cross")
 		if err == nil {
 			useCross = true
+			useZig = false
 		}
 	}
-
-	useZig := !useCross
 
 	var target, zigTargetSuffix string
 	switch cfg.OS {


### PR DESCRIPTION
Reverts to the old behavior of only using zig on cross compiles or releases, and not on local builds