### PR TITLE
chore: update schema file from `schema.graphqls` to `schema.graphql` in graphql tutorial doc for consistency

### DIFF
--- a/docs/ts/tutorials/graphql.mdx
+++ b/docs/ts/tutorials/graphql.mdx
@@ -87,10 +87,10 @@ generates:
 
 Now it's time to define the GraphQL schema.
 
-🥐 Create a `schema.graphqls` file in the application root containing:
+🥐 Create a `schema.graphql` file in the application root containing:
 
 ```
--- schema.graphqls --
+-- schema.graphql --
 type Query {
   books: [Book]
 }


### PR DESCRIPTION
I spotted a minor typo while reviewing the GraphQL Tutorial documentation. Take a look: https://encore.dev/docs/ts/tutorials/graphql.