### PR TITLE
clientgen/{ts,js}: default content type on raw request

### DIFF
--- a/e2e-tests/testdata/echo_client/js/client.js
+++ b/e2e-tests/testdata/echo_client/js/client.js
@@ -54,28 +54,28 @@ class CacheServiceClient {
 
     async GetList(key) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("GET", `/cache/list/${encodeURIComponent(key)}`)
+        const resp = await this.baseClient.callTypedAPI("GET", `/cache/list/${encodeURIComponent(key)}`)
         return await resp.json()
     }
 
     async GetStruct(key) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("GET", `/cache/struct/${encodeURIComponent(key)}`)
+        const resp = await this.baseClient.callTypedAPI("GET", `/cache/struct/${encodeURIComponent(key)}`)
         return await resp.json()
     }
 
     async Incr(key) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/cache/incr/${encodeURIComponent(key)}`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/cache/incr/${encodeURIComponent(key)}`)
         return await resp.json()
     }
 
     async PostList(key, val) {
-        await this.baseClient.callAPI("POST", `/cache/list/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
+        await this.baseClient.callTypedAPI("POST", `/cache/list/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
     }
 
     async PostStruct(key, val) {
-        await this.baseClient.callAPI("POST", `/cache/struct/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
+        await this.baseClient.callTypedAPI("POST", `/cache/struct/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
     }
 }
 
@@ -89,7 +89,7 @@ class DiServiceClient {
     }
 
     async One() {
-        await this.baseClient.callAPI("POST", `/di/one`)
+        await this.baseClient.callTypedAPI("POST", `/di/one`)
     }
 
     async Three(method, body, options) {
@@ -98,7 +98,7 @@ class DiServiceClient {
 
     async Two() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/di/two`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/di/two`)
         return await resp.json()
     }
 }
@@ -117,7 +117,7 @@ class EchoServiceClient {
      */
     async AppMeta() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.AppMeta`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.AppMeta`)
         return await resp.json()
     }
 
@@ -126,13 +126,13 @@ class EchoServiceClient {
      */
     async BasicEcho(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.BasicEcho`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.BasicEcho`, JSON.stringify(params))
         return await resp.json()
     }
 
     async ConfigValues() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.ConfigValues`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.ConfigValues`)
         return await resp.json()
     }
 
@@ -141,7 +141,7 @@ class EchoServiceClient {
      */
     async Echo(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.Echo`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.Echo`, JSON.stringify(params))
         return await resp.json()
     }
 
@@ -150,7 +150,7 @@ class EchoServiceClient {
      */
     async EmptyEcho(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.EmptyEcho`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.EmptyEcho`, JSON.stringify(params))
         return await resp.json()
     }
 
@@ -159,7 +159,7 @@ class EchoServiceClient {
      */
     async Env() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.Env`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.Env`)
         return await resp.json()
     }
 
@@ -174,7 +174,7 @@ class EchoServiceClient {
         })
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.HeadersEcho`, undefined, {headers})
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.HeadersEcho`, undefined, {headers})
 
         //Populate the return object from the JSON body and received headers
         const rtn = await resp.json()
@@ -193,7 +193,7 @@ class EchoServiceClient {
             value: params.Value,
         })
 
-        await this.baseClient.callAPI("GET", `/echo.MuteEcho`, undefined, {query})
+        await this.baseClient.callTypedAPI("GET", `/echo.MuteEcho`, undefined, {query})
     }
 
     /**
@@ -201,7 +201,7 @@ class EchoServiceClient {
      */
     async NilResponse() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/echo.NilResponse`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/echo.NilResponse`)
         return await resp.json()
     }
 
