### PR TITLE
.devcontainer: upgrade to go 1.23

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.23
 
 RUN apt-get update && apt-get install -y sudo
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \


### PR DESCRIPTION
- Thought I'd go conservative with https://github.com/encoredev/encore/pull/1476, as I thought that was all that was needed
- But now getting this when trying to open a codespace:
```shell
2024-10-14 16:54:48.017Z: #11 47.24 go: honnef.co/go/tools/cmd/staticcheck@master: honnef.co/go/tools@v0.6.0-0.dev.0.20241004131735-f6581d960da8 requires go >= 1.22.1 (running go 1.21.13; GOTOOLCHAIN=local)2024-10-14 16:54:48.018Z: 
```
- Thought there might be other libraries that have similar requirements, so updated to 1.23