### PR TITLE
clientgen/ts: qualify Request with globalThis to avoid name conflicts

### DIFF
--- a/e2e-tests/testdata/echo_client/ts/client.ts
+++ b/e2e-tests/testdata/echo_client/ts/client.ts
@@ -145,7 +145,7 @@ export namespace di {
             await this.baseClient.callAPI("POST", `/di/one`)
         }
 
-        public async Three(method: string, body?: BodyInit, options?: CallParameters): Promise<Response> {
+        public async Three(method: string, body?: BodyInit, options?: CallParameters): Promise<globalThis.Response> {
             return this.baseClient.callAPI(method, `/di/raw`, body, options)
         }
 
@@ -648,7 +648,7 @@ export namespace test {
          * RawEndpoint allows us to test the clients' ability to send raw requests
          * under auth
          */
-        public async RawEndpoint(method: "PUT" | "POST" | "DELETE" | "GET", id: string[], body?: BodyInit, options?: CallParameters): Promise<Response> {
+        public async RawEndpoint(method: "PUT" | "POST" | "DELETE" | "GET", id: string[], body?: BodyInit, options?: CallParameters): Promise<globalThis.Response> {
             return this.baseClient.callAPI(method, `/raw/blah/${id.map(encodeURIComponent).join("/")}`, body, options)
         }
 

--- a/internal/clientgen/testdata/goapp/expected_typescript.ts
+++ b/internal/clientgen/testdata/goapp/expected_typescript.ts
@@ -411,7 +411,7 @@ export namespace svc {
             return await resp.json() as Tuple<boolean, Foo>
         }
 
-        public async Webhook(method: string, a: string, b: string[], body?: BodyInit, options?: CallParameters): Promise<Response> {
+        public async Webhook(method: string, a: string, b: string[], body?: BodyInit, options?: CallParameters): Promise<globalThis.Response> {
             return this.baseClient.callAPI(method, `/webhook/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, body, options)
         }
 

--- a/internal/clientgen/typescript.go
+++ b/internal/clientgen/typescript.go
@@ -304,7 +304,7 @@ func (ts *typescript) writeService(svc *meta.Service, p clientgentypes.ServiceSe
 		} else if rpc.ResponseSchema != nil {
 			ts.writeTyp(ns, rpc.ResponseSchema, 0)
 		} else if rpc.Proto == meta.RPC_RAW {
-			ts.WriteString("Response")
+			ts.WriteString("globalThis.Response")
 		} else {
 			ts.WriteString("void")
 		}


### PR DESCRIPTION
Qualify Response with `globalThis` to avoid name conflicts with types used within that service.

[globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is available in all browsers and in nodejs