@@ -240,7 +240,7 @@ class EchoServiceClient {
         }
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/NonBasicEcho/${encodeURIComponent(pathString)}/${encodeURIComponent(pathInt)}/${pathWild.map(encodeURIComponent).join("/")}`, JSON.stringify(body), {headers, query})
+        const resp = await this.baseClient.callTypedAPI("POST", `/NonBasicEcho/${encodeURIComponent(pathString)}/${encodeURIComponent(pathInt)}/${pathWild.map(encodeURIComponent).join("/")}`, JSON.stringify(body), {headers, query})
 
         //Populate the return object from the JSON body and received headers
         const rtn = await resp.json()
@@ -253,7 +253,7 @@ class EchoServiceClient {
      * Noop does nothing
      */
     async Noop() {
-        await this.baseClient.callAPI("GET", `/echo.Noop`)
+        await this.baseClient.callTypedAPI("GET", `/echo.Noop`)
     }
 
     /**
@@ -261,7 +261,7 @@ class EchoServiceClient {
      */
     async Pong() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("GET", `/echo.Pong`)
+        const resp = await this.baseClient.callTypedAPI("GET", `/echo.Pong`)
         return await resp.json()
     }
 
@@ -269,7 +269,7 @@ class EchoServiceClient {
      * Publish publishes a request on a topic
      */
     async Publish() {
-        await this.baseClient.callAPI("POST", `/echo.Publish`)
+        await this.baseClient.callTypedAPI("POST", `/echo.Publish`)
     }
 }
 
@@ -283,7 +283,7 @@ class EmptycfgServiceClient {
     }
 
     async AnAPI() {
-        await this.baseClient.callAPI("POST", `/emptycfg.AnAPI`)
+        await this.baseClient.callTypedAPI("POST", `/emptycfg.AnAPI`)
     }
 }
 
@@ -297,7 +297,7 @@ class EndtoendServiceClient {
     }
 
     async GeneratedWrappersEndToEndTest() {
-        await this.baseClient.callAPI("GET", `/generated-wrappers-end-to-end-test`)
+        await this.baseClient.callTypedAPI("GET", `/generated-wrappers-end-to-end-test`)
     }
 }
 
@@ -311,18 +311,18 @@ class MiddlewareServiceClient {
     }
 
     async Error() {
-        await this.baseClient.callAPI("POST", `/middleware.Error`)
+        await this.baseClient.callTypedAPI("POST", `/middleware.Error`)
     }
 
     async ResponseGen(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/middleware.ResponseGen`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/middleware.ResponseGen`, JSON.stringify(params))
         return await resp.json()
     }
 
     async ResponseRewrite(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/middleware.ResponseRewrite`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/middleware.ResponseRewrite`, JSON.stringify(params))
         return await resp.json()
     }
 }
@@ -342,7 +342,7 @@ class TestServiceClient {
      */
     async GetMessage(clientID) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("GET", `/last_message/${encodeURIComponent(clientID)}`)
+        const resp = await this.baseClient.callTypedAPI("GET", `/last_message/${encodeURIComponent(clientID)}`)
         return await resp.json()
     }
 
@@ -392,7 +392,7 @@ class TestServiceClient {
         }
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/test.MarshallerTestHandler`, JSON.stringify(body), {headers, query})
+        const resp = await this.baseClient.callTypedAPI("POST", `/test.MarshallerTestHandler`, JSON.stringify(body), {headers, query})
 
         //Populate the return object from the JSON body and received headers
         const rtn = await resp.json()
@@ -412,14 +412,14 @@ class TestServiceClient {
      * Noop allows us to test if a simple HTTP request can be made
      */
     async Noop() {
-        await this.baseClient.callAPI("POST", `/test.Noop`)
+        await this.baseClient.callTypedAPI("POST", `/test.Noop`)
     }
 
     /**
      * NoopWithError allows us to test if the structured errors are returned
      */
     async NoopWithError() {
-        await this.baseClient.callAPI("POST", `/test.NoopWithError`)
+        await this.baseClient.callTypedAPI("POST", `/test.NoopWithError`)
     }
 
     /**
@@ -427,7 +427,7 @@ class TestServiceClient {
      */
     async PathMultiSegments(bool, _int, string, uuid, wildcard) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/multi/${encodeURIComponent(bool)}/${encodeURIComponent(_int)}/${encodeURIComponent(string)}/${encodeURIComponent(uuid)}/${wildcard.map(encodeURIComponent).join("/")}`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/multi/${encodeURIComponent(bool)}/${encodeURIComponent(_int)}/${encodeURIComponent(string)}/${encodeURIComponent(uuid)}/${wildcard.map(encodeURIComponent).join("/")}`)
         return await resp.json()
     }
 
@@ -460,7 +460,7 @@ class TestServiceClient {
         }
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("PUT", `/rest/object/${encodeURIComponent(objType)}/${encodeURIComponent(name)}`, JSON.stringify(body), {headers, query})
+        const resp = await this.baseClient.callTypedAPI("PUT", `/rest/object/${encodeURIComponent(objType)}/${encodeURIComponent(name)}`, JSON.stringify(body), {headers, query})
 
         //Populate the return object from the JSON body and received headers
         const rtn = await resp.json()
