### PR TITLE
chore(ci): upgrade setup-node to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           path: encr.dev
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -48,7 +48,7 @@ jobs:
           path: encr.dev
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.