### PR TITLE
ts middleware: do not mutate the middleware when constructing

### DIFF
--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -480,7 +480,9 @@ export function middleware(
     return a as Middleware;
   } else {
     const opts = a as MiddlewareOptions;
-    const mw = b as Middleware;
+    const mw: Middleware = (req: MiddlewareRequest, next: Next) => {
+      return b(req, next);
+    };
     mw.options = opts;
 
     return mw;

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -480,6 +480,7 @@ export function middleware(
     return a as Middleware;
   } else {
     const opts = a as MiddlewareOptions;
+    // Wrap the middleware function to prevent options from being mutated.
     const mw: Middleware = (req: MiddlewareRequest, next: Next) => {
       return b(req, next);
     };

--- a/runtimes/js/encore.dev/api/mod.ts
+++ b/runtimes/js/encore.dev/api/mod.ts
@@ -480,11 +480,12 @@ export function middleware(
     return a as Middleware;
   } else {
     const opts = a as MiddlewareOptions;
-    // Wrap the middleware function to prevent options from being mutated.
+    // Wrap the middleware function to delegate calls and preserve the original options.
+    // The options object is stored separately and made immutable to prevent accidental mutation.
     const mw: Middleware = (req: MiddlewareRequest, next: Next) => {
       return b(req, next);
     };
-    mw.options = opts;
+    mw.options = Object.freeze({ ...opts });
 
     return mw;
   }


### PR DESCRIPTION
when using the `middleware` helper, we need to make sure we don't mutate the passed middleware with options.

Currently if a middleware is used from two services, one service will override the other services middleware options. This should prevent that from happening.