### PR TITLE
runtime/core: encode cookies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,6 +1169,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
 ]

--- a/runtimes/core/Cargo.toml
+++ b/runtimes/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 rttrace = []
 
 [dependencies]
-pingora = { version = "0.4", features = [ "lb", "openssl" ] }
+pingora = { version = "0.4", features = ["lb", "openssl"] }
 anyhow = "1.0.76"
 base64 = "0.21.5"
 gjson = "0.8.1"
@@ -31,7 +31,7 @@ tokio-postgres = { version = "0.7.10", features = [
 ] }
 tokio-util = "0.7.10"
 tokio-tungstenite = "0.21.0"
-futures-util = "0.3.30"
+futures-util = "0.3.31"
 rand = "0.8.5"
 env_logger = "0.10.1"
 google-cloud-pubsub = "0.22.1"
@@ -86,17 +86,35 @@ tower-http = { version = "0.5.2", features = ["fs"] }
 google-cloud-storage = "0.22.1"
 serde_path_to_error = "0.1.16"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing"], default-features = false }
+tracing-subscriber = { version = "0.3.18", features = [
+    "alloc",
+    "ansi",
+    "env-filter",
+    "fmt",
+    "matchers",
+    "nu-ansi-term",
+    "once_cell",
+    "regex",
+    "registry",
+    "sharded-slab",
+    "smallvec",
+    "std",
+    "thread_local",
+    "tracing",
+], default-features = false }
 thiserror = "1.0.64"
 async-stream = "0.3.6"
 md5 = "0.7.0"
 aws-sdk-s3 = "1.58.0"
-aws-smithy-types = { version = "1.2.8", features = ["byte-stream-poll-next", "rt-tokio"] }
+aws-smithy-types = { version = "1.2.8", features = [
+    "byte-stream-poll-next",
+    "rt-tokio",
+] }
 percent-encoding = "2.3.1"
 aws-credential-types = "1.2.1"
 regex = "1.11.1"
 email_address = "0.2.9"
-cookie = "0.18.1"
+cookie = { version = "0.18.1", features = ["percent-encode"] }
 
 [build-dependencies]
 prost-build = "0.12.3"

--- a/runtimes/core/src/api/auth/mod.rs
+++ b/runtimes/core/src/api/auth/mod.rs
@@ -172,7 +172,7 @@ impl Authenticator {
                 .get_all(COOKIE)
                 .iter()
                 .filter_map(|raw| raw.to_str().ok())
-                .flat_map(cookie::Cookie::split_parse)
+                .flat_map(cookie::Cookie::split_parse_encoded)
                 .flatten()
                 .for_each(|c| inbound_cookies.add_original(c.into_owned()));
 

--- a/runtimes/core/src/api/pvalue.rs
+++ b/runtimes/core/src/api/pvalue.rs
@@ -128,7 +128,7 @@ impl<'a> From<&'a Cookie> for cookie::Cookie<'a> {
 impl Display for Cookie {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let c: cookie::Cookie<'_> = self.into();
-        write!(f, "{}", c)
+        write!(f, "{}", c.encoded())
     }
 }
 

--- a/runtimes/core/src/api/schema/cookie.rs
+++ b/runtimes/core/src/api/schema/cookie.rs
@@ -21,7 +21,7 @@ impl Cookie {
         let mut jar = cookie::CookieJar::new();
         for raw in headers.get_all(axum::http::header::COOKIE.as_str()) {
             if let Ok(raw) = raw.to_str() {
-                for c in cookie::Cookie::split_parse(raw).flatten() {
+                for c in cookie::Cookie::split_parse_encoded(raw).flatten() {
                     jar.add_original(c.into_owned());
                 }
             }
@@ -61,7 +61,7 @@ impl Cookie {
             .get_all(COOKIE)
             .iter()
             .filter_map(|raw| raw.to_str().ok())
-            .flat_map(cookie::Cookie::split_parse)
+            .flat_map(cookie::Cookie::split_parse_encoded)
             .flatten()
             .for_each(|c| jar.add_original(c.into_owned()));
 
@@ -81,7 +81,7 @@ impl Cookie {
             .get_all(SET_COOKIE)
             .iter()
             .filter_map(|raw| raw.to_str().ok())
-            .flat_map(cookie::Cookie::parse)
+            .flat_map(cookie::Cookie::parse_encoded)
             .for_each(|c| jar.add_original(c.into_owned()));
 
         match self.schema.parse(jar) {


### PR DESCRIPTION
This adds percent encoding/decoding to cookies. With out it we cant use a lot of characters, like `;`. It seems to be common practice to encode cookies in cookie libs, e.g in universal-cookie etc.