@@ -474,7 +474,7 @@ class TestServiceClient {
      */
     async SimpleBodyEcho(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/test.SimpleBodyEcho`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/test.SimpleBodyEcho`, JSON.stringify(params))
         return await resp.json()
     }
 
@@ -483,7 +483,7 @@ class TestServiceClient {
      */
     async TestAuthHandler() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/test.TestAuthHandler`)
+        const resp = await this.baseClient.callTypedAPI("POST", `/test.TestAuthHandler`)
         return await resp.json()
     }
 
@@ -492,7 +492,7 @@ class TestServiceClient {
      * but doesn't return anything
      */
     async UpdateMessage(clientID, params) {
-        await this.baseClient.callAPI("PUT", `/last_message/${encodeURIComponent(clientID)}`, JSON.stringify(params))
+        await this.baseClient.callTypedAPI("PUT", `/last_message/${encodeURIComponent(clientID)}`, JSON.stringify(params))
     }
 }
 
@@ -506,7 +506,7 @@ class ValidationServiceClient {
     }
 
     async TestOne(params) {
-        await this.baseClient.callAPI("POST", `/validation.TestOne`, JSON.stringify(params))
+        await this.baseClient.callTypedAPI("POST", `/validation.TestOne`, JSON.stringify(params))
     }
 }
 
@@ -719,9 +719,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -843,6 +841,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/e2e-tests/testdata/echo_client/ts/client.ts
+++ b/e2e-tests/testdata/echo_client/ts/client.ts
@@ -103,28 +103,28 @@ export namespace cache {
 
         public async GetList(key: number): Promise<ListResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/cache/list/${encodeURIComponent(key)}`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/cache/list/${encodeURIComponent(key)}`)
             return await resp.json() as ListResponse
         }
 
         public async GetStruct(key: number): Promise<StructVal> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/cache/struct/${encodeURIComponent(key)}`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/cache/struct/${encodeURIComponent(key)}`)
             return await resp.json() as StructVal
         }
 
         public async Incr(key: string): Promise<IncrResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/cache/incr/${encodeURIComponent(key)}`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/cache/incr/${encodeURIComponent(key)}`)
             return await resp.json() as IncrResponse
         }
 
         public async PostList(key: number, val: string): Promise<void> {
-            await this.baseClient.callAPI("POST", `/cache/list/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
+            await this.baseClient.callTypedAPI("POST", `/cache/list/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
         }
 
         public async PostStruct(key: number, val: string): Promise<void> {
-            await this.baseClient.callAPI("POST", `/cache/struct/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
+            await this.baseClient.callTypedAPI("POST", `/cache/struct/${encodeURIComponent(key)}/${encodeURIComponent(val)}`)
         }
     }
 }
@@ -142,7 +142,7 @@ export namespace di {
         }
 
         public async One(): Promise<void> {
-            await this.baseClient.callAPI("POST", `/di/one`)
+            await this.baseClient.callTypedAPI("POST", `/di/one`)
         }
 
         public async Three(method: string, body?: BodyInit, options?: CallParameters): Promise<globalThis.Response> {
@@ -151,7 +151,7 @@ export namespace di {
 
         public async Two(): Promise<TwoResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/di/two`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/di/two`)
             return await resp.json() as TwoResponse
         }
     }
@@ -269,7 +269,7 @@ export namespace echo {
          */
         public async AppMeta(): Promise<AppMetadata> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.AppMeta`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.AppMeta`)
             return await resp.json() as AppMetadata
         }
 
@@ -278,13 +278,13 @@ export namespace echo {
          */
         public async BasicEcho(params: BasicData): Promise<BasicData> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.BasicEcho`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.BasicEcho`, JSON.stringify(params))
             return await resp.json() as BasicData
         }
 
         public async ConfigValues(): Promise<ConfigResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.ConfigValues`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.ConfigValues`)
             return await resp.json() as ConfigResponse
         }
 
@@ -293,7 +293,7 @@ export namespace echo {
          */
         public async Echo(params: Data<string, number>): Promise<Data<string, number>> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.Echo`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.Echo`, JSON.stringify(params))
             return await resp.json() as Data<string, number>
         }
 
@@ -302,7 +302,7 @@ export namespace echo {
          */
         public async EmptyEcho(params: EmptyData): Promise<EmptyData> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.EmptyEcho`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.EmptyEcho`, JSON.stringify(params))
             return await resp.json() as EmptyData
         }
 
@@ -311,7 +311,7 @@ export namespace echo {
          */
         public async Env(): Promise<EnvResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.Env`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.Env`)
             return await resp.json() as EnvResponse
         }
 
