### PR TITLE
fix: add CREATEROLE permissions in daemon AdminRole

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.24
 
 RUN apt-get update && apt-get install -y sudo
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \

--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -146,7 +146,7 @@ func (c *Cluster) setupRoles(ctx context.Context, st *ClusterStatus) (EncoreRole
 		case RoleAdmin:
 			// Grant admins the ability to create databases.
 			_, err := conn.Exec(ctx, `
-				ALTER USER `+sanitizedUsername+` CREATEDB
+				ALTER USER `+sanitizedUsername+` CREATEDB CREATEROLE
 			`)
 			if err != nil {
 				c.log.Error().Err(err).Str("role", role.Username).Msg("unable to grant CREATEDB")


### PR DESCRIPTION
## Problem

Migrations failing in the `local` environment/cloud due to insufficient default permissions for the `admin` role. 

## Changes

Add the postgreSQL `CREATEROLE` permission to the `AdminRole` (`encore-admin` locally).