### PR TITLE
build: update upload-artifact to v4

### DIFF
--- a/.github/workflows/release-2.yml
+++ b/.github/workflows/release-2.yml
@@ -30,31 +30,31 @@ jobs:
           go run ./pkg/encorebuild/cmd/make-release/ -dst "${{ github.workspace	}}/build" -v "${{ github.event.inputs.version }}" -publish-npm=true
 
       - name: Publish artifact (darwin_amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-darwin_amd64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-darwin_amd64.tar.gz
 
       - name: Publish artifact (darwin_arm64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-darwin_arm64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-darwin_arm64.tar.gz
 
       - name: Publish artifact (linux_amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-linux_amd64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-linux_amd64.tar.gz
 
       - name: Publish artifact (linux_arm64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-linux_arm64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-linux_arm64.tar.gz
 
       - name: Publish artifact (windows_amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-windows_amd64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-windows_amd64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: "Tar artifacts"
         run: tar -czvf encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz -C encr.dev/dist/${{ matrix.goos }}_${{ matrix.goarch }} .
       - name: Publish artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}
           path: encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz


### PR DESCRIPTION
Updated actions/upload-artifact to v4 for better performance and reliability. No functional changes to workflows. Release notes: https://github.com/actions/upload-artifact/releases