@@ -326,7 +326,7 @@ export namespace echo {
             })
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.HeadersEcho`, undefined, {headers})
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.HeadersEcho`, undefined, {headers})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as HeadersData
@@ -345,7 +345,7 @@ export namespace echo {
                 value: params.Value,
             })
 
-            await this.baseClient.callAPI("GET", `/echo.MuteEcho`, undefined, {query})
+            await this.baseClient.callTypedAPI("GET", `/echo.MuteEcho`, undefined, {query})
         }
 
         /**
@@ -353,7 +353,7 @@ export namespace echo {
          */
         public async NilResponse(): Promise<BasicData> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/echo.NilResponse`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/echo.NilResponse`)
             return await resp.json() as BasicData
         }
 
@@ -392,7 +392,7 @@ export namespace echo {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/NonBasicEcho/${encodeURIComponent(pathString)}/${encodeURIComponent(pathInt)}/${pathWild.map(encodeURIComponent).join("/")}`, JSON.stringify(body), {headers, query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/NonBasicEcho/${encodeURIComponent(pathString)}/${encodeURIComponent(pathInt)}/${pathWild.map(encodeURIComponent).join("/")}`, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as NonBasicData
@@ -405,7 +405,7 @@ export namespace echo {
          * Noop does nothing
          */
         public async Noop(): Promise<void> {
-            await this.baseClient.callAPI("GET", `/echo.Noop`)
+            await this.baseClient.callTypedAPI("GET", `/echo.Noop`)
         }
 
         /**
@@ -413,7 +413,7 @@ export namespace echo {
          */
         public async Pong(): Promise<Data<string, string>> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/echo.Pong`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/echo.Pong`)
             return await resp.json() as Data<string, string>
         }
 
@@ -421,7 +421,7 @@ export namespace echo {
          * Publish publishes a request on a topic
          */
         public async Publish(): Promise<void> {
-            await this.baseClient.callAPI("POST", `/echo.Publish`)
+            await this.baseClient.callTypedAPI("POST", `/echo.Publish`)
         }
     }
 }
@@ -436,7 +436,7 @@ export namespace emptycfg {
         }
 
         public async AnAPI(): Promise<void> {
-            await this.baseClient.callAPI("POST", `/emptycfg.AnAPI`)
+            await this.baseClient.callTypedAPI("POST", `/emptycfg.AnAPI`)
         }
     }
 }
@@ -451,7 +451,7 @@ export namespace endtoend {
         }
 
         public async GeneratedWrappersEndToEndTest(): Promise<void> {
-            await this.baseClient.callAPI("GET", `/generated-wrappers-end-to-end-test`)
+            await this.baseClient.callTypedAPI("GET", `/generated-wrappers-end-to-end-test`)
         }
     }
 }
@@ -469,18 +469,18 @@ export namespace middleware {
         }
 
         public async Error(): Promise<void> {
-            await this.baseClient.callAPI("POST", `/middleware.Error`)
+            await this.baseClient.callTypedAPI("POST", `/middleware.Error`)
         }
 
         public async ResponseGen(params: Payload): Promise<Payload> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/middleware.ResponseGen`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/middleware.ResponseGen`, JSON.stringify(params))
             return await resp.json() as Payload
         }
 
         public async ResponseRewrite(params: Payload): Promise<Payload> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/middleware.ResponseRewrite`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/middleware.ResponseRewrite`, JSON.stringify(params))
             return await resp.json() as Payload
         }
     }
@@ -555,7 +555,7 @@ export namespace test {
          */
         public async GetMessage(clientID: string): Promise<BodyEcho> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/last_message/${encodeURIComponent(clientID)}`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/last_message/${encodeURIComponent(clientID)}`)
             return await resp.json() as BodyEcho
         }
 
