### PR TITLE
fix/make RPC functions and parameters accessible in generated Go client

### DIFF
--- a/pkg/clientgen/golang.go
+++ b/pkg/clientgen/golang.go
@@ -356,7 +356,7 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service, tags c
 		}
 
 		interfaceMethods = append(interfaceMethods,
-			Id(strings.Title(rpc.Name)).Add(g.rpcParams(rpc)).Add(g.rpcReturnType(rpc, false)),
+			Id(idents.Convert(rpc.Name, idents.PascalCase)).Add(g.rpcParams(rpc)).Add(g.rpcReturnType(rpc, false)),
 		)
 	}
 	file.Type().Id(interfaceName).Interface(interfaceMethods...)
@@ -395,7 +395,7 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service, tags c
 
 		file.Func().
 			Params(Id("c").Op("*").Id(structName)).
-			Id(strings.Title(rpc.Name)).
+			Id(idents.Convert(rpc.Name, idents.PascalCase)).
 			Add(
 				g.rpcParams(rpc),
 				g.rpcReturnType(rpc, true),
@@ -906,7 +906,7 @@ func (g *golang) getType(typ *schema.Type) Code {
 			}
 
 			// The base field name and type
-			fieldTyp := Id(strings.Title(field.Name)).Add(g.getType(field.Typ))
+			fieldTyp := Id(idents.Convert(field.Name, idents.PascalCase)).Add(g.getType(field.Typ))
 
 			// Add the field tags
 			if field.RawTag != "" {
@@ -1075,7 +1075,7 @@ func (g *golang) generateAnonStructTypes(fields []*encoding.ParameterEncoding, e
 
 		types = append(
 			types,
-			Id(strings.Title(field.SrcName)).Add(g.getType(field.Type)).Tag(map[string]string{encodingTag: tagValue.String()}),
+			Id(idents.Convert(field.SrcName, idents.PascalCase)).Add(g.getType(field.Type)).Tag(map[string]string{encodingTag: tagValue.String()}),
 		)
 	}
 
@@ -1434,7 +1434,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					// If we have a slice, we need to encode each bit
 					slice, err := enc.ToStringSlice(
 						field.Type,
-						Id("authData").Dot(strings.Title(field.SrcName)),
+						Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 					)
 					if err != nil {
 						err = errors.Wrapf(err, "unable to encode query fields %s", field.SrcName)
@@ -1451,7 +1451,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					// Otherwise, we can just append the field
 					val, err := enc.ToString(
 						field.Type,
-						Id("authData").Dot(strings.Title(field.SrcName)),
+						Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 					)
 					if err != nil {
 						err = errors.Wrapf(err, "unable to encode query field %s", field.SrcName)
@@ -1477,7 +1477,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 				// Otherwise, we can just append the field
 				val, err := enc.ToString(
 					field.Type,
-					Id("authData").Dot(strings.Title(field.SrcName)),
+					Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 				)
 				if err != nil {
 					err = errors.Wrapf(err, "unable to encode header field %s", field.SrcName)

--- a/pkg/clientgen/golang.go
+++ b/pkg/clientgen/golang.go
@@ -356,7 +356,7 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service, tags c
 		}
 
 		interfaceMethods = append(interfaceMethods,
-			Id(rpc.Name).Add(g.rpcParams(rpc)).Add(g.rpcReturnType(rpc, false)),
+			Id(g.capitalizeFirstLetter(rpc.Name)).Add(g.rpcParams(rpc)).Add(g.rpcReturnType(rpc, false)),
 		)
 	}
 	file.Type().Id(interfaceName).Interface(interfaceMethods...)
@@ -395,7 +395,7 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service, tags c
 
 		file.Func().
 			Params(Id("c").Op("*").Id(structName)).
-			Id(rpc.Name).
+			Id(g.capitalizeFirstLetter(rpc.Name)).
 			Add(
 				g.rpcParams(rpc),
 				g.rpcReturnType(rpc, true),
@@ -1503,4 +1503,15 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 	grp.Line()
 
 	return
+}
+
+// capitalizeFirstLetter ensures the first letter of the string is capitalized
+// to make it exported in Go (and thus accessible)
+func (g *golang) capitalizeFirstLetter(name string) string {
+	if len(name) == 0 {
+		return name
+	}
+	first := string(name[0])
+	rest := name[1:]
+	return strings.ToUpper(first) + rest
 }

--- a/pkg/clientgen/golang.go
+++ b/pkg/clientgen/golang.go
@@ -906,7 +906,7 @@ func (g *golang) getType(typ *schema.Type) Code {
 			}
 
 			// The base field name and type
-			fieldTyp := Id(field.Name).Add(g.getType(field.Typ))
+			fieldTyp := Id(g.capitalizeFirstLetter(field.Name)).Add(g.getType(field.Typ))
 
 			// Add the field tags
 			if field.RawTag != "" {
@@ -1075,7 +1075,7 @@ func (g *golang) generateAnonStructTypes(fields []*encoding.ParameterEncoding, e
 
 		types = append(
 			types,
-			Id(field.SrcName).Add(g.getType(field.Type)).Tag(map[string]string{encodingTag: tagValue.String()}),
+			Id(g.capitalizeFirstLetter(field.SrcName)).Add(g.getType(field.Type)).Tag(map[string]string{encodingTag: tagValue.String()}),
 		)
 	}
 
@@ -1434,7 +1434,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					// If we have a slice, we need to encode each bit
 					slice, err := enc.ToStringSlice(
 						field.Type,
-						Id("authData").Dot(field.SrcName),
+						Id("authData").Dot(g.capitalizeFirstLetter(field.SrcName)),
 					)
 					if err != nil {
 						err = errors.Wrapf(err, "unable to encode query fields %s", field.SrcName)
@@ -1451,7 +1451,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					// Otherwise, we can just append the field
 					val, err := enc.ToString(
 						field.Type,
-						Id("authData").Dot(field.SrcName),
+						Id("authData").Dot(g.capitalizeFirstLetter(field.SrcName)),
 					)
 					if err != nil {
 						err = errors.Wrapf(err, "unable to encode query field %s", field.SrcName)
@@ -1477,7 +1477,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 				// Otherwise, we can just append the field
 				val, err := enc.ToString(
 					field.Type,
-					Id("authData").Dot(field.SrcName),
+					Id("authData").Dot(g.capitalizeFirstLetter(field.SrcName)),
 				)
 				if err != nil {
 					err = errors.Wrapf(err, "unable to encode header field %s", field.SrcName)
@@ -1505,13 +1505,13 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 	return
 }
 
-// capitalizeFirstLetter ensures the first letter of the string is capitalized
-// to make it exported in Go (and thus accessible)
-func (g *golang) capitalizeFirstLetter(name string) string {
-	if len(name) == 0 {
-		return name
+// capitalizeFirstLetterLetter ensures the first letter of a string is capitalized.
+// This is used to make the string exported in Go.
+func (g *golang) capitalizeFirstLetter(s string) string {
+	if len(s) == 0 {
+		return s
 	}
-	first := string(name[0])
-	rest := name[1:]
+	first := string(s[0])
+	rest := s[1:]
 	return strings.ToUpper(first) + rest
 }

--- a/pkg/clientgen/golang.go
+++ b/pkg/clientgen/golang.go
@@ -356,7 +356,7 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service, tags c
 		}
 
 		interfaceMethods = append(interfaceMethods,
-			Id(g.capitalizeFirstLetter(rpc.Name)).Add(g.rpcParams(rpc)).Add(g.rpcReturnType(rpc, false)),
+			Id(strings.Title(rpc.Name)).Add(g.rpcParams(rpc)).Add(g.rpcReturnType(rpc, false)),
 		)
 	}
 	file.Type().Id(interfaceName).Interface(interfaceMethods...)
@@ -395,7 +395,7 @@ func (g *golang) generateServiceClient(file *File, service *meta.Service, tags c
 
 		file.Func().
 			Params(Id("c").Op("*").Id(structName)).
-			Id(g.capitalizeFirstLetter(rpc.Name)).
+			Id(strings.Title(rpc.Name)).
 			Add(
 				g.rpcParams(rpc),
 				g.rpcReturnType(rpc, true),
@@ -906,7 +906,7 @@ func (g *golang) getType(typ *schema.Type) Code {
 			}
 
 			// The base field name and type
-			fieldTyp := Id(g.capitalizeFirstLetter(field.Name)).Add(g.getType(field.Typ))
+			fieldTyp := Id(strings.Title(field.Name)).Add(g.getType(field.Typ))
 
 			// Add the field tags
 			if field.RawTag != "" {
@@ -1075,7 +1075,7 @@ func (g *golang) generateAnonStructTypes(fields []*encoding.ParameterEncoding, e
 
 		types = append(
 			types,
-			Id(g.capitalizeFirstLetter(field.SrcName)).Add(g.getType(field.Type)).Tag(map[string]string{encodingTag: tagValue.String()}),
+			Id(strings.Title(field.SrcName)).Add(g.getType(field.Type)).Tag(map[string]string{encodingTag: tagValue.String()}),
 		)
 	}
 
@@ -1434,7 +1434,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					// If we have a slice, we need to encode each bit
 					slice, err := enc.ToStringSlice(
 						field.Type,
-						Id("authData").Dot(g.capitalizeFirstLetter(field.SrcName)),
+						Id("authData").Dot(strings.Title(field.SrcName)),
 					)
 					if err != nil {
 						err = errors.Wrapf(err, "unable to encode query fields %s", field.SrcName)
@@ -1451,7 +1451,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					// Otherwise, we can just append the field
 					val, err := enc.ToString(
 						field.Type,
-						Id("authData").Dot(g.capitalizeFirstLetter(field.SrcName)),
+						Id("authData").Dot(strings.Title(field.SrcName)),
 					)
 					if err != nil {
 						err = errors.Wrapf(err, "unable to encode query field %s", field.SrcName)
@@ -1477,7 +1477,7 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 				// Otherwise, we can just append the field
 				val, err := enc.ToString(
 					field.Type,
-					Id("authData").Dot(g.capitalizeFirstLetter(field.SrcName)),
+					Id("authData").Dot(strings.Title(field.SrcName)),
 				)
 				if err != nil {
 					err = errors.Wrapf(err, "unable to encode header field %s", field.SrcName)
@@ -1503,15 +1503,4 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 	grp.Line()
 
 	return
-}
-
-// capitalizeFirstLetterLetter ensures the first letter of a string is capitalized.
-// This is used to make the string exported in Go.
-func (g *golang) capitalizeFirstLetter(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-	first := string(s[0])
-	rest := s[1:]
-	return strings.ToUpper(first) + rest
 }

--- a/pkg/clientgen/testdata/tsapp/expected_golang.go
+++ b/pkg/clientgen/testdata/tsapp/expected_golang.go
@@ -116,10 +116,10 @@ type SvcRequest struct {
 // SvcClient Provides you access to call public and authenticated APIs on svc. The concrete implementation is svcClient.
 // It is setup as an interface allowing you to use GoMock to create mock implementations during tests.
 type SvcClient interface {
-	dummy(ctx context.Context, params SvcRequest) error
-	imported(ctx context.Context, params Common_StuffImportedRequest) (Common_StuffImportedResponse, error)
-	onlyPathParams(ctx context.Context, pathParam string, pathParam2 string) (Common_StuffImportedResponse, error)
-	root(ctx context.Context, params SvcRequest) error
+	Dummy(ctx context.Context, params SvcRequest) error
+	Imported(ctx context.Context, params Common_StuffImportedRequest) (Common_StuffImportedResponse, error)
+	OnlyPathParams(ctx context.Context, pathParam string, pathParam2 string) (Common_StuffImportedResponse, error)
+	Root(ctx context.Context, params SvcRequest) error
 }
 
 type svcClient struct {
@@ -128,7 +128,7 @@ type svcClient struct {
 
 var _ SvcClient = (*svcClient)(nil)
 
-func (c *svcClient) dummy(ctx context.Context, params SvcRequest) error {
+func (c *svcClient) Dummy(ctx context.Context, params SvcRequest) error {
 	// Convert our params into the objects we need for the request
 	reqEncoder := &serde{}
 
@@ -159,7 +159,7 @@ func (c *svcClient) dummy(ctx context.Context, params SvcRequest) error {
 	return err
 }
 
-func (c *svcClient) imported(ctx context.Context, params Common_StuffImportedRequest) (resp Common_StuffImportedResponse, err error) {
+func (c *svcClient) Imported(ctx context.Context, params Common_StuffImportedRequest) (resp Common_StuffImportedResponse, err error) {
 	// Now make the actual call to the API
 	_, err = callAPI(ctx, c.base, "POST", "/imported", nil, params, &resp)
 	if err != nil {
@@ -169,7 +169,7 @@ func (c *svcClient) imported(ctx context.Context, params Common_StuffImportedReq
 	return
 }
 
-func (c *svcClient) onlyPathParams(ctx context.Context, pathParam string, pathParam2 string) (resp Common_StuffImportedResponse, err error) {
+func (c *svcClient) OnlyPathParams(ctx context.Context, pathParam string, pathParam2 string) (resp Common_StuffImportedResponse, err error) {
 	// Now make the actual call to the API
 	_, err = callAPI(ctx, c.base, "POST", fmt.Sprintf("/path/%s/%s", url.PathEscape(pathParam), url.PathEscape(pathParam2)), nil, nil, &resp)
 	if err != nil {
@@ -179,7 +179,7 @@ func (c *svcClient) onlyPathParams(ctx context.Context, pathParam string, pathPa
 	return
 }
 
-func (c *svcClient) root(ctx context.Context, params SvcRequest) error {
+func (c *svcClient) Root(ctx context.Context, params SvcRequest) error {
 	// Convert our params into the objects we need for the request
 	reqEncoder := &serde{}
 

--- a/pkg/clientgen/testdata/tsapp/expected_golang.go
+++ b/pkg/clientgen/testdata/tsapp/expected_golang.go
@@ -91,26 +91,26 @@ func WithAuthFunc(authGenerator func(ctx context.Context) (SvcAuthParams, error)
 }
 
 type SvcAuthParams struct {
-	cookie string `encore:"optional" header:"Cookie,optional"`
-	token  string `encore:"optional" header:"x-api-token,optional"`
+	Cookie string `encore:"optional" header:"Cookie,optional"`
+	Token  string `encore:"optional" header:"x-api-token,optional"`
 }
 
 type SvcRequest struct {
-	foo       float64 `encore:"optional"` // Foo is good
-	baz       string  // Baz is better
-	queryFoo  bool    `encore:"optional" query:"foo,optional"`
-	queryBar  string  `encore:"optional" query:"bar,optional"`
-	headerBaz string  `encore:"optional" header:"baz,optional"`
-	headerNum float64 `encore:"optional" header:"num,optional"`
+	Foo       float64 `encore:"optional"` // Foo is good
+	Baz       string  // Baz is better
+	QueryFoo  bool    `encore:"optional" query:"foo,optional"`
+	QueryBar  string  `encore:"optional" query:"bar,optional"`
+	HeaderBaz string  `encore:"optional" header:"baz,optional"`
+	HeaderNum float64 `encore:"optional" header:"num,optional"`
 }
 
 type SvcRequest struct {
-	foo       float64 `encore:"optional"` // Foo is good
-	baz       string  // Baz is better
-	queryFoo  bool    `encore:"optional" query:"foo,optional"`
-	queryBar  string  `encore:"optional" query:"bar,optional"`
-	headerBaz string  `encore:"optional" header:"baz,optional"`
-	headerNum float64 `encore:"optional" header:"num,optional"`
+	Foo       float64 `encore:"optional"` // Foo is good
+	Baz       string  // Baz is better
+	QueryFoo  bool    `encore:"optional" query:"foo,optional"`
+	QueryBar  string  `encore:"optional" query:"bar,optional"`
+	HeaderBaz string  `encore:"optional" header:"baz,optional"`
+	HeaderNum float64 `encore:"optional" header:"num,optional"`
 }
 
 // SvcClient Provides you access to call public and authenticated APIs on svc. The concrete implementation is svcClient.
@@ -148,8 +148,8 @@ func (c *svcClient) Dummy(ctx context.Context, params SvcRequest) error {
 
 	// Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
 	body := struct {
-		foo float64 `json:"foo"`
-		baz string  `json:"baz"`
+		Foo float64 `json:"foo"`
+		Baz string  `json:"baz"`
 	}{
 		baz: params.baz,
 		foo: params.foo,
@@ -199,8 +199,8 @@ func (c *svcClient) Root(ctx context.Context, params SvcRequest) error {
 
 	// Construct the body with only the fields which we want encoded within the body (excluding query string or header fields)
 	body := struct {
-		foo float64 `json:"foo"`
-		baz string  `json:"baz"`
+		Foo float64 `json:"foo"`
+		Baz string  `json:"baz"`
 	}{
 		baz: params.baz,
 		foo: params.foo,
@@ -211,11 +211,11 @@ func (c *svcClient) Root(ctx context.Context, params SvcRequest) error {
 }
 
 type Common_StuffImportedRequest struct {
-	name string
+	Name string
 }
 
 type Common_StuffImportedResponse struct {
-	message string
+	Message string
 }
 
 // HTTPDoer is an interface which can be used to swap out the default
@@ -246,8 +246,8 @@ func (b *baseClient) Do(req *http.Request) (*http.Response, error) {
 			authEncoder := &serde{}
 
 			// Add the auth fields to the headers
-			req.Header.Set("cookie", authEncoder.FromString(authData.cookie))
-			req.Header.Set("x-api-token", authEncoder.FromString(authData.token))
+			req.Header.Set("cookie", authEncoder.FromString(authData.Cookie))
+			req.Header.Set("x-api-token", authEncoder.FromString(authData.Token))
 
 			if authEncoder.LastError != nil {
 				return nil, fmt.Errorf("unable to marshal authentication data: %w", authEncoder.LastError)


### PR DESCRIPTION
# Changes
This PR addresses a problem with Go client generation from a Typescript API. Currently naming of RPC functions and parameters are taken straight from the Typescript codebase. This is a problem because in Typescript these typically start with lowercase characters, making them private and unaccessible in Go.

This PR fixes that by making sure that the first letter is always capitalized for:
- RPC function names
- RPC parameters

# Note for potential further improvement of client generation (Go -> Typescript)
Ideally client generation the other way around (from Go code to Typescript) would also follow Typescript naming conventions of using `camelCase`. Currently it just takes the casing from Go, which means it usually is `PascalCase`. 

I would be happy to submit a PR for this, but also realize this could have backwards compatibility issues so wanted to get your thoughts on the matter first.