### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/pkg/namealloc/namealloc_test.go
+++ b/pkg/namealloc/namealloc_test.go
@@ -2,6 +2,7 @@ package namealloc
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -27,12 +28,7 @@ func TestAlloc(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reserved := func(s string) bool {
-				for _, r := range tt.reserved {
-					if r == s {
-						return true
-					}
-				}
-				return false
+				return slices.Contains(tt.reserved, s)
 			}
 			a := &Allocator{Reserved: reserved}
 


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.