@@ -605,7 +605,7 @@ export namespace test {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/test.MarshallerTestHandler`, JSON.stringify(body), {headers, query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/test.MarshallerTestHandler`, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as MarshallerTest<number>
@@ -625,14 +625,14 @@ export namespace test {
          * Noop allows us to test if a simple HTTP request can be made
          */
         public async Noop(): Promise<void> {
-            await this.baseClient.callAPI("POST", `/test.Noop`)
+            await this.baseClient.callTypedAPI("POST", `/test.Noop`)
         }
 
         /**
          * NoopWithError allows us to test if the structured errors are returned
          */
         public async NoopWithError(): Promise<void> {
-            await this.baseClient.callAPI("POST", `/test.NoopWithError`)
+            await this.baseClient.callTypedAPI("POST", `/test.NoopWithError`)
         }
 
         /**
@@ -640,7 +640,7 @@ export namespace test {
          */
         public async PathMultiSegments(bool: boolean, int: number, _string: string, uuid: string, wildcard: string[]): Promise<MultiPathSegment> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/multi/${encodeURIComponent(bool)}/${encodeURIComponent(int)}/${encodeURIComponent(_string)}/${encodeURIComponent(uuid)}/${wildcard.map(encodeURIComponent).join("/")}`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/multi/${encodeURIComponent(bool)}/${encodeURIComponent(int)}/${encodeURIComponent(_string)}/${encodeURIComponent(uuid)}/${wildcard.map(encodeURIComponent).join("/")}`)
             return await resp.json() as MultiPathSegment
         }
 
@@ -673,7 +673,7 @@ export namespace test {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("PUT", `/rest/object/${encodeURIComponent(objType)}/${encodeURIComponent(name)}`, JSON.stringify(body), {headers, query})
+            const resp = await this.baseClient.callTypedAPI("PUT", `/rest/object/${encodeURIComponent(objType)}/${encodeURIComponent(name)}`, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as RestParams
@@ -687,7 +687,7 @@ export namespace test {
          */
         public async SimpleBodyEcho(params: BodyEcho): Promise<BodyEcho> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/test.SimpleBodyEcho`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/test.SimpleBodyEcho`, JSON.stringify(params))
             return await resp.json() as BodyEcho
         }
 
@@ -696,7 +696,7 @@ export namespace test {
          */
         public async TestAuthHandler(): Promise<BodyEcho> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/test.TestAuthHandler`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/test.TestAuthHandler`)
             return await resp.json() as BodyEcho
         }
 
@@ -705,7 +705,7 @@ export namespace test {
          * but doesn't return anything
          */
         public async UpdateMessage(clientID: string, params: BodyEcho): Promise<void> {
-            await this.baseClient.callAPI("PUT", `/last_message/${encodeURIComponent(clientID)}`, JSON.stringify(params))
+            await this.baseClient.callTypedAPI("PUT", `/last_message/${encodeURIComponent(clientID)}`, JSON.stringify(params))
         }
     }
 }
@@ -723,7 +723,7 @@ export namespace validation {
         }
 
         public async TestOne(params: Request): Promise<void> {
-            await this.baseClient.callAPI("POST", `/validation.TestOne`, JSON.stringify(params))
+            await this.baseClient.callTypedAPI("POST", `/validation.TestOne`, JSON.stringify(params))
         }
     }
 }
@@ -969,9 +969,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -1094,6 +1092,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -1106,7 +1112,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();

--- a/internal/clientgen/javascript.go
+++ b/internal/clientgen/javascript.go
@@ -430,9 +430,9 @@ func (js *javascript) rpcCallSite(w *indentWriter, rpc *meta.RPC, rpcPath string
 		}
 	}
 
-	// Build the call to callAPI
+	// Build the call to callTypedAPI
 	callAPI := fmt.Sprintf(
-		"this.baseClient.callAPI(\"%s\", `%s`",
+		"this.baseClient.callTypedAPI(\"%s\", `%s`",
 		rpcEncoding.DefaultMethod,
 		rpcPath,
 	)
