### PR TITLE
Remove redaction section from ts tracing docs

### DIFF
--- a/docs/ts/observability/tracing.md
+++ b/docs/ts/observability/tracing.md
@@ -29,11 +29,3 @@ Unlike other tracing solutions, Encore understands what each trace event is and 
 * API calls
 * Database queries
 * etc.
-
-## Redacting sensitive data
-
-Encore's tracing automatically captures request and response payloads to simplify debugging.
-
-For cases where this is undesirable, such as for passwords or personally identifiable information (PII), Encore supports redacting fields marked as containing sensitive data.
-
-See the documentation on [API Schemas](/docs/ts/primitives/defining-apis#sensitive-data) for more information.


### PR DESCRIPTION
It appears that there is no support for marking fields for redaction in ts yet.

The docs section looks like it was just copied from the `go` one, and is at the moment incorrect and created a false assumption.

This section of the docs can be restored when redaction support actually exists.