### PR TITLE
tsparser: better errors when defining secrets

### DIFF
--- a/tsparser/src/parser/resources/infra/secret.rs
+++ b/tsparser/src/parser/resources/infra/secret.rs
@@ -7,10 +7,11 @@ use crate::parser::resources::parseutil::{
 };
 use crate::parser::resources::Resource;
 use crate::parser::Range;
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use litparser::LitParser;
 use swc_common::errors::HANDLER;
 use swc_common::sync::Lrc;
+use swc_common::Span;
 use swc_ecma_ast as ast;
 
 #[derive(Debug, Clone)]
@@ -40,15 +41,6 @@ pub const SECRET_PARSER: ResourceParser = ResourceParser {
                 .type_checker
                 .resolve_obj(pass.module.clone(), &ast::Expr::Ident(r.bind_name.clone()));
 
-            if object.is_none() {
-                HANDLER.with(|handler| {
-                    handler.span_err(
-                        r.range,
-                        "unable to resolve secret. make sure it is defined as a global variable",
-                    )
-                });
-            }
-
             pass.add_resource(resource.clone());
             pass.add_bind(BindData {
                 range: r.range,
@@ -70,6 +62,17 @@ struct SecretLiteral {
     pub bind_name: ast::Ident,
 }
 
+fn inside_function(path: &swc_ecma_visit::AstNodePath) -> Option<Span> {
+    for item in path.iter().rev() {
+        match item {
+            swc_ecma_visit::AstParentNodeRef::ArrowExpr(expr, ..) => return Some(expr.span),
+            swc_ecma_visit::AstParentNodeRef::Function(expr, ..) => return Some(expr.span),
+            _ => continue,
+        }
+    }
+
+    None
+}
 impl ReferenceParser for SecretLiteral {
     fn parse_resource_reference(
         module: &Module,
@@ -81,6 +84,16 @@ impl ReferenceParser for SecretLiteral {
                 swc_ecma_visit::fields::CallExprField::Callee,
             ) = node
             {
+                if let Some(fn_span) = inside_function(path) {
+                    HANDLER.with(|handler| {
+                        handler
+                            .struct_span_err(expr.span, "secrets must be defined globally")
+                            .span_note(fn_span, "secret defined within this function")
+                            .emit();
+                    });
+                    return Ok(None);
+                }
+
                 let doc_comment = module.preceding_comments(expr.span.lo.into());
                 let Some(bind_name) = extract_bind_name(path)? else {
                     HANDLER.with(|handler| {

--- a/tsparser/src/parser/resources/infra/secret.rs
+++ b/tsparser/src/parser/resources/infra/secret.rs
@@ -44,7 +44,7 @@ pub const SECRET_PARSER: ResourceParser = ResourceParser {
                 HANDLER.with(|handler| {
                     handler.span_err(
                         r.range,
-                        "Unable to resolve secret. Make sure it is defined as a global variable",
+                        "unable to resolve secret. make sure it is defined as a global variable",
                     )
                 });
             }

--- a/tsparser/src/parser/resources/infra/secret.rs
+++ b/tsparser/src/parser/resources/infra/secret.rs
@@ -7,7 +7,7 @@ use crate::parser::resources::parseutil::{
 };
 use crate::parser::resources::Resource;
 use crate::parser::Range;
-use anyhow::{Ok, Result};
+use anyhow::Result;
 use litparser::LitParser;
 use swc_common::errors::HANDLER;
 use swc_common::sync::Lrc;

--- a/tsparser/src/parser/resources/infra/secret.rs
+++ b/tsparser/src/parser/resources/infra/secret.rs
@@ -84,7 +84,7 @@ impl ReferenceParser for SecretLiteral {
                 let doc_comment = module.preceding_comments(expr.span.lo.into());
                 let Some(bind_name) = extract_bind_name(path)? else {
                     HANDLER.with(|handler| {
-                        handler.span_err(expr.span, "Secrets must be bound to a variable")
+                        handler.span_err(expr.span, "secrets must be bound to a variable")
                     });
                     continue;
                 };


### PR DESCRIPTION
Check if secret is defined within a function and gives a error referencing the secret with a note referencing the function 

```
error: secrets must be defined globally
  --> /home/fredr/projects/encore-apps/teeeest/repro/repro.ts:36:27
   |
36 |       const githubToken = secret("GitHubAPIToken");
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: secret defined within this function
  --> /home/fredr/projects/encore-apps/teeeest/repro/repro.ts:27:3
   |
27 | /   async ({ name }: { name: string }): Promise<Response> => {
28 | |     try {
29 | |       // ..
30 | |       // ..
...  |
41 | |     }
42 | |   },
   | |___^
```
