### PR TITLE
tsparser: duplicate api name error

### DIFF
--- a/tsparser/src/app/mod.rs
+++ b/tsparser/src/app/mod.rs
@@ -7,7 +7,6 @@ use swc_common::Span;
 use crate::encore::parser::meta::v1;
 use crate::legacymeta::compute_meta;
 use crate::parser::parser::{ParseContext, ParseResult};
-use crate::parser::resourceparser::bind::Bind;
 use crate::parser::resources::apis::api::{Endpoint, Method, Methods};
 use crate::parser::resources::Resource;
 use crate::parser::respath::Path;
@@ -94,19 +93,14 @@ impl AppValidator<'_> {
 
     fn validate_apis(&self) {
         let mut seen = std::collections::HashMap::new();
-        for bind in &self.parse.binds {
-            if let Bind {
-                resource: Resource::APIEndpoint(ep),
-                object: Some(object),
-                ..
-            } = bind.as_ref()
-            {
+        for resource in &self.parse.resources {
+            if let Resource::APIEndpoint(ep) = resource {
                 let key = (ep.service_name.clone(), ep.name.clone());
-                if let Some(prev) = seen.insert(key, object.range) {
+                if let Some(prev) = seen.insert(key, ep.name_range) {
                     HANDLER.with(|handler| {
                         handler
                             .struct_span_err(
-                                object.range,
+                                ep.name_range,
                                 "api endpoints with conflicting names defined within the same service",
                             )
                             .span_note(prev, "previously defined here")

--- a/tsparser/src/app/mod.rs
+++ b/tsparser/src/app/mod.rs
@@ -7,6 +7,7 @@ use swc_common::Span;
 use crate::encore::parser::meta::v1;
 use crate::legacymeta::compute_meta;
 use crate::parser::parser::{ParseContext, ParseResult};
+use crate::parser::resourceparser::bind::Bind;
 use crate::parser::resources::apis::api::{Endpoint, Method, Methods};
 use crate::parser::resources::Resource;
 use crate::parser::respath::Path;
@@ -92,6 +93,29 @@ impl AppValidator<'_> {
     }
 
     fn validate_apis(&self) {
+        let mut seen = std::collections::HashMap::new();
+        for bind in &self.parse.binds {
+            if let Bind {
+                resource: Resource::APIEndpoint(ep),
+                object: Some(object),
+                ..
+            } = bind.as_ref()
+            {
+                let key = (ep.service_name.clone(), ep.name.clone());
+                if let Some(prev) = seen.insert(key, object.range) {
+                    HANDLER.with(|handler| {
+                        handler
+                            .struct_span_err(
+                                object.range,
+                                "api endpoints with conflicting names defined within the same service",
+                            )
+                            .span_note(prev, "previously defined here")
+                            .emit();
+                    })
+                }
+            }
+        }
+
         for service in self.parse.services.iter() {
             let mut router = Router::new();
             for bind in &service.binds {

--- a/tsparser/src/parser/resources/apis/api.rs
+++ b/tsparser/src/parser/resources/apis/api.rs
@@ -31,6 +31,7 @@ use crate::span_err::ErrReporter;
 pub struct Endpoint {
     pub range: Range,
     pub name: String,
+    pub name_range: Range,
     pub service_name: String,
     pub doc: Option<String>,
     pub expose: bool,
@@ -365,6 +366,7 @@ pub const ENDPOINT_PARSER: ResourceParser = ResourceParser {
             let resource = Resource::APIEndpoint(Lrc::new(Endpoint {
                 range: r.range,
                 name: r.endpoint_name,
+                name_range: r.bind_name.span.into(),
                 service_name: service_name.clone(),
                 doc: r.doc_comment,
                 expose: cfg.expose.unwrap_or(false),

--- a/tsparser/src/parser/usageparser/mod.rs
+++ b/tsparser/src/parser/usageparser/mod.rs
@@ -533,6 +533,7 @@ export const Bar = 5;
                 range: Default::default(),
                 service_name: "svc".into(),
                 name: "Bar".into(),
+                name_range: Default::default(),
                 doc: None,
                 expose: true,
                 raw: false,
@@ -628,6 +629,7 @@ export const Bar = 5;
             let res = Resource::APIEndpoint(Lrc::new(Endpoint {
                 range: Default::default(),
                 name: "Bar".to_string(),
+                name_range: Default::default(),
                 service_name: "svc".to_string(),
                 doc: None,
                 expose: true,


### PR DESCRIPTION
emit error when two endpoints with the same name are defined within the same service

```
error: api endpoints with conflicting names defined within the same service
  --> /home/fredr/projects/encore-apps/ts-tags/other/otherfile.ts:3:14
   |
3  | export const get1 = api(
   |              ^^^^
   |
note: previously defined here
  --> /home/fredr/projects/encore-apps/ts-tags/other/other.ts:18:14
   |
18 | export const get1 = api(
   |              ^^^^

```