### PR TITLE
tsparser: make tags non-nullable

### DIFF
--- a/tsparser/src/legacymeta/mod.rs
+++ b/tsparser/src/legacymeta/mod.rs
@@ -166,8 +166,6 @@ impl MetaBuilder<'_> {
 
                     let tags = ep
                         .tags
-                        .as_ref()
-                        .unwrap_or(&vec![])
                         .iter()
                         .map(|tag| Selector {
                             r#type: selector::Type::Tag.into(),

--- a/tsparser/src/parser/resources/apis/api.rs
+++ b/tsparser/src/parser/resources/apis/api.rs
@@ -36,7 +36,7 @@ pub struct Endpoint {
     pub expose: bool,
     pub raw: bool,
     pub require_auth: bool,
-    pub tags: Option<Vec<String>>,
+    pub tags: Vec<String>,
 
     /// Body limit in bytes.
     /// None means no limit.
@@ -375,7 +375,7 @@ pub const ENDPOINT_PARSER: ResourceParser = ResourceParser {
                 static_assets,
                 body_limit,
                 encoding,
-                tags: cfg.tags,
+                tags: cfg.tags.unwrap_or_default(),
             }));
 
             pass.add_resource(resource.clone());

--- a/tsparser/src/parser/usageparser/mod.rs
+++ b/tsparser/src/parser/usageparser/mod.rs
@@ -556,7 +556,7 @@ export const Bar = 5;
                 streaming_request: false,
                 streaming_response: false,
                 static_assets: None,
-                tags: None,
+                tags: vec![],
             }));
 
             let bar_binds = vec![Lrc::new(Bind {
@@ -654,7 +654,7 @@ export const Bar = 5;
                 streaming_request: false,
                 streaming_response: false,
                 static_assets: None,
-                tags: None,
+                tags: vec![],
             }));
             let bar_binds = vec![Lrc::new(Bind {
                 kind: BindKind::Create,


### PR DESCRIPTION
This makes the `tags` field always set, in line with what the runtime expects. Otherwise we can end up with type errors when tags are undefined.

Thanks Daan Kets for reporting.