### PR TITLE
runtimes/js: add tags to api description

### DIFF
--- a/runtimes/js/encore.dev/req_meta.ts
+++ b/runtimes/js/encore.dev/req_meta.ts
@@ -13,6 +13,9 @@ export interface APIDesc {
 
   /** Whether the endpoint requires auth. */
   auth: boolean;
+
+  /** Tags specifified on the API endpoint. */
+  tags: string[];
 }
 
 export type Method =
@@ -171,7 +174,8 @@ export function currentRequest(): RequestMeta | undefined {
         service: meta.apiCall.api.service,
         endpoint: meta.apiCall.api.endpoint,
         raw: meta.apiCall.api.raw,
-        auth: meta.apiCall.api.requiresAuth
+        auth: meta.apiCall.api.requiresAuth,
+        tags: meta.apiCall.api.tags
       },
       method: meta.apiCall.method as Method,
       path: meta.apiCall.path,

--- a/runtimes/js/encore.dev/req_meta.ts
+++ b/runtimes/js/encore.dev/req_meta.ts
@@ -14,7 +14,7 @@ export interface APIDesc {
   /** Whether the endpoint requires auth. */
   auth: boolean;
 
-  /** Tags specifified on the API endpoint. */
+  /** Tags specified on the endpoint. */
   tags: string[];
 }
 

--- a/runtimes/js/src/request_meta.rs
+++ b/runtimes/js/src/request_meta.rs
@@ -17,6 +17,7 @@ pub fn meta(req: &model::Request) -> Result<RequestMeta, serde_json::Error> {
                     endpoint: rpc.endpoint.name.endpoint().to_string(),
                     raw: rpc.endpoint.raw,
                     requires_auth: rpc.endpoint.requires_auth,
+                    tags: rpc.endpoint.tags.clone(),
                 },
                 method: rpc.method.as_str().to_string(),
                 path: rpc.path.clone(),
@@ -43,6 +44,7 @@ pub fn meta(req: &model::Request) -> Result<RequestMeta, serde_json::Error> {
                     endpoint: data.endpoint.name.endpoint().to_string(),
                     raw: data.endpoint.raw,
                     requires_auth: data.endpoint.requires_auth,
+                    tags: data.endpoint.tags.clone(),
                 },
                 method: Default::default(),
                 path: data.path.clone(),
@@ -117,6 +119,7 @@ pub struct APIDesc {
     pub endpoint: String,
     pub raw: bool,
     pub requires_auth: bool,
+    pub tags: Vec<String>,
 }
 
 #[napi(object)]


### PR DESCRIPTION
Add tags to api descriptions so that the can be accessed via middleware and endpoint handlers