### PR TITLE
validation: make marker optional

### DIFF
--- a/runtimes/js/encore.dev/validate/mod.ts
+++ b/runtimes/js/encore.dev/validate/mod.ts
@@ -1,55 +1,55 @@
 declare const __validate: unique symbol;
 
 export type Min<N extends number> = {
-  [__validate]: {
+  [__validate]?: {
     minValue: N;
   };
 };
 
 export type Max<N extends number> = {
-  [__validate]: {
+  [__validate]?: {
     maxValue: N;
   };
 };
 
 export type MinLen<N extends number> = {
-  [__validate]: {
+  [__validate]?: {
     minLen: N;
   };
 };
 
 export type MaxLen<N extends number> = {
-  [__validate]: {
+  [__validate]?: {
     maxLen: N;
   };
 };
 
 export type MatchesRegexp<S extends string> = {
-  [__validate]: {
+  [__validate]?: {
     matchesRegexp: S;
   };
 };
 
 export type StartsWith<S extends string> = {
-  [__validate]: {
+  [__validate]?: {
     startsWith: S;
   };
 };
 
 export type EndsWith<S extends string> = {
-  [__validate]: {
+  [__validate]?: {
     endsWith: S;
   };
 };
 
 export type IsEmail = {
-  [__validate]: {
+  [__validate]?: {
     isEmail: true;
   };
 };
 
 export type IsURL = {
-  [__validate]: {
+  [__validate]?: {
     isURL: true;
   };
 };


### PR DESCRIPTION
To make the type checker happy when crating instances of the types. Currently the following will result in an error (`Type 'string' is not assignable to type 'string & MinLen<1> & MaxLen<2>'. Type 'string' is not assignable to type 'MinLen<1>'.`):

```ts
interface MyType {
    field: string & MinLen<1> & MaxLen<2>;
}

const x: MyType = { field: "a" };
```