### PR TITLE
runtimes/js: fix setting of multi-headers

### DIFF
--- a/runtimes/js/src/raw_api.rs
+++ b/runtimes/js/src/raw_api.rs
@@ -74,10 +74,8 @@ impl ResponseWriterState {
         match self {
             Self::Initial { mut resp, sender } => {
                 resp = resp.status(status);
-                for (k, v) in headers {
-                    if let Some(k) = k {
-                        resp = resp.header(k, v);
-                    }
+                for (k, v) in headers.iter() {
+                    resp = resp.header(k, v);
                 }
                 Ok(Self::Initial { resp, sender })
             }


### PR DESCRIPTION
subtle difference, 
```
for (k, v) in headers
```
yeilds each key only once, for multiple values it will be set to None the second time

```
for (k, v) in headers.iter()
```

yeilds the same key for each value (https://docs.rs/http/latest/http/header/struct.HeaderMap.html#method.iter)