### PR TITLE
.devcontainer: upgrade to go 1.21

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.21
 
 RUN apt-get update && apt-get install -y sudo
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \


### PR DESCRIPTION
- Fixes encoredev/encore#1475
- opening project in Codespace requires Go 1.21, as it uses strings.CutPrefix