### PR TITLE
Add new instructions for vscode vitest workaround

### DIFF
--- a/docs/ts/develop/testing.md
+++ b/docs/ts/develop/testing.md
@@ -45,7 +45,32 @@ This is nothing to worry about and is the recommended best practice.
 
 If you're using Vitest, install the official Vitest VS Code extension and then add to the `.vscode/settings.json` file:
 
-```
+```jsonc
 "vitest.commandLine": "encore test"
 ```
+As of Vitest plugin version 0.5 ([issue](https://github.com/vitest-dev/vscode/issues/306)), environment configuration requires an updated approach. The following configuration is required to ensure proper functionality:
 
+```jsonc
+"vitest.nodeEnv": {
+    // generated with `encore daemon env | grep ENCORE_RUNTIME_LIB | cut -d'=' -f2`
+    "ENCORE_RUNTIME_LIB": "/opt/homebrew/Cellar/encore/1.44.5/libexec/runtimes/js/encore-runtime.node"
+}
+```
+
+When running tests within VSCode, file-level parallel execution must be disabled. Update your `vite.config.ts` as follows:
+
+```typescript
+// File vite.config.ts
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~encore": path.resolve(__dirname, "./encore.gen"),
+    },
+  },
+  test: {
+    fileParallelism: false,
+  },
+});
+```
+
+To improve the performance in CI, you can re-enable the parallel execution by overwriting the config in cli `encore test --fileParallelism=true`.


### PR DESCRIPTION
This enables using native Vitest vscode plugin to run and debug encore tests.