### PR TITLE
chore: correct typos docs

### DIFF
--- a/docs/ts/how-to/nestjs.md
+++ b/docs/ts/how-to/nestjs.md
@@ -193,5 +193,5 @@ Open [http://localhost:9400](http://localhost:9400) in your browser to access it
 The Local Development Dashboard is a powerful tool to help you move faster when you're developing new features.
 
 It comes with an API explorer, a Service Catalog with automatically generated documentation, and powerful
-oberservability features
+observability features
 like [distributed tracing](/docs/ts/observability/tracing).

--- a/tsparser/txtar/README.md
+++ b/tsparser/txtar/README.md
@@ -54,7 +54,7 @@ The format spec as written in the `txtar` Go package source code:
 > The comment or file content ends at the next file marker line.
 > The file marker line must begin with the three-byte sequence "-- "
 > and end with the three-byte sequence " --", but the enclosed
-> file name can be surrounding by additional white space,
+> file name can be surrounded by additional white space,
 > all of which is stripped.
 >
 > If the txtar file is missing a trailing newline on the final line,


### PR DESCRIPTION
I reviewed the entire repository, no more typos found in docs. 
Hope this helps streamline the project!
Best regards,
Bilogweb3