### PR TITLE
Share the db migration logic between the Encore platform and the daemon

### DIFF
--- a/cli/daemon/sqldb/db.go
+++ b/cli/daemon/sqldb/db.go
@@ -290,7 +290,7 @@ func (db *DB) doMigrate(ctx context.Context, cloudName, appRoot string, dbMeta *
 	defer fns.CloseIgnore(pool)
 
 	path := filepath.Join(appRoot, *dbMeta.MigrationRelPath)
-	mdSrc := NewMetadataSource(NewOsReader(path), dbMeta.Migrations)
+	mdSrc := NewMetadataSource(NewOsMigrationReader(path), dbMeta.Migrations)
 	conn, err := pool.Conn(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to postgres")


### PR DESCRIPTION
Refactors and exports the database migration logic so we can reuse it in the Encore Platform. This is mainly to ensure consistency between platform deploys and local runs. 