### PR TITLE
internal/version: capture original path

### DIFF
--- a/cli/cmd/encore/cmdutil/daemon.go
+++ b/cli/cmd/encore/cmdutil/daemon.go
@@ -65,6 +65,13 @@ func ConnectDaemon(ctx context.Context) daemonpb.DaemonClient {
 					} else if configHash == resp.ConfigHash {
 						return cl
 					}
+
+					// If we're running a development release, and so is the daemon, don't restart.
+					// This is to avoid spurious restarts during development.
+					if version.Channel == version.DevBuild && version.ChannelFor(resp.Version) == version.DevBuild {
+						return cl
+					}
+
 					// Daemon is running the same version but different config
 					fmt.Fprintf(os.Stderr, "encore: restarting daemon due to configuration change.\n")
 				case diff > 0:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"runtime/debug"
 	"strings"
 
@@ -30,6 +31,10 @@ const (
 	unknown  ReleaseChannel = "unknown" // An unknown release stream (not exported as it should be an error case)
 )
 
+// Capture the original PATH on startup, since it may be changed
+// at runtime (see pkginfo.UpdateGoPath).
+var originalPath = os.Getenv("PATH")
+
 // ConfigHash reports a hash of the configuration that affects the behavior of the daemon.
 // It is used to decide whether to restart the daemon.
 func ConfigHash() (string, error) {
@@ -39,6 +44,7 @@ func ConfigHash() (string, error) {
 		return "", err
 	}
 
+	fmt.Fprintf(h, "PATH=%s\n", originalPath)
 	fmt.Fprintf(h, "APIBaseURL=%s\n", conf.APIBaseURL)
 	fmt.Fprintf(h, "ConfigDir=%s\n", configDir)
 	fmt.Fprintf(h, "EncoreDevDashListenAddr=%s\n", env.EncoreDevDashListenAddr().GetOrElse(""))


### PR DESCRIPTION
Reintroduce the check, but this time with the original path
in case it gets changed at runtime.
