### PR TITLE
[errs] use errors.As instead of type assertions

### DIFF
--- a/runtimes/go/beta/errs/error.go
+++ b/runtimes/go/beta/errs/error.go
@@ -111,15 +111,15 @@ func Convert(err error) error {
 		return nil
 	}
 
+	if e, ok := err.(*Error); ok {
+		// If the parent is already an *Error we can return it directly.
+		return e
+	}
+
 	var e *Error
 	if errors.As(err, &e) {
-		if directErr, ok := err.(*Error); ok {
-			// If the parent is already an *Error, return it directly
-			return directErr
-		}
-
-		// The error itself isn't an *Error, but it wraps one somewhere in the chain
-		// Create a new *Error that preserves the outer error but takes properties from inner *Error
+		// The error itself isn't an *Error, but it wraps one somewhere in the chain. Create a new *Error that preserves
+		// the outer error but takes properties from inner *Error
 		return &Error{
 			Code:       e.Code,
 			Message:    err.Error(),

--- a/runtimes/go/beta/errs/error.go
+++ b/runtimes/go/beta/errs/error.go
@@ -190,13 +190,12 @@ func (e *Error) ErrorMessage() string {
 	var b strings.Builder
 	b.WriteString(e.Message)
 
-	var next error = e.underlying
+	next := e.underlying
 	for next != nil {
 		var msg string
-		var ee *Error
-		if errors.As(next, &ee) {
-			msg = ee.Message
-			next = ee.underlying
+		if e, ok := next.(*Error); ok {
+			msg = e.Message
+			next = e.underlying
 		} else {
 			msg = next.Error()
 			next = nil

--- a/runtimes/go/beta/errs/error.go
+++ b/runtimes/go/beta/errs/error.go
@@ -113,7 +113,21 @@ func Convert(err error) error {
 
 	var e *Error
 	if errors.As(err, &e) {
-		return e
+		if directErr, ok := err.(*Error); ok {
+			// If the parent is already an *Error, return it directly
+			return directErr
+		}
+
+		// The error itself isn't an *Error, but it wraps one somewhere in the chain
+		// Create a new *Error that preserves the outer error but takes properties from inner *Error
+		return &Error{
+			Code:       e.Code,
+			Message:    err.Error(),
+			Details:    e.Details,
+			Meta:       e.Meta,
+			underlying: err,
+			stack:      e.stack,
+		}
 	}
 
 	return &Error{


### PR DESCRIPTION
I'd like to be able to embed the `errs.Error` struct without losing the error metadata when the handlers in `errs` are used. Currently, if I try to use an error struct with an embedded `*errs.Error` struct, the type assertions fail and the error metadata is lost. 

The use case is a bit niche, but if this change is controversial I can go into more details.