### PR TITLE
dockerbuild: Copy encore.dev instead of linking

### DIFF
--- a/pkg/dockerbuild/spec.go
+++ b/pkg/dockerbuild/spec.go
@@ -384,11 +384,8 @@ func (b *imageSpecBuilder) Describe(cfg DescribeConfig) (*ImageSpec, error) {
 	// If we have any JS outputs that need the local runtime, copy it into the image.
 	{
 		for _, out := range cfg.Compile.Outputs {
+			// TODO this code ...
 			if _, ok := out.(*builder.JSBuildOutput); ok {
-				// Include the encore.dev package, at the same location.
-				runtimeSrc := cfg.Runtimes.Join("js", "encore.dev")
-				b.spec.CopyData[runtimeSrc.ToImage()] = runtimeSrc
-
 				// Add the encore-runtime.node file, and set the environment variable to point to it.
 				nativeRuntimeHost := cfg.NodeRuntime.GetOrElse(cfg.Runtimes.Join("js", "encore-runtime.node"))
 				nativeRuntimeImg := nativeRuntimeHost.ToImage().Dir().Join("encore-runtime.node")

--- a/pkg/dockerbuild/spec.go
+++ b/pkg/dockerbuild/spec.go
@@ -385,10 +385,9 @@ func (b *imageSpecBuilder) Describe(cfg DescribeConfig) (*ImageSpec, error) {
 	{
 		for _, out := range cfg.Compile.Outputs {
 			if _, ok := out.(*builder.JSBuildOutput); ok {
-				// TODO copy runtime to /encore or something instead
 				// Add the encore-runtime.node file, and set the environment variable to point to it.
 				nativeRuntimeHost := cfg.NodeRuntime.GetOrElse(cfg.Runtimes.Join("js", "encore-runtime.node"))
-				nativeRuntimeImg := nativeRuntimeHost.ToImage().Dir().Join("encore-runtime.node")
+				nativeRuntimeImg := ImagePath("/encore/runtimes/js/encore-runtime.node")
 				b.spec.CopyData[nativeRuntimeImg] = nativeRuntimeHost
 				b.spec.Env = append(b.spec.Env, fmt.Sprintf("ENCORE_RUNTIME_LIB=%s", nativeRuntimeImg))
 				b.addPrio(nativeRuntimeImg)

--- a/pkg/dockerbuild/spec.go
+++ b/pkg/dockerbuild/spec.go
@@ -384,8 +384,8 @@ func (b *imageSpecBuilder) Describe(cfg DescribeConfig) (*ImageSpec, error) {
 	// If we have any JS outputs that need the local runtime, copy it into the image.
 	{
 		for _, out := range cfg.Compile.Outputs {
-			// TODO this code ...
 			if _, ok := out.(*builder.JSBuildOutput); ok {
+				// TODO copy runtime to /encore or something instead
 				// Add the encore-runtime.node file, and set the environment variable to point to it.
 				nativeRuntimeHost := cfg.NodeRuntime.GetOrElse(cfg.Runtimes.Join("js", "encore-runtime.node"))
 				nativeRuntimeImg := nativeRuntimeHost.ToImage().Dir().Join("encore-runtime.node")

--- a/pkg/dockerbuild/tarcopy.go
+++ b/pkg/dockerbuild/tarcopy.go
@@ -131,8 +131,7 @@ func (tc *tarCopier) CopyDir(desc *dirCopyDesc) error {
 				return errors.WithStack(err)
 			}
 
-			// if the target is encore.dev in the runtime path, copy the files instead
-			// of linking
+			// copy the files instead of linking if its the encore.dev package
 			if target == filepath.Join(env.EncoreRuntimesPath(), "js", "encore.dev") {
 				err = tc.CopyDir(&dirCopyDesc{
 					Spec:            desc.Spec,
@@ -150,7 +149,6 @@ func (tc *tarCopier) CopyDir(desc *dirCopyDesc) error {
 				// Drop the symlink
 				return nil
 			}
-
 		}
 
 		fi, err := d.Info()


### PR DESCRIPTION
This also changes where we put the js runtime, instead of mirroring the host system we put it in /encore where we also store infra config etc.