### PR TITLE
runtimes/{js,core}: add call options to api calls

### DIFF
--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -120,7 +120,7 @@ impl ServiceRegistry {
         target: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<api::CallOpts>,
     ) -> impl Future<Output = APIResult<ResponsePayload>> + 'static {
         let tracer = self.tracer.clone();
         let call = model::APICall { source, target };
@@ -131,7 +131,7 @@ impl ServiceRegistry {
             data,
             call.source.as_deref(),
             start_event_id,
-            opts,
+            opts.as_ref(),
         );
         async move {
             let result = fut.await;
@@ -147,7 +147,7 @@ impl ServiceRegistry {
         target: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<api::CallOpts>,
     ) -> impl Future<Output = APIResult<WebSocketClient>> + 'static {
         let tracer = self.tracer.clone();
         let call = model::APICall { source, target };
@@ -158,7 +158,7 @@ impl ServiceRegistry {
             data,
             call.source.as_deref(),
             start_event_id,
-            opts,
+            opts.as_ref(),
         );
 
         async move {
@@ -176,7 +176,7 @@ impl ServiceRegistry {
         data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<&api::CallOpts>,
     ) -> impl Future<Output = APIResult<ResponsePayload>> + 'static {
         let http_client = self.http_client.clone();
         let req = self.prepare_api_call_request(target, data, source, start_event_id, opts);
@@ -205,7 +205,7 @@ impl ServiceRegistry {
         mut data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<&api::CallOpts>,
     ) -> APIResult<(reqwest::Request, Arc<schema::Response>)> {
         let base_url = self
             .base_urls
@@ -295,7 +295,7 @@ impl ServiceRegistry {
         data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<&api::CallOpts>,
     ) -> impl Future<Output = APIResult<WebSocketClient>> + 'static {
         let req = self.prepare_stream_request(target, data, source, start_event_id, opts);
         async move {
@@ -315,7 +315,7 @@ impl ServiceRegistry {
         mut data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<&api::CallOpts>,
     ) -> APIResult<(
         http::Request<()>,
         Arc<schema::Request>,
@@ -406,7 +406,7 @@ impl ServiceRegistry {
         endpoint: &Endpoint,
         source: Option<&model::Request>,
         parent_event_id: Option<TraceEventId>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<&api::CallOpts>,
     ) -> anyhow::Result<()> {
         let svc_auth_method = self
             .service_auth_method(endpoint.name.service())

--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -120,12 +120,19 @@ impl ServiceRegistry {
         target: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> impl Future<Output = APIResult<ResponsePayload>> + 'static {
         let tracer = self.tracer.clone();
         let call = model::APICall { source, target };
         let start_event_id = tracer.rpc_call_start(&call);
 
-        let fut = self.do_api_call(&call.target, data, call.source.as_deref(), start_event_id);
+        let fut = self.do_api_call(
+            &call.target,
+            data,
+            call.source.as_deref(),
+            start_event_id,
+            opts,
+        );
         async move {
             let result = fut.await;
             if let Some(start_event_id) = start_event_id {
@@ -140,13 +147,19 @@ impl ServiceRegistry {
         target: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> impl Future<Output = APIResult<WebSocketClient>> + 'static {
         let tracer = self.tracer.clone();
         let call = model::APICall { source, target };
         let start_event_id = tracer.rpc_call_start(&call);
 
-        let fut =
-            self.do_connect_stream(&call.target, data, call.source.as_deref(), start_event_id);
+        let fut = self.do_connect_stream(
+            &call.target,
+            data,
+            call.source.as_deref(),
+            start_event_id,
+            opts,
+        );
 
         async move {
             let result = fut.await;
@@ -163,9 +176,10 @@ impl ServiceRegistry {
         data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> impl Future<Output = APIResult<ResponsePayload>> + 'static {
         let http_client = self.http_client.clone();
-        let req = self.prepare_api_call_request(target, data, source, start_event_id);
+        let req = self.prepare_api_call_request(target, data, source, start_event_id, opts);
         async move {
             match req {
                 Ok((req, resp_schema)) => {
@@ -191,6 +205,7 @@ impl ServiceRegistry {
         mut data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> APIResult<(reqwest::Request, Arc<schema::Response>)> {
         let base_url = self
             .base_urls
@@ -266,7 +281,7 @@ impl ServiceRegistry {
 
         // Add call metadata.
         let headers = req.headers_mut();
-        self.propagate_call_meta(headers, &endpoint, source, start_event_id)
+        self.propagate_call_meta(headers, &endpoint, source, start_event_id, opts)
             .map_err(api::Error::internal)?;
 
         let resp_schema = endpoint.response.clone();
@@ -280,8 +295,9 @@ impl ServiceRegistry {
         data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> impl Future<Output = APIResult<WebSocketClient>> + 'static {
-        let req = self.prepare_stream_request(target, data, source, start_event_id);
+        let req = self.prepare_stream_request(target, data, source, start_event_id, opts);
         async move {
             match req {
                 Ok((req, outgoing, incoming)) => {
@@ -299,6 +315,7 @@ impl ServiceRegistry {
         mut data: JSONPayload,
         source: Option<&model::Request>,
         start_event_id: Option<TraceEventId>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> APIResult<(
         http::Request<()>,
         Arc<schema::Request>,
@@ -375,7 +392,7 @@ impl ServiceRegistry {
             }
         }
 
-        self.propagate_call_meta(req.headers_mut(), endpoint, source, start_event_id)
+        self.propagate_call_meta(req.headers_mut(), endpoint, source, start_event_id, opts)
             .map_err(api::Error::internal)?;
 
         let outgoing = endpoint.request[0].clone();
@@ -389,6 +406,7 @@ impl ServiceRegistry {
         endpoint: &Endpoint,
         source: Option<&model::Request>,
         parent_event_id: Option<TraceEventId>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> anyhow::Result<()> {
         let svc_auth_method = self
             .service_auth_method(endpoint.name.service())
@@ -425,6 +443,30 @@ impl ServiceRegistry {
             },
         };
 
+        let auth_data = opts.as_ref().and_then(|o| o.auth_data.clone()).or_else(|| {
+            source
+                .and_then(|r| match &r.data {
+                    model::RequestData::RPC(data) => data.auth_data.as_ref(),
+                    model::RequestData::Stream(data) => data.auth_data.as_ref(),
+                    model::RequestData::Auth(_) => None,
+                    model::RequestData::PubSub(_) => None,
+                })
+                .cloned()
+        });
+
+        let auth_user_id = opts
+            .as_ref()
+            .and_then(|o| o.auth_user_id.as_ref())
+            .or_else(|| {
+                source.and_then(|r| match &r.data {
+                    model::RequestData::RPC(data) => data.auth_user_id.as_ref(),
+                    model::RequestData::Stream(data) => data.auth_user_id.as_ref(),
+                    model::RequestData::Auth(_) => None,
+                    model::RequestData::PubSub(_) => None,
+                })
+            })
+            .map(|id| Cow::Borrowed(id.as_str()));
+
         let desc = CallDesc {
             caller: &caller,
             svc_auth_method: svc_auth_method.as_ref(),
@@ -435,21 +477,8 @@ impl ServiceRegistry {
                     .as_ref()
                     .map(|id| Cow::Borrowed(id.as_str()))
             }),
-            auth_user_id: source.and_then(|r| {
-                match &r.data {
-                    model::RequestData::RPC(data) => data.auth_user_id.as_ref(),
-                    model::RequestData::Stream(data) => data.auth_user_id.as_ref(),
-                    model::RequestData::Auth(_) => None,
-                    model::RequestData::PubSub(_) => None,
-                }
-                .map(|id| Cow::Borrowed(id.as_str()))
-            }),
-            auth_data: source.and_then(|r| match &r.data {
-                model::RequestData::RPC(data) => data.auth_data.as_ref(),
-                model::RequestData::Stream(data) => data.auth_data.as_ref(),
-                model::RequestData::Auth(_) => None,
-                model::RequestData::PubSub(_) => None,
-            }),
+            auth_user_id,
+            auth_data,
         };
 
         desc.add_meta(headers)?;

--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -443,20 +443,19 @@ impl ServiceRegistry {
             },
         };
 
-        let auth_data = opts.as_ref().and_then(|o| o.auth_data.clone()).or_else(|| {
-            source
-                .and_then(|r| match &r.data {
-                    model::RequestData::RPC(data) => data.auth_data.as_ref(),
-                    model::RequestData::Stream(data) => data.auth_data.as_ref(),
-                    model::RequestData::Auth(_) => None,
-                    model::RequestData::PubSub(_) => None,
-                })
-                .cloned()
+        let auth_opts = opts.as_ref().and_then(|o| o.auth.as_ref());
+
+        let auth_data = auth_opts.map(|o| &o.data).or_else(|| {
+            source.and_then(|r| match &r.data {
+                model::RequestData::RPC(data) => data.auth_data.as_ref(),
+                model::RequestData::Stream(data) => data.auth_data.as_ref(),
+                model::RequestData::Auth(_) => None,
+                model::RequestData::PubSub(_) => None,
+            })
         });
 
-        let auth_user_id = opts
-            .as_ref()
-            .and_then(|o| o.auth_user_id.as_ref())
+        let auth_user_id = auth_opts
+            .map(|o| &o.user_id)
             .or_else(|| {
                 source.and_then(|r| match &r.data {
                     model::RequestData::RPC(data) => data.auth_user_id.as_ref(),

--- a/runtimes/core/src/api/manager.rs
+++ b/runtimes/core/src/api/manager.rs
@@ -324,7 +324,7 @@ impl Manager {
         target: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
-        opts: Option<Arc<CallOpts>>,
+        opts: Option<CallOpts>,
     ) -> impl Future<Output = APIResult<ResponsePayload>> + 'static {
         self.service_registry.api_call(target, data, source, opts)
     }
@@ -334,7 +334,7 @@ impl Manager {
         endpoint_name: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
-        opts: Option<Arc<api::CallOpts>>,
+        opts: Option<api::CallOpts>,
     ) -> impl Future<Output = APIResult<WebSocketClient>> + 'static {
         self.service_registry
             .connect_stream(endpoint_name, data, source, opts)

--- a/runtimes/core/src/api/manager.rs
+++ b/runtimes/core/src/api/manager.rs
@@ -441,6 +441,11 @@ fn listen_addr() -> String {
 
 #[derive(Debug)]
 pub struct CallOpts {
-    pub auth_data: Option<PValues>,
-    pub auth_user_id: Option<String>,
+    pub auth: Option<AuthOpts>,
+}
+
+#[derive(Debug)]
+pub struct AuthOpts {
+    pub data: PValues,
+    pub user_id: String,
 }

--- a/runtimes/core/src/api/manager.rs
+++ b/runtimes/core/src/api/manager.rs
@@ -23,7 +23,7 @@ use crate::{api, model, pubsub, secrets, EncoreName, EndpointName, Hosted};
 
 use super::encore_routes::healthz;
 use super::websocket_client::WebSocketClient;
-use super::ResponsePayload;
+use super::{PValues, ResponsePayload};
 
 pub struct ManagerConfig<'a> {
     pub meta: &'a meta::Data,
@@ -324,8 +324,9 @@ impl Manager {
         target: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
+        opts: Option<Arc<CallOpts>>,
     ) -> impl Future<Output = APIResult<ResponsePayload>> + 'static {
-        self.service_registry.api_call(target, data, source)
+        self.service_registry.api_call(target, data, source, opts)
     }
 
     pub fn stream(
@@ -333,9 +334,10 @@ impl Manager {
         endpoint_name: EndpointName,
         data: JSONPayload,
         source: Option<Arc<model::Request>>,
+        opts: Option<Arc<api::CallOpts>>,
     ) -> impl Future<Output = APIResult<WebSocketClient>> + 'static {
         self.service_registry
-            .connect_stream(endpoint_name, data, source)
+            .connect_stream(endpoint_name, data, source, opts)
     }
 
     /// Starts serving the API.
@@ -435,4 +437,9 @@ fn listen_addr() -> String {
         return format!("0.0.0.0:{}", port);
     }
     "0.0.0.0:8080".to_string()
+}
+
+pub struct CallOpts {
+    pub auth_data: Option<PValues>,
+    pub auth_user_id: Option<String>,
 }

--- a/runtimes/core/src/api/manager.rs
+++ b/runtimes/core/src/api/manager.rs
@@ -439,6 +439,7 @@ fn listen_addr() -> String {
     "0.0.0.0:8080".to_string()
 }
 
+#[derive(Debug)]
 pub struct CallOpts {
     pub auth_data: Option<PValues>,
     pub auth_user_id: Option<String>,

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -7,7 +7,7 @@ import { RawRequest } from "./mod";
 import { InternalHandlerResponse } from "../internal/appinit/mod";
 import { IterableSocket, IterableStream, Sink } from "./stream";
 export { RawRequest, RawResponse } from "../internal/api/node_http";
-export { CallOpts } from "../internal/runtime/mod";
+export { type CallOpts } from "../internal/runtime/mod";
 
 export type Method =
   | "GET"

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -7,6 +7,7 @@ import { RawRequest } from "./mod";
 import { InternalHandlerResponse } from "../internal/appinit/mod";
 import { IterableSocket, IterableStream, Sink } from "./stream";
 export { RawRequest, RawResponse } from "../internal/api/node_http";
+export { CallOpts } from "../internal/runtime/mod";
 
 export type Method =
   | "GET"
@@ -26,14 +27,14 @@ export type Header<
 
 export type Query<
   TypeOrName extends
-  | string
-  | string[]
-  | number
-  | number[]
-  | boolean
-  | boolean[]
-  | Date
-  | Date[] = string,
+    | string
+    | string[]
+    | number
+    | number[]
+    | boolean
+    | boolean[]
+    | Date
+    | Date[] = string,
   Name extends string = ""
 > = TypeOrName extends string ? string : TypeOrName;
 
@@ -159,21 +160,21 @@ export interface StreamOut<Response> {
 
 export type StreamInOutHandlerFn<HandshakeData, Request, Response> =
   HandshakeData extends void
-  ? (stream: StreamInOut<Request, Response>) => Promise<void>
-  : (
-    data: HandshakeData,
-    stream: StreamInOut<Request, Response>
-  ) => Promise<void>;
+    ? (stream: StreamInOut<Request, Response>) => Promise<void>
+    : (
+        data: HandshakeData,
+        stream: StreamInOut<Request, Response>
+      ) => Promise<void>;
 
 export type StreamOutHandlerFn<HandshakeData, Response> =
   HandshakeData extends void
-  ? (stream: StreamOut<Response>) => Promise<void>
-  : (data: HandshakeData, stream: StreamOut<Response>) => Promise<void>;
+    ? (stream: StreamOut<Response>) => Promise<void>
+    : (data: HandshakeData, stream: StreamOut<Response>) => Promise<void>;
 
 export type StreamInHandlerFn<HandshakeData, Request, Response> =
   HandshakeData extends void
-  ? (stream: StreamIn<Request>) => Promise<Response>
-  : (data: HandshakeData, stream: StreamIn<Request>) => Promise<Response>;
+    ? (stream: StreamIn<Request>) => Promise<Response>
+    : (data: HandshakeData, stream: StreamIn<Request>) => Promise<Response>;
 
 export type StreamInOut<Request, Response> = StreamIn<Request> &
   StreamOut<Response>;

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -487,6 +487,16 @@ export function middleware(
   }
 }
 
+/**
+ * Options when making api calls.
+ *
+ * This interface will be extended with additional fields from
+ * app's generated code.
+ */
+export interface CallOpts {
+  /* authData?: AuthData */
+}
+
 export { APIError, ErrCode } from "./error";
 export { Gateway, type GatewayConfig } from "./gateway";
 export { IterableSocket, IterableStream, Sink } from "./stream";

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -7,7 +7,6 @@ import { RawRequest } from "./mod";
 import { InternalHandlerResponse } from "../internal/appinit/mod";
 import { IterableSocket, IterableStream, Sink } from "./stream";
 export { RawRequest, RawResponse } from "../internal/api/node_http";
-export { type CallOpts } from "../internal/runtime/mod";
 
 export type Method =
   | "GET"

--- a/runtimes/js/encore.dev/internal/api/mod.ts
+++ b/runtimes/js/encore.dev/internal/api/mod.ts
@@ -29,10 +29,11 @@ export async function apiCall(
 export async function streamInOut(
   service: string,
   endpoint: string,
-  data: any
+  data: any,
+  opts?: runtime.CallOpts
 ): Promise<any> {
   const source = getCurrentRequest();
-  const stream = await runtime.RT.stream(service, endpoint, data, source);
+  const stream = await runtime.RT.stream(service, endpoint, data, source, opts);
 
   return {
     async send(msg: any) {
@@ -59,10 +60,11 @@ export async function streamInOut(
 export async function streamIn(
   service: string,
   endpoint: string,
-  data: any
+  data: any,
+  opts?: runtime.CallOpts
 ): Promise<any> {
   const source = getCurrentRequest();
-  const stream = await runtime.RT.stream(service, endpoint, data, source);
+  const stream = await runtime.RT.stream(service, endpoint, data, source, opts);
   const response = new Promise(async (resolve, reject) => {
     try {
       resolve(await stream.recv());
@@ -87,10 +89,11 @@ export async function streamIn(
 export async function streamOut(
   service: string,
   endpoint: string,
-  data: any
+  data: any,
+  opts?: runtime.CallOpts
 ): Promise<any> {
   const source = getCurrentRequest();
-  const stream = await runtime.RT.stream(service, endpoint, data, source);
+  const stream = await runtime.RT.stream(service, endpoint, data, source, opts);
 
   return {
     async recv(): Promise<any> {

--- a/runtimes/js/encore.dev/internal/api/mod.ts
+++ b/runtimes/js/encore.dev/internal/api/mod.ts
@@ -5,10 +5,11 @@ import { APIError, ErrCode } from "../../api/error";
 export async function apiCall(
   service: string,
   endpoint: string,
-  data: any
+  data: any,
+  opts?: runtime.CallOpts
 ): Promise<any> {
   const source = getCurrentRequest();
-  const resp = await runtime.RT.apiCall(service, endpoint, data, source);
+  const resp = await runtime.RT.apiCall(service, endpoint, data, source, opts);
 
   // Convert any call error to our APIError type.
   // We do this here because NAPI doesn't have great support

--- a/runtimes/js/encore.dev/mod.ts
+++ b/runtimes/js/encore.dev/mod.ts
@@ -1,7 +1,3 @@
-declare global {
-  interface CallOpts {}
-}
-
 export { appMeta } from "./app_meta";
 export type {
   AppMeta,

--- a/runtimes/js/encore.dev/mod.ts
+++ b/runtimes/js/encore.dev/mod.ts
@@ -1,3 +1,7 @@
+declare global {
+  interface CallOpts {}
+}
+
 export { appMeta } from "./app_meta";
 export type {
   AppMeta,
@@ -5,7 +9,7 @@ export type {
   CloudProvider,
   DeployMeta,
   EnvironmentMeta,
-  EnvironmentType,
+  EnvironmentType
 } from "./app_meta";
 
 export { currentRequest } from "./req_meta";
@@ -15,5 +19,5 @@ export type {
   Method,
   PubSubMessageMeta,
   RequestMeta,
-  TraceData,
+  TraceData
 } from "./req_meta";

--- a/runtimes/js/src/pvalue.rs
+++ b/runtimes/js/src/pvalue.rs
@@ -43,9 +43,9 @@ pub fn pvalues_to_js(env: Env, val: &PValues) -> Result<JsUnknown> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PVal(pub PValue);
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PVals(pub PValues);
 
 impl ToNapiValue for PVal {

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -328,7 +328,7 @@ impl Runtime {
 }
 
 #[napi(object)]
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 /// CallOpts can be used to set options for API calls.
 pub struct CallOpts {
     pub auth_data: Option<PVals>,

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -329,6 +329,7 @@ impl Runtime {
 
 #[napi]
 #[derive(Clone, Default)]
+/// CallOpts can be used to set options for API calls.
 pub struct CallOpts {
     pub auth_data: Option<PVals>,
 }

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -208,7 +208,7 @@ impl Runtime {
         endpoint: String,
         payload: Option<JsUnknown>,
         source: Option<&Request>,
-        opts: Option<&CallOpts>,
+        opts: Option<CallOpts>,
     ) -> napi::Result<JsObject> {
         let payload = match payload {
             Some(payload) => parse_pvalues(payload)?,
@@ -238,7 +238,7 @@ impl Runtime {
         endpoint: EndpointName,
         payload: Option<PValues>,
         source: Option<&'a Request>,
-        opts: Option<&'a CallOpts>,
+        opts: Option<CallOpts>,
     ) -> impl Future<Output = api::APIResult<Option<PValues>>> + 'static {
         let source = source.map(|s| s.inner.clone());
         let opts = opts.map(|o| Arc::new(o.clone().into()));
@@ -267,7 +267,7 @@ impl Runtime {
         endpoint: String,
         payload: Option<JsUnknown>,
         source: Option<&Request>,
-        opts: Option<&CallOpts>,
+        opts: Option<CallOpts>,
     ) -> napi::Result<JsObject> {
         let payload = match payload {
             Some(payload) => parse_pvalues(payload)?,
@@ -327,26 +327,11 @@ impl Runtime {
     }
 }
 
-#[napi]
+#[napi(object)]
 #[derive(Clone, Default)]
 /// CallOpts can be used to set options for API calls.
 pub struct CallOpts {
     pub auth_data: Option<PVals>,
-}
-
-#[napi]
-impl CallOpts {
-    #[napi(constructor)]
-    pub fn new() -> CallOpts {
-        CallOpts::default()
-    }
-
-    #[napi]
-    pub fn with_auth_data(&self, data: PVals) -> CallOpts {
-        CallOpts {
-            auth_data: Some(data),
-        }
-    }
 }
 
 impl From<CallOpts> for api::CallOpts {

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -241,8 +241,10 @@ impl Runtime {
         opts: Option<CallOpts>,
     ) -> impl Future<Output = api::APIResult<Option<PValues>>> + 'static {
         let source = source.map(|s| s.inner.clone());
-        let opts = opts.map(|o| Arc::new(o.clone().into()));
-        let fut = self.runtime.api().call(endpoint, payload, source, opts);
+        let fut = self
+            .runtime
+            .api()
+            .call(endpoint, payload, source, opts.map(Into::into));
 
         async move {
             let data = fut.await?;
@@ -275,8 +277,10 @@ impl Runtime {
         };
         let endpoint = encore_runtime_core::EndpointName::new(service, endpoint);
         let source = source.map(|s| s.inner.clone());
-        let opts = opts.map(|o| Arc::new(o.clone().into()));
-        let fut = self.runtime.api().stream(endpoint, payload, source, opts);
+        let fut = self
+            .runtime
+            .api()
+            .stream(endpoint, payload, source, opts.map(Into::into));
 
         let fut = async move {
             fut.await.map_err(|e| {

--- a/tsparser/src/builder/codegen.rs
+++ b/tsparser/src/builder/codegen.rs
@@ -169,9 +169,16 @@ impl Builder<'_> {
                         .join(&svc_rel_path)
                         .join(rel_path);
 
+                    let has_params = if rpc.streaming_request || rpc.streaming_response {
+                        rpc.encoding.handshake.is_some()
+                    } else {
+                        !rpc.encoding.default_request_encoding().params.is_empty()
+                    };
+
                     endpoint_ctx.push(json!({
                         "name": rpc.name,
                         "raw": rpc.raw,
+                        "has_params": has_params,
                         "streaming_request": rpc.streaming_request,
                         "streaming_response": rpc.streaming_response,
                         "import_path": import_path,
@@ -270,9 +277,16 @@ impl Builder<'_> {
                         .join(rel_path)
                         .with_extension("js");
 
+                    let has_params = if rpc.streaming_request || rpc.streaming_response {
+                        rpc.encoding.handshake.is_some()
+                    } else {
+                        !rpc.encoding.default_request_encoding().params.is_empty()
+                    };
+
                     endpoint_ctx.push(json!({
                         "name": rpc.name,
                         "raw": rpc.raw,
+                        "has_params": has_params,
                         "streaming_request": rpc.streaming_request,
                         "streaming_response": rpc.streaming_response,
                         "import_path": import_path,
@@ -420,9 +434,16 @@ impl Builder<'_> {
                     let rel_path = get_svc_rel_path(&svc.root, rpc.range, true);
                     let import_path = Path::new("../../../../").join(&svc_rel_path).join(rel_path);
 
+                    let has_params = if rpc.streaming_request || rpc.streaming_response {
+                        rpc.encoding.handshake.is_some()
+                    } else {
+                        !rpc.encoding.default_request_encoding().params.is_empty()
+                    };
+
                     endpoint_ctx.push(json!({
                         "name": rpc.name,
                         "raw": rpc.raw,
+                        "has_params": has_params,
                         "streaming_request": rpc.streaming_request,
                         "streaming_response": rpc.streaming_response,
                         "service_name": svc.name,

--- a/tsparser/src/builder/templates/catalog/auth/auth_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/auth/auth_ts.handlebars
@@ -11,12 +11,6 @@ export function getAuthData(): AuthData | null {
     return _getAuthData()
 }
 
-declare global {
-  interface CallOpts {
-    authData?: AuthData;
-  }
-}
-
 {{else}}
 export type AuthData = null;
 
@@ -25,3 +19,9 @@ export function getAuthData(): AuthData | null {
     throw new Error("authData cannot be called when there are no auth handlers.")
 }
 {{/if}}
+declare module "encore.dev/api" {
+  interface CallOpts {
+    authData?: AuthData;
+  }
+}
+

--- a/tsparser/src/builder/templates/catalog/auth/auth_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/auth/auth_ts.handlebars
@@ -10,6 +10,13 @@ export type AuthData = {{#each auth_handlers }}{{#unless @first}}
 export function getAuthData(): AuthData | null {
     return _getAuthData()
 }
+
+declare global {
+  interface CallOpts {
+    authData?: AuthData;
+  }
+}
+
 {{else}}
 export type AuthData = null;
 

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
@@ -16,7 +16,7 @@ import { {{name}} as {{name}}_handler } from {{toJSON import_path}};
 {{/if}}
 {{/each}}
 
-type StreamHandshake<Type extends (...args: any[]) => any> = Parameters<Type> extends [infer H, any] ? H : void;
+type StreamHandshake<Type extends (...args: any[]) => any> = Parameters<Type> extends [infer H, any] ? H : never;
 
 type StreamRequest<Type> = Type extends
   | StreamInOutHandlerFn<any, infer Req, any>
@@ -43,7 +43,9 @@ type WithCallOpts<T extends (...args: any) => any> = (
 
 {{#if (and streaming_request streaming_response)}}
 export function {{name}}(
-  data: StreamHandshake<typeof {{name}}_handler>,
+  ...args: StreamHandshake<typeof {{name}}_handler> extends void
+    ? [opts?: CallOpts]
+    : [data: StreamHandshake<typeof {{name}}_handler>, opts?: CallOpts]
 ): Promise<
   StreamInOut<
     StreamResponse<typeof {{name}}_handler>,
@@ -53,7 +55,9 @@ export function {{name}}(
 {{else}}
 {{#if streaming_request}}
 export function {{name}}(
-  data: StreamHandshake<typeof {{name}}_handler>,
+  ...args: StreamHandshake<typeof {{name}}_handler> extends void
+    ? [opts?: CallOpts]
+    : [data: StreamHandshake<typeof {{name}}_handler>, opts?: CallOpts]
 ): Promise<
   StreamOutWithResponse<
     StreamRequest<typeof {{name}}_handler>,
@@ -63,7 +67,9 @@ export function {{name}}(
 {{/if}}
 {{#if streaming_response}}
 export function {{name}}(
-  data: StreamHandshake<typeof {{name}}_handler>,
+  ...args: StreamHandshake<typeof {{name}}_handler> extends void
+    ? [opts?: CallOpts]
+    : [data: StreamHandshake<typeof {{name}}_handler>, opts?: CallOpts]
 ): Promise<
   StreamIn<
     StreamResponse<typeof {{name}}_handler>
@@ -76,6 +82,7 @@ export function {{name}}(
 import { {{name}} as {{name}}_handler } from {{toJSON import_path}};
 declare const {{name}}: WithCallOpts<typeof {{name}}_handler>;
 export { {{name}} };
+
 {{/if}}
 {{/each}}
 

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
@@ -31,11 +31,6 @@ type StreamResponse<Type> = Type extends
   : never;
 
 {{/if}}
-import { AuthData } from "../../auth/auth.js";
-export interface CallOpts {
-  authData?: AuthData;
-}
-
 type Parameters<T> = T extends (...args: infer P) => unknown ? P : never;
 type WithCallOpts<T extends (...args: any) => any> = (
   ...args: [...Parameters<T>, CallOpts?]

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
@@ -1,3 +1,5 @@
+import { CallOpts } from "encore.dev/api";
+
 {{#if has_streams}}
 import {
   StreamInOutHandlerFn,
@@ -33,7 +35,7 @@ type StreamResponse<Type> = Type extends
 {{/if}}
 type Parameters<T> = T extends (...args: infer P) => unknown ? P : never;
 type WithCallOpts<T extends (...args: any) => any> = (
-  ...args: [...Parameters<T>, CallOpts?]
+  ...args: [...Parameters<T>, opts?: CallOpts]
 ) => ReturnType<T>;
 
 {{#each endpoints}}

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
@@ -31,6 +31,12 @@ type StreamResponse<Type> = Type extends
   : never;
 
 {{/if}}
+import { CallOpts } from "encore.dev/api";
+type Parameters<T> = T extends (...args: infer P) => unknown ? P : never;
+type WithCallOpts<T extends (...args: any) => any> = (
+  ...args: [...Parameters<T>, CallOpts?]
+) => ReturnType<T>;
+
 {{#each endpoints}}
 {{#if (or streaming_request streaming_response)~}}
 
@@ -66,7 +72,9 @@ export function {{name}}(
 {{/if}}
 
 {{~else}}
-export { {{name}} } from {{toJSON import_path}};
+import { {{name}} as {{name}}_handler } from {{toJSON import_path}};
+declare const {{name}}: WithCallOpts<typeof {{name}}_handler>;
+export { {{name}} };
 {{/if}}
 {{/each}}
 

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
@@ -31,7 +31,11 @@ type StreamResponse<Type> = Type extends
   : never;
 
 {{/if}}
-import { CallOpts } from "encore.dev/api";
+import { AuthData } from "../../auth/auth.js";
+export interface CallOpts {
+  authData?: AuthData;
+}
+
 type Parameters<T> = T extends (...args: infer P) => unknown ? P : never;
 type WithCallOpts<T extends (...args: any) => any> = (
   ...args: [...Parameters<T>, CallOpts?]

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_d_ts.handlebars
@@ -16,7 +16,7 @@ import { {{name}} as {{name}}_handler } from {{toJSON import_path}};
 {{/if}}
 {{/each}}
 
-type StreamHandshake<Type extends (...args: any[]) => any> = Parameters<Type> extends [infer H, any] ? H : never;
+type StreamHandshake<Type extends (...args: any[]) => any> = Parameters<Type> extends [infer H, any] ? H : void;
 
 type StreamRequest<Type> = Type extends
   | StreamInOutHandlerFn<any, infer Req, any>

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_js.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_js.handlebars
@@ -5,7 +5,12 @@ const TEST_ENDPOINTS = typeof ENCORE_DROP_TESTS === "undefined" && process.env.N
     : null;
 
 {{#each endpoints}}
+{{#if has_params}}
 export async function {{name}}(params, opts) {
+{{else}}
+export async function {{name}}(opts) {
+    const params = undefined;
+{{/if}}
     if (typeof ENCORE_DROP_TESTS === "undefined" && process.env.NODE_ENV === "test") {
         return TEST_ENDPOINTS.{{name}}(params, opts);
     }
@@ -24,5 +29,4 @@ export async function {{name}}(params, opts) {
     return apiCall("{{../name}}", "{{name}}", params, opts);
     {{/if}}
 }
-
 {{/each}}

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_js.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_js.handlebars
@@ -5,23 +5,23 @@ const TEST_ENDPOINTS = typeof ENCORE_DROP_TESTS === "undefined" && process.env.N
     : null;
 
 {{#each endpoints}}
-export async function {{name}}(params) {
+export async function {{name}}(params, opts) {
     if (typeof ENCORE_DROP_TESTS === "undefined" && process.env.NODE_ENV === "test") {
-        return TEST_ENDPOINTS.{{name}}(params);
+        return TEST_ENDPOINTS.{{name}}(params, opts);
     }
 
     {{#if (or streaming_request streaming_response)}}
     {{#if (and streaming_request streaming_response)}}
-    return streamInOut("{{../name}}", "{{name}}", params);
+    return streamInOut("{{../name}}", "{{name}}", params, opts);
     {{else}}
     {{#if streaming_request}}
-    return streamIn("{{../name}}", "{{name}}", params);
+    return streamIn("{{../name}}", "{{name}}", params, opts);
     {{else}}
-    return streamOut("{{../name}}", "{{name}}", params);
+    return streamOut("{{../name}}", "{{name}}", params, opts);
     {{/if}}
     {{/if}}
     {{else}}
-    return apiCall("{{../name}}", "{{name}}", params);
+    return apiCall("{{../name}}", "{{name}}", params, opts);
     {{/if}}
 }
 

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_testing_js.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_testing_js.handlebars
@@ -8,7 +8,7 @@ import * as {{encoreNameToIdent name}}_service from {{toJSON import_path}};
 {{/with}}
 
 {{#each endpoints}}
-export async function {{name}}(params) {
+export async function {{name}}(params, opts) {
     const handler = (await import({{toJSON (stripExt import_path)}})).{{name}};
     registerTestHandler({
         apiRoute: { service: "{{../name}}", name: "{{name}}", raw: {{toJSON raw}}, handler, streamingRequest: {{ streaming_request }}, streamingResponse: {{ streaming_response }} },
@@ -18,16 +18,16 @@ export async function {{name}}(params) {
 
     {{#if (or streaming_request streaming_response)}}
     {{#if (and streaming_request streaming_response)}}
-    return streamInOut("{{../name}}", "{{name}}", params);
+    return streamInOut("{{../name}}", "{{name}}", params, opts);
     {{else}}
     {{#if streaming_request}}
-    return streamIn("{{../name}}", "{{name}}", params);
+    return streamIn("{{../name}}", "{{name}}", params, opts);
     {{else}}
-    return streamOut("{{../name}}", "{{name}}", params);
+    return streamOut("{{../name}}", "{{name}}", params, opts);
     {{/if}}
     {{/if}}
     {{else}}
-    return apiCall("{{../name}}", "{{name}}", params);
+    return apiCall("{{../name}}", "{{name}}", params, opts);
     {{/if}}
 }
 


### PR DESCRIPTION
Adds call options for api calls that can be used to set options when calling apis. For now only adds a way of overriding auth data, mainly for, but not limited to, mocking when calling via ~encore/clients in tests.