### PR TITLE
builder: make Stderr configurable

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -90,6 +90,9 @@ type ParseParams struct {
 	Experiments *experiments.Set
 	WorkingDir  string
 	ParseTests  bool
+
+	// Optional writer to redirect stderr to.
+	Stderr option.Option[io.Writer]
 }
 
 type ParseResult struct {

--- a/v2/tsbuilder/tsbuilder.go
+++ b/v2/tsbuilder/tsbuilder.go
@@ -122,7 +122,13 @@ func (i *BuilderImpl) Parse(ctx context.Context, p builder.ParseParams) (*builde
 	if err != nil {
 		return nil, fmt.Errorf("unable to get stdin: %s", err)
 	}
-	cmd.Stderr = os.Stderr
+
+	if stderr, ok := p.Stderr.Get(); ok {
+		cmd.Stderr = stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("unable to start builder: %s", err)
 	}


### PR DESCRIPTION
This will make it easier to configure where build errors are redirected, for use in e.g. Encore Cloud CI pipelines.