@@ -738,9 +738,7 @@ class BaseClient {`)
 	js.WriteString(`
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -911,6 +909,15 @@ class BaseClient {`)
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/goapp/expected_baseauth_javascript.js
+++ b/internal/clientgen/testdata/goapp/expected_baseauth_javascript.js
@@ -58,14 +58,14 @@ class SvcServiceClient {
      * DummyAPI is a dummy endpoint.
      */
     async DummyAPI(params) {
-        await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
+        await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
     }
 
     /**
      * Private is a basic auth endpoint.
      */
     async Private(params) {
-        await this.baseClient.callAPI("POST", `/svc.Private`, JSON.stringify(params))
+        await this.baseClient.callTypedAPI("POST", `/svc.Private`, JSON.stringify(params))
     }
 }
 
@@ -264,9 +264,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -381,6 +379,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/goapp/expected_baseauth_typescript.ts
+++ b/internal/clientgen/testdata/goapp/expected_baseauth_typescript.ts
@@ -101,14 +101,14 @@ export namespace svc {
          * DummyAPI is a dummy endpoint.
          */
         public async DummyAPI(params: Request): Promise<void> {
-            await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
+            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
         }
 
         /**
          * Private is a basic auth endpoint.
          */
         public async Private(params: Request): Promise<void> {
-            await this.baseClient.callAPI("POST", `/svc.Private`, JSON.stringify(params))
+            await this.baseClient.callTypedAPI("POST", `/svc.Private`, JSON.stringify(params))
         }
     }
 }
@@ -337,9 +337,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -455,6 +453,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -467,7 +473,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();

--- a/internal/clientgen/testdata/goapp/expected_javascript.js
+++ b/internal/clientgen/testdata/goapp/expected_javascript.js
@@ -48,7 +48,7 @@ class AuthenticationServiceClient {
     }
 
     async Docs(params) {
-        await this.baseClient.callAPI("POST", `/authentication.Docs`, JSON.stringify(params))
+        await this.baseClient.callTypedAPI("POST", `/authentication.Docs`, JSON.stringify(params))
     }
 }
 
@@ -74,13 +74,13 @@ class ProductsServiceClient {
         }
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/products.Create`, JSON.stringify(body), {headers})
+        const resp = await this.baseClient.callTypedAPI("POST", `/products.Create`, JSON.stringify(body), {headers})
         return await resp.json()
     }
 
     async List() {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("GET", `/products.List`)
+        const resp = await this.baseClient.callTypedAPI("GET", `/products.List`)
         return await resp.json()
     }
 }
@@ -116,11 +116,11 @@ class SvcServiceClient {
             boo: params.boo,
         }
 
-        await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
+        await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
     }
 
     async FallbackPath(a, b) {
-        await this.baseClient.callAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+        await this.baseClient.callTypedAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
     }
 
     async Get(params) {
@@ -129,7 +129,7 @@ class SvcServiceClient {
             boo: String(params.Baz),
         })
 
-        await this.baseClient.callAPI("GET", `/svc.Get`, undefined, {query})
+        await this.baseClient.callTypedAPI("GET", `/svc.Get`, undefined, {query})
     }
 
     async GetRequestWithAllInputTypes(params) {
@@ -145,7 +145,7 @@ class SvcServiceClient {
         })
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
+        const resp = await this.baseClient.callTypedAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
 
         //Populate the return object from the JSON body and received headers
         const rtn = await resp.json()
@@ -175,22 +175,22 @@ class SvcServiceClient {
             "x-uuid":    String(params.UUID),
         })
 
-        await this.baseClient.callAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
+        await this.baseClient.callTypedAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
     }
 
     async Nested(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/svc.Nested`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/svc.Nested`, JSON.stringify(params))
         return await resp.json()
     }
 
     async RESTPath(a, b) {
-        await this.baseClient.callAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
+        await this.baseClient.callTypedAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
     }
 
     async Rec(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/svc.Rec`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/svc.Rec`, JSON.stringify(params))
         return await resp.json()
     }
 
@@ -211,7 +211,7 @@ class SvcServiceClient {
         }
 
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/svc.RequestWithAllInputTypes`, JSON.stringify(body), {headers, query})
+        const resp = await this.baseClient.callTypedAPI("POST", `/svc.RequestWithAllInputTypes`, JSON.stringify(body), {headers, query})
 
         //Populate the return object from the JSON body and received headers
         const rtn = await resp.json()
@@ -225,7 +225,7 @@ class SvcServiceClient {
      */
     async TupleInputOutput(params) {
         // Now make the actual call to the API
-        const resp = await this.baseClient.callAPI("POST", `/svc.TupleInputOutput`, JSON.stringify(params))
+        const resp = await this.baseClient.callTypedAPI("POST", `/svc.TupleInputOutput`, JSON.stringify(params))
         return await resp.json()
     }
 
@@ -234,7 +234,7 @@ class SvcServiceClient {
     }
 
     async Webhook2(a, b) {
-        await this.baseClient.callAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+        await this.baseClient.callTypedAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
     }
 }
 
@@ -447,9 +447,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -565,6 +563,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/goapp/expected_noauth_javascript.js
+++ b/internal/clientgen/testdata/goapp/expected_noauth_javascript.js
@@ -49,7 +49,7 @@ class SvcServiceClient {
      * DummyAPI is a dummy endpoint.
      */
     async DummyAPI(params) {
-        await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
+        await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
     }
 }
 
@@ -248,9 +248,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -333,6 +331,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/goapp/expected_noauth_typescript.ts
+++ b/internal/clientgen/testdata/goapp/expected_noauth_typescript.ts
@@ -76,7 +76,7 @@ export namespace svc {
          * DummyAPI is a dummy endpoint.
          */
         public async DummyAPI(params: Request): Promise<void> {
-            await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
+            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
         }
     }
 }
@@ -299,9 +299,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -386,6 +384,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -398,7 +404,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();

--- a/internal/clientgen/testdata/goapp/expected_typescript.ts
+++ b/internal/clientgen/testdata/goapp/expected_typescript.ts
@@ -114,7 +114,7 @@ export namespace authentication {
         }
 
         public async Docs(params: FooType): Promise<void> {
-            await this.baseClient.callAPI("POST", `/authentication.Docs`, JSON.stringify(params))
+            await this.baseClient.callTypedAPI("POST", `/authentication.Docs`, JSON.stringify(params))
         }
     }
 }
@@ -166,13 +166,13 @@ export namespace products {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/products.Create`, JSON.stringify(body), {headers})
+            const resp = await this.baseClient.callTypedAPI("POST", `/products.Create`, JSON.stringify(body), {headers})
             return await resp.json() as Product
         }
 
         public async List(): Promise<ProductListing> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/products.List`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/products.List`)
             return await resp.json() as ProductListing
         }
     }
