### PR TITLE
Increase max message size

### DIFF
--- a/cli/cmd/encore/cmdutil/daemon.go
+++ b/cli/cmd/encore/cmdutil/daemon.go
@@ -155,11 +155,14 @@ func dialDaemon(ctx context.Context, socketPath string) (*grpc.ClientConn, error
 	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
 		return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	}
+	// Set max message size to 16mb (up from default 4mb) for json formatted debug metadata for large applications.
 	return grpc.DialContext(ctx, "",
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
 		grpc.WithUnaryInterceptor(errInterceptor),
-		grpc.WithContextDialer(dialer))
+		grpc.WithContextDialer(dialer),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(16*1024*1024)),
+	)
 }
 
 func errInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {


### PR DESCRIPTION
Generating debug metadata for large apps fails due to default gRPC message size limits:

```
git:(main) encore debug meta --format json
error: grpc: received message larger than max (6181042 vs. 4194304)
```

This increases the limit from 4mb to 16mb.