### PR TITLE
cli/daemon: support watching embedded files

### DIFF
--- a/cli/daemon/run/watch.go
+++ b/cli/daemon/run/watch.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -12,7 +14,7 @@ import (
 // them on c.
 func (mgr *Manager) watch(run *Run) error {
 	sub, err := run.App.Watch(func(i *apps.Instance, event []watcher.Event) {
-		if IgnoreEvents(event) {
+		if IgnoreEvents(run.App.Root(), event) {
 			return
 		}
 
@@ -44,21 +46,30 @@ func (mgr *Manager) watch(run *Run) error {
 }
 
 // IgnoreEvents will return true if _all_ events are on files that should be ignored
-// as the do not impact the running app, or are the result of Encore itself generating code.
-func IgnoreEvents(events []watcher.Event) bool {
+// as they do not impact the running app, or are the result of Encore itself generating code.
+func IgnoreEvents(root string, events []watcher.Event) bool {
 	for _, event := range events {
-		if !ignoreEvent(event) {
+		if !ignoreEvent(root, event) {
 			return false
 		}
 	}
 	return true
 }
 
-func ignoreEvent(ev watcher.Event) bool {
+func ignoreEvent(root string, ev watcher.Event) bool {
 	filename := filepath.Base(ev.Path)
 	if strings.HasPrefix(strings.ToLower(filename), "encore.gen.") {
 		// Ignore generated code
 		return true
+	}
+
+	embedded, err := checkIfFileIsEmbedded(root, ev.Path)
+	if err != nil {
+		return true
+	}
+	if embedded {
+		// Don't ignore embedded files
+		return false
 	}
 
 	// Ignore files which wouldn't impact the running app
@@ -70,4 +81,77 @@ func ignoreEvent(ev watcher.Event) bool {
 	default:
 		return true
 	}
+}
+
+// checkIfFileIsEmbedded checks if a file is embedded somewhere in the encore project using the //go:embed directive
+func checkIfFileIsEmbedded(projectRoot, sourceFile string) (bool, error) {
+	isEmbedded := false
+
+	err := filepath.Walk(projectRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && filepath.Ext(path) == ".go" {
+			embeddedPaths, err := getEmbeddedFilePaths(path)
+			if err != nil {
+				return err
+			}
+			for _, embeddedPath := range embeddedPaths {
+				if embeddedPath == sourceFile {
+					isEmbedded = true
+					return nil
+				}
+			}
+		}
+		return nil
+	})
+
+	return isEmbedded, err
+}
+
+func getEmbeddedFilePaths(sourceFile string) ([]string, error) {
+	var embeddedPaths []string
+
+	data, err := os.ReadFile(sourceFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read source file: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "//go:embed") {
+			parts := strings.Fields(line)
+			if len(parts) > 1 {
+				dir := parts[1]
+				filepaths, err := getFilePathsFromDir(filepath.Join(filepath.Dir(sourceFile), dir))
+				if err != nil {
+					return nil, err
+				}
+				embeddedPaths = append(embeddedPaths, filepaths...)
+			}
+		}
+	}
+
+	return embeddedPaths, nil
+}
+
+func getFilePathsFromDir(dir string) ([]string, error) {
+	var filePaths []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			filePaths = append(filePaths, path)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk through directory %s: %w", dir, err)
+	}
+
+	return filePaths, nil
 }

--- a/cli/daemon/watch.go
+++ b/cli/daemon/watch.go
@@ -38,7 +38,7 @@ func (s *Server) watchApps() {
 }
 
 func (s *Server) onWatchEvent(i *apps.Instance, events []watcher.Event) {
-	if run.IgnoreEvents(events) {
+	if run.IgnoreEvents(i.Root(), events) {
 		return
 	}
 


### PR DESCRIPTION
Regarding #416.

Added a very basic implementation to support watching files embedded using `//go:embed`.

Might make sense to track go files using watcher events instead of walking the whole project every time. Let me know if you want me to add that.