### PR TITLE
feat(daemon): clarify warning when secrets are missing due to lack of app access

### DIFF
--- a/cli/daemon/run/proc_groups.go
+++ b/cli/daemon/run/proc_groups.go
@@ -361,7 +361,7 @@ func (pg *ProcGroup) Warnings() (rtn []warning) {
 	if missing := pg.ConfigGen.MissingSecrets(); len(missing) > 0 {
 		rtn = append(rtn, warning{
 			Title: "secrets not defined: " + strings.Join(missing, ", "),
-			Help:  "undefined secrets are left empty for local development only.\nsee https://encore.dev/docs/primitives/secrets for more information",
+			Help:  "undefined secrets are left empty for local development only, make sure you have access to the app.\nsee https://encore.dev/docs/primitives/secrets for more information",
 		})
 	}
 


### PR DESCRIPTION
Sometimes I see other co-workers struggling with this error, and it can be very frustrating if you have no idea about the origin of the problem which, in some cases, is simply because you're not currently logged into your Encore account with access to the app you're trying to run.

I'd like to suggest to the user to run `encore auth whoami`, but I've tried not to make the help message longer than it already is. With some luck, this could help other people find guidance when encountering this error.