### PR TITLE
runtimes/core/sqldb: add cidr and inet postgres types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cidr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1b64030216239a2e7c364b13cd96a2097ebf0dfe5025f2dedee14a23f2ab60"
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1581,7 @@ dependencies = [
  "bb8-postgres",
  "bytes",
  "chrono",
+ "cidr",
  "colored",
  "cookie",
  "duct",
@@ -2041,6 +2048,18 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -4050,10 +4069,10 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.6"
-source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches#eaf1bb1158e007b0ad873794a58284d5e172a1bd"
+version = "0.6.8"
+source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#828c13e00024309c10c5581d5876f92576b16f35"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -4061,19 +4080,20 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand 0.9.1",
  "sha2",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.6"
-source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches#eaf1bb1158e007b0ad873794a58284d5e172a1bd"
+version = "0.2.9"
+source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#828c13e00024309c10c5581d5876f92576b16f35"
 dependencies = [
  "array-init",
  "bytes",
  "chrono",
+ "cidr",
  "fallible-iterator",
  "geo-types",
  "postgres-protocol",
@@ -4288,6 +4308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radix_fmt"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,6 +4357,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4348,6 +4384,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4381,6 +4427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -6001,8 +6056,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.10"
-source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches#eaf1bb1158e007b0ad873794a58284d5e172a1bd"
+version = "0.7.13"
+source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#828c13e00024309c10c5581d5876f92576b16f35"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6018,7 +6073,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.9.1",
  "socket2",
  "tokio",
  "tokio-util",
@@ -6656,6 +6711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7022,6 +7086,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ insta.opt-level = 3
 lto = true
 
 [patch.crates-io]
-tokio-postgres = { git = "https://github.com/encoredev/rust-postgres", branch = "encore-patches" }
-postgres-protocol = { git = "https://github.com/encoredev/rust-postgres", branch = "encore-patches" }
+tokio-postgres = { git = "https://github.com/encoredev/rust-postgres", branch = "encore-patches-sync" }
+postgres-protocol = { git = "https://github.com/encoredev/rust-postgres", branch = "encore-patches-sync" }
 swc_ecma_parser = { git = "https://github.com/encoredev/swc", branch = "node-resolve-exports" }
 swc_ecma_ast = { git = "https://github.com/encoredev/swc", branch = "node-resolve-exports" }
 swc_ecma_transforms_base = { git = "https://github.com/encoredev/swc", branch = "node-resolve-exports" }

--- a/runtimes/core/Cargo.toml
+++ b/runtimes/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 rttrace = []
 
 [dependencies]
-pingora = { version = "0.4", features = [ "lb", "openssl" ] }
+pingora = { version = "0.4", features = ["lb", "openssl"] }
 anyhow = "1.0.76"
 base64 = "0.21.5"
 gjson = "0.8.1"
@@ -21,17 +21,19 @@ tokio-nsq = "0.14.0"
 xid = "1.0.3"
 log = { version = "0.4.20", features = ["kv_unstable", "kv_unstable_serde"] }
 bytes = { version = "1.5.0", features = [] }
-postgres-protocol = "0.6.6"
-tokio-postgres = { version = "0.7.10", features = [
+postgres-protocol = "0.6.8"
+tokio-postgres = { version = "0.7.13", features = [
     "array-impls",
     "with-serde_json-1",
     "with-geo-types-0_7",
     "with-uuid-1",
     "with-chrono-0_4",
+    "with-cidr-0_3",
 ] }
+cidr = "0.3.1"
 tokio-util = "0.7.10"
 tokio-tungstenite = "0.21.0"
-futures-util = "0.3.30"
+futures-util = "0.3.31"
 rand = "0.8.5"
 env_logger = "0.10.1"
 google-cloud-pubsub = "0.22.1"
@@ -86,12 +88,30 @@ tower-http = { version = "0.5.2", features = ["fs"] }
 google-cloud-storage = "0.22.1"
 serde_path_to_error = "0.1.16"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing"], default-features = false }
+tracing-subscriber = { version = "0.3.18", features = [
+    "alloc",
+    "ansi",
+    "env-filter",
+    "fmt",
+    "matchers",
+    "nu-ansi-term",
+    "once_cell",
+    "regex",
+    "registry",
+    "sharded-slab",
+    "smallvec",
+    "std",
+    "thread_local",
+    "tracing",
+], default-features = false }
 thiserror = "1.0.64"
 async-stream = "0.3.6"
 md5 = "0.7.0"
 aws-sdk-s3 = "1.58.0"
-aws-smithy-types = { version = "1.2.8", features = ["byte-stream-poll-next", "rt-tokio"] }
+aws-smithy-types = { version = "1.2.8", features = [
+    "byte-stream-poll-next",
+    "rt-tokio",
+] }
 percent-encoding = "2.3.1"
 aws-credential-types = "1.2.1"
 regex = "1.11.1"

--- a/runtimes/core/src/sqldb/val.rs
+++ b/runtimes/core/src/sqldb/val.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use bytes::{BufMut, BytesMut};
 use serde::Serialize;
-use std::error::Error;
+use std::{error::Error, str::FromStr};
 use tokio_postgres::types::{to_sql_checked, FromSql, IsNull, Kind, ToSql, Type};
 use uuid::Uuid;
 
@@ -12,6 +12,8 @@ pub enum RowValue {
     PVal(PValue),
     Bytes(Vec<u8>),
     Uuid(uuid::Uuid),
+    Inet(cidr::IpInet),
+    Cidr(cidr::IpCidr),
 }
 
 impl ToSql for RowValue {
@@ -26,14 +28,26 @@ impl ToSql for RowValue {
                 Type::TEXT | Type::VARCHAR => val.to_string().to_sql(ty, out),
                 _ => Err(format!("uuid not supported for column of type {}", ty).into()),
             },
+            Self::Cidr(val) => match *ty {
+                Type::CIDR => val.to_sql(ty, out),
+                Type::TEXT | Type::VARCHAR => val.to_string().to_sql(ty, out),
+                _ => Err(format!("cidr not supported for column of type {}", ty).into()),
+            },
+            Self::Inet(val) => match *ty {
+                Type::INET => val.to_sql(ty, out),
+                Type::TEXT | Type::VARCHAR => val.to_string().to_sql(ty, out),
+                _ => Err(format!("inet not supported for column of type {}", ty).into()),
+            },
 
             Self::PVal(val) => val.to_sql(ty, out),
         }
     }
 
     fn accepts(ty: &Type) -> bool {
-        matches!(*ty, Type::BYTEA | Type::UUID | Type::TEXT | Type::VARCHAR)
-            || matches!(ty.kind(), Kind::Array(ty) if <RowValue as ToSql>::accepts(ty))
+        matches!(
+            *ty,
+            Type::BYTEA | Type::UUID | Type::TEXT | Type::VARCHAR | Type::CIDR | Type::INET
+        ) || matches!(ty.kind(), Kind::Array(ty) if <RowValue as ToSql>::accepts(ty))
             || <PValue as ToSql>::accepts(ty)
     }
 
@@ -91,6 +105,14 @@ impl ToSql for PValue {
                     }
                     Type::UUID => {
                         let val = Uuid::parse_str(str).context("unable to parse uuid")?;
+                        val.to_sql(ty, out)
+                    }
+                    Type::CIDR => {
+                        let val = cidr::IpCidr::from_str(str).context("unable to parse cidr")?;
+                        val.to_sql(ty, out)
+                    }
+                    Type::INET => {
+                        let val = cidr::IpInet::from_str(str).context("unable to parse inet")?;
                         val.to_sql(ty, out)
                     }
                     _ => {
@@ -250,6 +272,8 @@ impl ToSql for PValue {
                 | Type::TIMESTAMPTZ
                 | Type::DATE
                 | Type::TIME
+                | Type::INET
+                | Type::CIDR
         ) || matches!(ty.kind(), Kind::Enum(_))
             || matches!(ty.kind(), Kind::Array(ty) if <PValue as ToSql>::accepts(ty))
     }
@@ -267,6 +291,14 @@ impl<'a> FromSql<'a> for RowValue {
                 let val: uuid::Uuid = FromSql::from_sql(ty, raw)?;
                 Self::Uuid(val)
             }
+            Type::CIDR => {
+                let val: cidr::IpCidr = FromSql::from_sql(ty, raw)?;
+                Self::Cidr(val)
+            }
+            Type::INET => {
+                let val: cidr::IpInet = FromSql::from_sql(ty, raw)?;
+                Self::Inet(val)
+            }
             _ => {
                 if <PValue as FromSql>::accepts(ty) {
                     Self::PVal(FromSql::from_sql(ty, raw)?)
@@ -282,7 +314,7 @@ impl<'a> FromSql<'a> for RowValue {
     }
 
     fn accepts(ty: &Type) -> bool {
-        matches!(*ty, Type::BYTEA | Type::UUID)
+        matches!(*ty, Type::BYTEA | Type::UUID | Type::CIDR | Type::INET)
             || matches!(ty.kind(), Kind::Array(ty) if <RowValue as FromSql>::accepts(ty))
             || <PValue as FromSql>::accepts(ty)
     }
@@ -349,6 +381,14 @@ impl<'a> FromSql<'a> for PValue {
                 let val: chrono::NaiveTime = FromSql::from_sql(ty, raw)?;
                 PValue::String(val.to_string())
             }
+            Type::CIDR => {
+                let val: cidr::IpCidr = FromSql::from_sql(ty, raw)?;
+                PValue::String(val.to_string())
+            }
+            Type::INET => {
+                let val: cidr::IpInet = FromSql::from_sql(ty, raw)?;
+                PValue::String(val.to_string())
+            }
 
             _ => {
                 if let Kind::Array(_) = ty.kind() {
@@ -386,6 +426,8 @@ impl<'a> FromSql<'a> for PValue {
                 | Type::TIMESTAMPTZ
                 | Type::DATE
                 | Type::TIME
+                | Type::CIDR
+                | Type::INET
         ) || matches!(ty.kind(), Kind::Enum(_))
             || matches!(ty.kind(), Kind::Array(ty) if <PValue as FromSql>::accepts(ty))
     }

--- a/runtimes/core/src/sqldb/val.rs
+++ b/runtimes/core/src/sqldb/val.rs
@@ -509,6 +509,52 @@ mod tests {
     }
 
     #[test]
+    fn test_rowvalue_to_sql_cidr() {
+        let cidr = cidr::IpCidr::new(std::net::Ipv4Addr::new(192, 168, 0, 0).into(), 16).unwrap();
+        let value = RowValue::Cidr(cidr);
+        let mut buf = BytesMut::new();
+        let result = value.to_sql(&Type::CIDR, &mut buf);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_rowvalue_from_sql_cidr() {
+        let cidr = cidr::IpCidr::new(std::net::Ipv4Addr::new(192, 168, 0, 0).into(), 16).unwrap();
+        let mut buf = BytesMut::new();
+        cidr.to_sql(&Type::CIDR, &mut buf).unwrap();
+        let result = RowValue::from_sql(&Type::CIDR, &buf);
+        assert!(result.is_ok());
+        if let RowValue::Cidr(val) = result.unwrap() {
+            assert_eq!(val, cidr);
+        } else {
+            panic!("Expected RowValue::Cidr");
+        }
+    }
+
+    #[test]
+    fn test_rowvalue_to_sql_inet() {
+        let inet = cidr::IpInet::new_host(std::net::Ipv4Addr::new(192, 168, 1, 1).into());
+        let value = RowValue::Inet(inet);
+        let mut buf = BytesMut::new();
+        let result = value.to_sql(&Type::INET, &mut buf);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_rowvalue_from_sql_inet() {
+        let inet = cidr::IpInet::new_host(std::net::Ipv4Addr::new(192, 168, 1, 1).into());
+        let mut buf = BytesMut::new();
+        inet.to_sql(&Type::INET, &mut buf).unwrap();
+        let result = RowValue::from_sql(&Type::INET, &buf);
+        assert!(result.is_ok());
+        if let RowValue::Inet(val) = result.unwrap() {
+            assert_eq!(val, inet);
+        } else {
+            panic!("Expected RowValue::Inet");
+        }
+    }
+
+    #[test]
     fn test_pvalue_from_sql_bool() {
         let raw = &[1]; // true
         let result = PValue::from_sql(&Type::BOOL, raw);

--- a/runtimes/js/src/sqldb.rs
+++ b/runtimes/js/src/sqldb.rs
@@ -214,6 +214,8 @@ impl Row {
                     env.create_arraybuffer_with_data(val)?.into_unknown()
                 }
                 sqldb::RowValue::Uuid(val) => env.create_string(&val.to_string())?.into_unknown(),
+                sqldb::RowValue::Cidr(val) => env.create_string(&val.to_string())?.into_unknown(),
+                sqldb::RowValue::Inet(val) => env.create_string(&val.to_string())?.into_unknown(),
             };
             map.insert(key, val);
         }


### PR DESCRIPTION
updates our rust-postgres patch branch to one that is rebased on latest master so we get the integration with the `cidr` crate.