### PR TITLE
windows: handle the runtime and app is on different drives

### DIFF
--- a/pkg/dockerbuild/spec.go
+++ b/pkg/dockerbuild/spec.go
@@ -175,15 +175,18 @@ func (h HostPath) JoinHost(p HostPath) HostPath {
 	return h.Join(string(p))
 }
 func (h HostPath) ToImage() ImagePath {
+	return ImagePath(string(h.ToUnix()))
+}
+func (h HostPath) ToUnix() HostPath {
 	if runtime.GOOS == "windows" {
 		// convert windows path with volume to a unix path, i.e c:\some\path -> /c/some/path
 		volume := filepath.VolumeName(string(h))
 		if len(volume) == 2 && volume[1] == ':' {
-			return ImagePath("/" + string(volume[0]) + filepath.ToSlash(string(h[2:])))
+			return HostPath("/" + string(volume[0]) + filepath.ToSlash(string(h[2:])))
 		}
 	}
 
-	return ImagePath(filepath.ToSlash(string(h)))
+	return HostPath(filepath.ToSlash(string(h)))
 }
 func (h HostPath) String() string { return string(h) }
 func (h HostPath) Rel(target HostPath) (HostPath, error) {


### PR DESCRIPTION
Handles the case when e.g encore is installed on C: and the app is created on D: