### PR TITLE
fix correct accepts

### DIFF
--- a/runtimes/core/src/sqldb/val.rs
+++ b/runtimes/core/src/sqldb/val.rs
@@ -281,6 +281,7 @@ impl<'a> FromSql<'a> for RowValue {
     fn accepts(ty: &Type) -> bool {
         matches!(*ty, Type::BYTEA | Type::UUID)
             || matches!(ty.kind(), Kind::Array(ty) if <RowValue as FromSql>::accepts(ty))
+            || <PValue as FromSql>::accepts(ty)
     }
 }
 
@@ -384,7 +385,6 @@ impl<'a> FromSql<'a> for PValue {
                 | Type::TIME
         ) || matches!(ty.kind(), Kind::Enum(_))
             || matches!(ty.kind(), Kind::Array(ty) if <PValue as FromSql>::accepts(ty))
-            || <PValue as FromSql>::accepts(ty)
     }
 }
 


### PR DESCRIPTION
I accidentally remove the accepts on the wrong place in https://github.com/encoredev/encore/pull/1856

:facepalm: sorry

The PValue implenetation should not call the PValue implementation, but the RowValue should call the PValue implementation