### PR TITLE
runtimes/core: deserialize details to none if not valid pvalues

### DIFF
--- a/runtimes/core/src/api/jsonschema/mod.rs
+++ b/runtimes/core/src/api/jsonschema/mod.rs
@@ -102,6 +102,15 @@ impl JSONSchema {
             root: 0,
         }
     }
+
+    pub fn any() -> Self {
+        JSONSchema {
+            registry: Arc::new(Registry {
+                values: vec![Value::Basic(Basic::Any)],
+            }),
+            root: 0,
+        }
+    }
 }
 
 impl fmt::Debug for JSONSchema {


### PR DESCRIPTION
If we can't deserialize error details as pvalues, set them to null (e.g if they are null)