### PR TITLE
fix(gen): better typing for optional types in typescript client

### DIFF
--- a/pkg/clientgen/testdata/goapp/expected_typescript.ts
+++ b/pkg/clientgen/testdata/goapp/expected_typescript.ts
@@ -223,7 +223,7 @@ export namespace svc {
     }
 
     export interface Recursive {
-        Optional?: Recursive
+        Optional?: Recursive | undefined | null
         Slice: Recursive[]
         Map: { [key: string]: Recursive }
     }
@@ -232,17 +232,17 @@ export namespace svc {
         /**
          * Foo is good
          */
-        Foo?: Foo
+        Foo?: Foo | undefined | null
 
         /**
          * Baz is better
          */
         boo: string
 
-        QueryFoo?: boolean
-        QueryBar?: string
-        HeaderBaz?: string
-        HeaderInt?: number
+        QueryFoo?: boolean | undefined | null
+        QueryBar?: string | undefined | null
+        HeaderBaz?: string | undefined | null
+        HeaderInt?: number | undefined | null
         /**
          * This is a multiline
          * comment on the raw message!

--- a/pkg/clientgen/testdata/goapp/input.go
+++ b/pkg/clientgen/testdata/goapp/input.go
@@ -33,6 +33,7 @@ type Request struct {
     Bar string `json:"-"`
     Baz string `json:"boo"`        // Baz is better
 
+
     QueryFoo bool    `query:"foo" encore:"optional"`
     QueryBar string  `query:"bar" encore:"optional"`
     HeaderBaz string `header:"baz" encore:"optional"`

--- a/pkg/clientgen/testdata/goapp/input.go
+++ b/pkg/clientgen/testdata/goapp/input.go
@@ -33,7 +33,6 @@ type Request struct {
     Bar string `json:"-"`
     Baz string `json:"boo"`        // Baz is better
 
-
     QueryFoo bool    `query:"foo" encore:"optional"`
     QueryBar string  `query:"bar" encore:"optional"`
     HeaderBaz string `header:"baz" encore:"optional"`

--- a/pkg/clientgen/testdata/tsapp/expected_typescript.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_typescript.ts
@@ -69,42 +69,42 @@ export interface ClientOptions {
 
 export namespace svc {
     export interface AuthParams {
-        cookie?: string
-        token?: string
+        cookie?: string | undefined | null
+        token?: string | undefined | null
     }
 
     export interface Request {
         /**
          * Foo is good
          */
-        foo?: number
+        foo?: number | undefined | null
 
         /**
          * Baz is better
          */
         baz: string
 
-        queryFoo?: boolean
-        queryBar?: string
-        headerBaz?: string
-        headerNum?: number
+        queryFoo?: boolean | undefined | null
+        queryBar?: string | undefined | null
+        headerBaz?: string | undefined | null
+        headerNum?: number | undefined | null
     }
 
     export interface Request {
         /**
          * Foo is good
          */
-        foo?: number
+        foo?: number | undefined | null
 
         /**
          * Baz is better
          */
         baz: string
 
-        queryFoo?: boolean
-        queryBar?: string
-        headerBaz?: string
-        headerNum?: number
+        queryFoo?: boolean | undefined | null
+        queryBar?: string | undefined | null
+        headerBaz?: string | undefined | null
+        headerNum?: number | undefined | null
     }
 
     export class ServiceClient {

--- a/pkg/clientgen/typescript.go
+++ b/pkg/clientgen/typescript.go
@@ -1744,11 +1744,15 @@ func (ts *typescript) writeTyp(ns string, typ *schema.Type, numIndents int) {
 			indent()
 			ts.WriteString(ts.QuoteIfRequired(ts.fieldNameInStruct(field)))
 
-			if field.Optional || ts.isRecursive(field.Typ) {
+			isOptional := field.Optional || ts.isRecursive(field.Typ)
+			if isOptional {
 				ts.WriteString("?")
 			}
 			ts.WriteString(": ")
 			ts.writeTyp(ns, field.Typ, numIndents+1)
+			if isOptional {
+				ts.WriteString(" | undefined | null")
+			}
 			ts.WriteString("\n")
 
 			// Add another empty line if we have a doc comment


### PR DESCRIPTION
This aims to solve the issue described in https://github.com/encoredev/encore/issues/1623.

It's still not a perfect solution. For example, it does not correctly handle that when `omitempty` is present, it is never null, and when `omitempty` is NOT present, it is never undefined when returned from the JSON marshaller. 

I don't know if this opens for any other issues, so let me know if it needs some rework!