### PR TITLE
cli/daemon/run: avoid double-reporting parse errors

### DIFF
--- a/cli/daemon/run/exec_script.go
+++ b/cli/daemon/run/exec_script.go
@@ -99,7 +99,8 @@ func (mgr *Manager) ExecScript(ctx context.Context, p ExecScriptParams) (err err
 		ParseTests:  false,
 	})
 	if err != nil {
-		tracker.Fail(parseOp, err)
+		// Don't use the error itself in tracker.Fail, as it will lead to duplicate error output.
+		tracker.Fail(parseOp, errors.New("parse error"))
 		return err
 	}
 	if err := p.App.CacheMetadata(parse.Meta); err != nil {

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -369,9 +369,11 @@ func (r *Run) buildAndStart(ctx context.Context, tracker *optracker.OpTracker, i
 		ParseTests:  false,
 	})
 	if err != nil {
-		tracker.Fail(parseOp, err)
+		// Don't use the error itself in tracker.Fail, as it will lead to duplicate error output.
+		tracker.Fail(parseOp, errors.New("parse error"))
 		return err
 	}
+
 	if err := r.App.CacheMetadata(parse.Meta); err != nil {
 		return errors.Wrap(err, "cache metadata")
 	}


### PR DESCRIPTION
This wasn't a big problem for Go errors as we only
reported the first line, but it was problematic for TypeScript
errors which duplicated the full error output.