@@ -298,11 +298,11 @@ export namespace svc {
                 boo: params.boo,
             }
 
-            await this.baseClient.callAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
+            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
         }
 
         public async FallbackPath(a: string, b: string[]): Promise<void> {
-            await this.baseClient.callAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+            await this.baseClient.callTypedAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
         }
 
         public async Get(params: GetRequest): Promise<void> {
@@ -311,7 +311,7 @@ export namespace svc {
                 boo: String(params.Baz),
             })
 
-            await this.baseClient.callAPI("GET", `/svc.Get`, undefined, {query})
+            await this.baseClient.callTypedAPI("GET", `/svc.Get`, undefined, {query})
         }
 
         public async GetRequestWithAllInputTypes(params: AllInputTypes<number>): Promise<HeaderOnlyStruct> {
@@ -327,7 +327,7 @@ export namespace svc {
             })
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
+            const resp = await this.baseClient.callTypedAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as HeaderOnlyStruct
@@ -357,22 +357,22 @@ export namespace svc {
                 "x-uuid":    String(params.UUID),
             })
 
-            await this.baseClient.callAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
+            await this.baseClient.callTypedAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
         }
 
         public async Nested(params: WithNested): Promise<WithNested> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/svc.Nested`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.Nested`, JSON.stringify(params))
             return await resp.json() as WithNested
         }
 
         public async RESTPath(a: string, b: number): Promise<void> {
-            await this.baseClient.callAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
+            await this.baseClient.callTypedAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
         }
 
         public async Rec(params: Recursive): Promise<Recursive> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/svc.Rec`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.Rec`, JSON.stringify(params))
             return await resp.json() as Recursive
         }
 
