### PR TITLE
Fix CI step "Install encore-go"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install encore-go
         run: |
-          URL=$(curl -s https://api.github.com/repos/encoredev/go/releases/latest | grep "browser_download_url.*linux_x86-64.tar.gz" | cut -d : -f 2,3 | tr -d \")
+          URL=$(curl -s https://api.github.com/repos/encoredev/go/releases/latest | grep "browser_download_url.*linux_x86-64.tar.gz" | cut -d : -f 2,3 | tr -d \" | tr -d '[:space:]')
           curl --fail -L -o encore-go.tar.gz $URL && tar -C . -xzf ./encore-go.tar.gz
 
       - name: Install tsparser


### PR DESCRIPTION
We are getting failures on this step, see e.g https://github.com/encoredev/encore/actions/runs/16312896373/job/46081988889?pr=2007

When running the command locally, this solves the problem, but locally I get a slightly different error message:
```
curl: (3) URL rejected: Malformed input to a URL function
```

So might be a different problem