### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/runtimes/go/pubsub/internal/utils/utils.go
+++ b/runtimes/go/pubsub/internal/utils/utils.go
@@ -247,12 +247,6 @@ func WithDefaultValue[T comparable](setValue, defaultValue T) T {
 }
 
 // Clamp returns the value clamped to the range [min, max].
-func Clamp[T cmp.Ordered](d T, min T, max T) T {
-	if d < min {
-		return min
-	}
-	if d > max {
-		return max
-	}
-	return d
+func Clamp[T cmp.Ordered](d T, minVal T, maxVal T) T {
+	return max(min(d, maxVal), minVal)
 }


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.