### PR TITLE
gcsemu: trim os path separator

### DIFF
--- a/pkg/emulators/storage/gcsemu/filestore.go
+++ b/pkg/emulators/storage/gcsemu/filestore.go
@@ -247,7 +247,7 @@ func (fs *filestore) Walk(ctx context.Context, bucket string, cb func(ctx contex
 		}
 
 		filename := strings.TrimPrefix(path, root)
-		filename = strings.TrimPrefix(filename, "/")
+		filename = strings.TrimPrefix(filename, string(os.PathSeparator))
 		if err != nil {
 			if os.IsNotExist(err) {
 				return err


### PR DESCRIPTION
on windows the separator in \\, so it will not be stripped