### PR TITLE
make it possible to override what rust builder to use

### DIFF
--- a/pkg/encorebuild/buildconf/config.go
+++ b/pkg/encorebuild/buildconf/config.go
@@ -37,6 +37,9 @@ type Config struct {
 
 	// Whether to copy the built native module back to the repo dir.
 	CopyToRepo bool
+
+	// RustBuilder will override the automatic builder selection if set.
+	RustBuilder option.Option[string]
 }
 
 // IsCross reports whether the build is a cross-compile.

--- a/pkg/encorebuild/cmd/build-local-binary/build-local-binary.go
+++ b/pkg/encorebuild/cmd/build-local-binary/build-local-binary.go
@@ -21,6 +21,7 @@ func join(strs ...string) string {
 
 var archFlag = flag.String("arch", runtime.GOARCH, "the architecture to target")
 var osFlag = flag.String("os", runtime.GOOS, "the operating system to target")
+var builderFlag = flag.String("builder", "", "the builder to use")
 
 func main() {
 	binary := os.Args[1]
@@ -44,16 +45,23 @@ func main() {
 	}
 	cacheDir := filepath.Join(userCacheDir, "encore-build-cache")
 
+	builder := option.None[string]()
+
+	if builderFlag != nil && *builderFlag != "" {
+		builder = option.Some(*builderFlag)
+	}
+
 	cfg := &buildconf.Config{
-		Log:        log.Logger,
-		OS:         *osFlag,
-		Arch:       *archFlag,
-		Release:    false,
-		Version:    version.Version,
-		RepoDir:    root,
-		CacheDir:   cacheDir,
-		MacSDKPath: option.None[string](),
-		CopyToRepo: true,
+		Log:         log.Logger,
+		OS:          *osFlag,
+		Arch:        *archFlag,
+		Release:     false,
+		Version:     version.Version,
+		RepoDir:     root,
+		CacheDir:    cacheDir,
+		MacSDKPath:  option.None[string](),
+		CopyToRepo:  true,
+		RustBuilder: builder,
 	}
 
 	switch binary {

--- a/runtimes/js/.gitignore
+++ b/runtimes/js/.gitignore
@@ -1,4 +1,4 @@
-encore-runtime.node
+encore-runtime.node*
 node_modules
 dist
 .turbo


### PR DESCRIPTION
This to make it easier when building a dev runtime locally