### PR TITLE
tsparser: handle default type params

### DIFF
--- a/tsparser/src/legacymeta/schema.rs
+++ b/tsparser/src/legacymeta/schema.rs
@@ -131,11 +131,12 @@ impl BuilderCtx<'_, '_> {
             },
             Type::Class(_) => anyhow::bail!("class types are not yet supported in schemas"),
             Type::Named(tt) => {
+                let has_type_params = tt.obj.kind.type_params().count() > 0;
                 let state = self.builder.pc.type_checker.state();
                 if state.is_universe(tt.obj.module_id) {
                     let underlying = tt.underlying(state);
                     self.typ(&underlying)?
-                } else if !tt.type_arguments.is_empty() {
+                } else if has_type_params {
                     tracing::trace!(
                         "got named type with type arguments, resolving to underlying type"
                     );

--- a/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@generic.ts.snap
+++ b/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@generic.ts.snap
@@ -1,0 +1,448 @@
+---
+source: tsparser/src/parser/types/tests.rs
+expression: result
+input_file: tsparser/src/parser/types/testdata/generic.ts
+---
+{
+    "Interface": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 0,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "InterfaceDefault": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 0,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "InterfaceDefaultMulti": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 0,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "bar",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 1,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "baz",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 2,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "qux",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 3,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "quux",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 4,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "corge",
+                    ),
+                    optional: false,
+                    typ: Generic(
+                        TypeParam(
+                            TypeParam {
+                                idx: 5,
+                                constraint: None,
+                            },
+                        ),
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "X": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        String,
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "Y": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        String,
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "Z": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Boolean,
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "M1": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Object,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "bar",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Undefined,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "baz",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Null,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "qux",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        String,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "quux",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Number,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "corge",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Boolean,
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "M2": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Object,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "bar",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Undefined,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "baz",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Null,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "qux",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        BigInt,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "quux",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Number,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "corge",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Boolean,
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "M3": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Object,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "bar",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Undefined,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "baz",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Null,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "qux",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        BigInt,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "quux",
+                    ),
+                    optional: false,
+                    typ: Literal(
+                        Boolean(
+                            false,
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "corge",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Boolean,
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "M4": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Object,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "bar",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Undefined,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "baz",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        Null,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "qux",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        BigInt,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "quux",
+                    ),
+                    optional: false,
+                    typ: Literal(
+                        Boolean(
+                            false,
+                        ),
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "corge",
+                    ),
+                    optional: false,
+                    typ: Literal(
+                        String(
+                            "literal",
+                        ),
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+}

--- a/tsparser/src/parser/types/testdata/generic.ts
+++ b/tsparser/src/parser/types/testdata/generic.ts
@@ -1,0 +1,42 @@
+// Basic interface with generic param
+export interface Interface<T> {
+  foo: T;
+}
+
+// Basic interface with generic param with default type
+export interface InterfaceDefault<T = string> {
+  foo: T;
+}
+
+// Interface with multiple generic param with default type
+export interface InterfaceDefaultMulti<
+  A,
+  B,
+  C,
+  D = string,
+  E = number,
+  F = boolean
+> {
+  foo: A;
+  bar: B;
+  baz: C;
+  qux: D;
+  quux: E;
+  corge: F;
+}
+
+export type X = Interface<string>;
+export type Y = InterfaceDefault;
+export type Z = InterfaceDefault<boolean>;
+
+export type M1 = InterfaceDefaultMulti<object, undefined, null>;
+export type M2 = InterfaceDefaultMulti<object, undefined, null, bigint>;
+export type M3 = InterfaceDefaultMulti<object, undefined, null, bigint, false>;
+export type M4 = InterfaceDefaultMulti<
+  object,
+  undefined,
+  null,
+  bigint,
+  false,
+  "literal"
+>;


### PR DESCRIPTION
for req/res types like

```ts
export interface MyType<A, B = string> {
   field1: A;
   field2: B;
}
```