### PR TITLE
db proxy: better logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,17 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -2320,6 +2331,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3011,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3774,7 +3788,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ee62f28526d8d484621e77f8d6a1807f1bd07558a06ab5a204b4834d6be056"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "async-trait",
  "blake2",
  "bytes",
@@ -3809,7 +3823,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d123320b69bd06e897fc16bd1dde962a7b488c4d2ae825683fbca0198fad8669"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "async-trait",
  "brotli",
  "bytes",
@@ -3913,7 +3927,7 @@ dependencies = [
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.8.5",
+ "rand 0.4.6",
  "tokio",
 ]
 
@@ -3924,9 +3938,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb50f65f06c4b81ccb3edcceaa54bb9439608506b0b3b8c048798169a64aad8e"
 dependencies = [
  "arrayvec",
- "hashbrown 0.15.2",
+ "hashbrown 0.12.3",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.4.6",
 ]
 
 [[package]]
@@ -4070,7 +4084,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.8"
-source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#828c13e00024309c10c5581d5876f92576b16f35"
+source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#e71577eea1d14769a3021b6dd214448e3de3ffb6"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -4088,7 +4102,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.9"
-source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#828c13e00024309c10c5581d5876f92576b16f35"
+source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#e71577eea1d14769a3021b6dd214448e3de3ffb6"
 dependencies = [
  "array-init",
  "bytes",
@@ -5510,7 +5524,7 @@ name = "swc_cached"
 version = "0.3.18"
 source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#2b917407c2dca79a9dc327adcf6607f893decb2f"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "anyhow",
  "dashmap",
  "once_cell",
@@ -6057,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.13"
-source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#828c13e00024309c10c5581d5876f92576b16f35"
+source = "git+https://github.com/encoredev/rust-postgres?branch=encore-patches-sync#e71577eea1d14769a3021b6dd214448e3de3ffb6"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/runtimes/core/src/log/mod.rs
+++ b/runtimes/core/src/log/mod.rs
@@ -40,7 +40,7 @@ pub fn root() -> &'static Logger {
                     // Otherwise use ENCORE_RUNTIME_LOG to set the Encore runtime log level,
                     // which defaults
                     let level = std::env::var("ENCORE_RUNTIME_LOG").unwrap_or("debug".to_string());
-                    format!("encore_={level},pingora_core::listeners=warn,pingora_core::services::listening=warn")
+                    format!("encore_={level},pingora_core::listeners=warn,pingora_core::services::listening=warn,tokio_postgres::proxy={level},tokio_postgres::connect_proxy={level}")
                 });
                 env_logger::filter::Builder::new().parse(&level).build()
             };


### PR DESCRIPTION
Add more logging when db proxying fails. This is especially when using ORMs that bypasses our checks when calling through the runtime. Adds this: https://github.com/encoredev/rust-postgres/pull/2