### PR TITLE
Fix schema filename mismatch in TypeScript GraphQL tutorial

### DIFF
--- a/docs/ts/tutorials/graphql.mdx
+++ b/docs/ts/tutorials/graphql.mdx
@@ -87,10 +87,10 @@ generates:
 
 Now it's time to define the GraphQL schema.
 
-🥐 Create a `schema.graphqls` file in the application root containing:
+🥐 Create a `schema.graphql` file in the application root containing:
 
 ```
--- schema.graphqls --
+-- schema.graphql --
 type Query {
   books: [Book]
 }


### PR DESCRIPTION
In the GraphQL tutorial for encore.ts, the schema filename specified in the codegen config does not match the one that the tutorial asks us to create.