@@ -393,7 +393,7 @@ export namespace svc {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/svc.RequestWithAllInputTypes`, JSON.stringify(body), {headers, query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.RequestWithAllInputTypes`, JSON.stringify(body), {headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as AllInputTypes<number>
@@ -407,7 +407,7 @@ export namespace svc {
          */
         public async TupleInputOutput(params: Tuple<string, WrappedRequest>): Promise<Tuple<boolean, Foo>> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callAPI("POST", `/svc.TupleInputOutput`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.TupleInputOutput`, JSON.stringify(params))
             return await resp.json() as Tuple<boolean, Foo>
         }
 
@@ -416,7 +416,7 @@ export namespace svc {
         }
 
         public async Webhook2(a: string, b: string[]): Promise<void> {
-            await this.baseClient.callAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+            await this.baseClient.callTypedAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
         }
     }
 }
@@ -668,9 +668,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -787,6 +785,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -799,7 +805,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();

--- a/internal/clientgen/testdata/tsapp/expected_javascript.js
+++ b/internal/clientgen/testdata/tsapp/expected_javascript.js
@@ -63,7 +63,7 @@ class SvcServiceClient {
             foo: params.foo,
         }
 
-        await this.baseClient.callAPI("POST", `/dummy`, JSON.stringify(body), {headers, query})
+        await this.baseClient.callTypedAPI("POST", `/dummy`, JSON.stringify(body), {headers, query})
     }
 
     async root(params) {
@@ -84,7 +84,7 @@ class SvcServiceClient {
             foo: params.foo,
         }
 
-        await this.baseClient.callAPI("POST", `/`, JSON.stringify(body), {headers, query})
+        await this.baseClient.callTypedAPI("POST", `/`, JSON.stringify(body), {headers, query})
     }
 }
 
@@ -283,9 +283,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -402,6 +400,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/tsapp/expected_list_of_union_javascript.js
+++ b/internal/clientgen/testdata/tsapp/expected_list_of_union_javascript.js
@@ -51,7 +51,7 @@ class SvcServiceClient {
             listOfUnion: params.listOfUnion.map((v) => String(v)),
         })
 
-        await this.baseClient.callAPI("GET", `/dummy`, undefined, {query})
+        await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, {query})
     }
 }
 
@@ -250,9 +250,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -335,6 +333,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/tsapp/expected_list_of_union_typescript.ts
+++ b/internal/clientgen/testdata/tsapp/expected_list_of_union_typescript.ts
@@ -78,7 +78,7 @@ export namespace svc {
                 listOfUnion: params.listOfUnion.map((v) => String(v)),
             })
 
-            await this.baseClient.callAPI("GET", `/dummy`, undefined, {query})
+            await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, {query})
         }
     }
 }
@@ -301,9 +301,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -388,6 +386,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -400,7 +406,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();

--- a/internal/clientgen/testdata/tsapp/expected_stream_javascript.js
+++ b/internal/clientgen/testdata/tsapp/expected_stream_javascript.js
@@ -319,9 +319,7 @@ const boundFetch = fetch.bind(this)
 class BaseClient {
     constructor(baseURL, options) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -404,6 +402,15 @@ class BaseClient {
 
         const queryString = query ? '?' + encodeQuery(query) : ''
         return new StreamOut(this.baseURL + path + queryString, headers);
+    }
+
+
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    async callTypedAPI(method, path, body, params) {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
     }
 
     // callAPI is used by each generated API method to actually make the request

--- a/internal/clientgen/testdata/tsapp/expected_stream_typescript.ts
+++ b/internal/clientgen/testdata/tsapp/expected_stream_typescript.ts
@@ -416,9 +416,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -503,6 +501,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -515,7 +521,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();

--- a/internal/clientgen/testdata/tsapp/expected_typescript.ts
+++ b/internal/clientgen/testdata/tsapp/expected_typescript.ts
@@ -132,7 +132,7 @@ export namespace svc {
                 foo: params.foo,
             }
 
-            await this.baseClient.callAPI("POST", `/dummy`, JSON.stringify(body), {headers, query})
+            await this.baseClient.callTypedAPI("POST", `/dummy`, JSON.stringify(body), {headers, query})
         }
 
         public async root(params: Request): Promise<void> {
@@ -153,7 +153,7 @@ export namespace svc {
                 foo: params.foo,
             }
 
-            await this.baseClient.callAPI("POST", `/`, JSON.stringify(body), {headers, query})
+            await this.baseClient.callTypedAPI("POST", `/`, JSON.stringify(body), {headers, query})
         }
     }
 }
@@ -382,9 +382,7 @@ class BaseClient {
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
-        this.headers = {
-            "Content-Type": "application/json",
-        }
+        this.headers = {}
 
         // Add User-Agent header if the script is running in the server
         // because browsers do not allow setting User-Agent headers to requests
@@ -502,6 +500,14 @@ class BaseClient {
         return new StreamOut(this.baseURL + path + queryString, headers);
     }
 
+    // callTypedAPI makes an API call, defaulting content type to "application/json"
+    public async callTypedAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
+        return this.callAPI(method, path, body, {
+            ...params,
+            headers: { "Content-Type": "application/json", ...params?.headers }
+        });
+    }
+
     // callAPI is used by each generated API method to actually make the request
     public async callAPI(method: string, path: string, body?: BodyInit, params?: CallParameters): Promise<Response> {
         let { query, headers, ...rest } = params ?? {}
@@ -514,7 +520,6 @@ class BaseClient {
 
         // Merge our headers with any predefined headers
         init.headers = {...this.headers, ...init.headers, ...headers}
-
 
         // Fetch auth data if there is any
         const authData = await this.getAuthData();


### PR DESCRIPTION
node-fetch will automatically figure out the content type (such as `FormData`) and handle it for certain types, see https://fetch.spec.whatwg.org/#concept-bodyinit-extract and it seems like relying on that logic for raw endoints would be a sane default

