### PR TITLE
parse error details as pvalues to support dates

### DIFF
--- a/runtimes/core/src/api/error.rs
+++ b/runtimes/core/src/api/error.rs
@@ -1,11 +1,14 @@
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
+use crate::api::jsonschema;
 use crate::error::{AppError, StackTrace};
 use axum::extract::ws::rejection::WebSocketUpgradeRejection;
 use serde::ser::SerializeStruct;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+use super::PValues;
 
 /// Represents an API Error.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -13,10 +16,34 @@ pub struct Error {
     pub code: ErrCode,
     pub message: String,
     pub internal_message: Option<String>,
-    pub details: Option<Box<serde_json::Map<String, serde_json::Value>>>,
+    #[serde(deserialize_with = "deserialize_details_as_any")]
+    pub details: ErrDetails,
 
     #[serde(skip_serializing)]
     pub stack: Option<StackTrace>,
+}
+
+pub type ErrDetails = Option<Box<PValues>>;
+
+// We don't have a schema for error details, so we do best effort to deserialize them.
+// Special types like Date will be lost, as we can't know if its a Date or a string.
+fn deserialize_details_as_any<'de, D>(deserializer: D) -> Result<ErrDetails, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let any_schema = {
+        use crate::encore::parser::meta::v1 as meta;
+        let md = meta::Data::default();
+        let mut builder = jsonschema::Builder::new(&md);
+        let idx = builder.register_value(jsonschema::Value::Basic(jsonschema::Basic::Any));
+        let registry = builder.build();
+        registry.schema(idx)
+    };
+
+    any_schema
+        .deserialize(deserializer, jsonschema::DecodeConfig::default())
+        .map(|pvalues| Some(Box::new(pvalues)))
+        .map_err(|err| err.into_inner())
 }
 
 /// ErrorExternal hides internal information on `Error` when it serializes

--- a/runtimes/js/src/pvalue.rs
+++ b/runtimes/js/src/pvalue.rs
@@ -43,7 +43,9 @@ pub fn pvalues_to_js(env: Env, val: &PValues) -> Result<JsUnknown> {
     }
 }
 
+#[derive(Clone)]
 pub struct PVal(pub PValue);
+#[derive(Clone)]
 pub struct PVals(pub PValues);
 
 impl ToNapiValue for PVal {

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -326,7 +326,7 @@ impl Runtime {
 pub struct APICallError {
     pub code: String,
     pub message: String,
-    pub details: Option<serde_json::Map<String, serde_json::Value>>,
+    pub details: Option<PVals>,
 }
 
 impl From<api::Error> for APICallError {
@@ -334,7 +334,7 @@ impl From<api::Error> for APICallError {
         Self {
             code: value.code.to_string(),
             message: value.message,
-            details: value.details.map(|d| *d),
+            details: value.details.map(|d| PVals(*d)),
         }
     }
 }


### PR DESCRIPTION
This adds support for Date-fields in error details

Since we don't have a schema for the details field, we deserialize it as `any`. We will lose the type infromation for date fields, and they will then be represented as strings instead.