### PR TITLE
extract non-visible ascii from header value

### DIFF
--- a/runtimes/core/src/api/reqauth/meta.rs
+++ b/runtimes/core/src/api/reqauth/meta.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::str::{self, FromStr};
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum MetaKey {
@@ -78,7 +78,8 @@ impl MetaMapMut for reqwest::header::HeaderMap {
 
 impl MetaMap for axum::http::HeaderMap {
     fn get_meta(&self, key: MetaKey) -> Option<&str> {
-        self.get(key.header_key()).and_then(|v| v.to_str().ok())
+        self.get(key.header_key())
+            .and_then(|val| std::str::from_utf8(val.as_bytes()).ok())
     }
 
     fn meta_values<'a>(&'a self, key: MetaKey) -> Box<dyn Iterator<Item = &'a str> + 'a> {

--- a/runtimes/core/src/api/reqauth/meta.rs
+++ b/runtimes/core/src/api/reqauth/meta.rs
@@ -78,6 +78,8 @@ impl MetaMapMut for reqwest::header::HeaderMap {
 
 impl MetaMap for axum::http::HeaderMap {
     fn get_meta(&self, key: MetaKey) -> Option<&str> {
+        // Some meta values may contain utf8 characters (e.g authdata) so we use `str::from_utf8`
+        // rather than using `HeaderValues::to_str` which errors on non-visible ASCII characters.
         self.get(key.header_key())
             .and_then(|val| std::str::from_utf8(val.as_bytes()).ok())
     }


### PR DESCRIPTION
`HeaderValue::to_str` errors if there are non-visible us ascii characters in the header value, see https://docs.rs/http/latest/http/header/struct.HeaderValue.html#method.to_str

```ts
export const auth = authHandler<AuthParams, AuthData>(async (params) => {
  return { userID: "🎅", name: "åäöテポกขฃคฅฆ🧜" };
});
```

Tested locally with emojis and non-us chars, and can get them out via `getAuthData()` from the above auth handler:

```
6:09PM INF starting request endpoint=get service=hello span_id=clce60omtmpes trace_id=m2g95q064peir9gm2cgub8gsv4 uid="🎅" x_correlation_id=dash-call-1
{ name: 'åäöテポกขฃคฅฆ🧜', userID: '🎅' }
```