### PR TITLE
runtimes/go: make it possible to add respone headers from middleware

### DIFF
--- a/runtimes/go/appruntime/apisdk/api/auth.go
+++ b/runtimes/go/appruntime/apisdk/api/auth.go
@@ -137,7 +137,7 @@ func (s *Server) runAuthHandler(h Handler, c IncomingContext) (info model.AuthIn
 		if c.auth.UID == "" && requiresAuth {
 			// Unless there isn't some and we need it, in which case we error.
 			err := errs.B().Code(errs.Unauthenticated).Msg("no auth info provided").Err()
-			returnError(c, err, 0)
+			returnError(c, err, 0, nil)
 			return model.AuthInfo{}, false
 		}
 
@@ -152,7 +152,7 @@ func (s *Server) runAuthHandler(h Handler, c IncomingContext) (info model.AuthIn
 		if errs.Code(err) == errs.Unauthenticated && !requiresAuth {
 			return model.AuthInfo{}, true
 		} else {
-			returnError(c, err, 0)
+			returnError(c, err, 0, nil)
 			return model.AuthInfo{}, false
 		}
 	}

--- a/runtimes/go/appruntime/apisdk/api/auth_remote.go
+++ b/runtimes/go/appruntime/apisdk/api/auth_remote.go
@@ -132,7 +132,7 @@ func (s *Server) handleRemoteAuthCall(w http.ResponseWriter, req *http.Request, 
 	// Call the original auth handler
 	authInfo, err := s.authHandler.Authenticate(c)
 	if err != nil {
-		returnError(originalC, err, 0)
+		returnError(originalC, err, 0, nil)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (s *Server) handleRemoteAuthCall(w http.ResponseWriter, req *http.Request, 
 
 	// Write the auth info to the response
 	if err := authJSON.NewEncoder(w).Encode(authInfo.UserData); err != nil {
-		returnError(originalC, err, 0)
+		returnError(originalC, err, 0, nil)
 		return
 	}
 }

--- a/runtimes/go/appruntime/apisdk/api/handler.go
+++ b/runtimes/go/appruntime/apisdk/api/handler.go
@@ -138,14 +138,14 @@ func (d *Desc[Req, Resp]) Handle(c IncomingContext) {
 		targetAPI, _ := t.ReadMeta(calleeMetaName)
 
 		if targetAPI != fmt.Sprintf("%s.%s", d.Service, d.Endpoint) {
-			returnError(c, errs.B().Code(errs.PermissionDenied).Msg("internal call auth did not align with API").Err(), 0)
+			returnError(c, errs.B().Code(errs.PermissionDenied).Msg("internal call auth did not align with API").Err(), 0, nil)
 			return
 		}
 	}
 
 	reqData, beginErr := d.begin(c)
 	if beginErr != nil {
-		returnError(c, beginErr, 0)
+		returnError(c, beginErr, 0, nil)
 		return
 	}
 
@@ -156,12 +156,19 @@ func (d *Desc[Req, Resp]) Handle(c IncomingContext) {
 		// If the endpoint is raw it has already written its response;
 		// don't write another.
 		if !d.Raw {
-			returnError(c, resp.Err, resp.HTTPStatus)
+			returnError(c, resp.Err, resp.HTTPStatus, resp.Headers)
 		}
 		return
 	}
 
 	if !d.Raw {
+		// Apply any custom headers from middleware
+		for key, values := range resp.Headers {
+			for _, value := range values {
+				c.w.Header().Add(key, value)
+			}
+		}
+
 		c.w.Header().Set("Content-Type", "application/json")
 		c.w.Header().Set("X-Content-Type-Options", "nosniff")
 		resp.Err = d.EncodeResp(c.w, c.server.json, respData)
@@ -182,7 +189,16 @@ func (d *Desc[Req, Resp]) Handle(c IncomingContext) {
 //
 // If statusCodeToUse is 0, we will use the default status code for the error using
 // the [errs] package.
-func returnError(c IncomingContext, err error, statusCodeToUse int) {
+//
+// headers will be applied to the response if provided.
+func returnError(c IncomingContext, err error, statusCodeToUse int, headers http.Header) {
+	// Apply any custom headers from middleware
+	for key, values := range headers {
+		for _, value := range values {
+			c.w.Header().Add(key, value)
+		}
+	}
+
 	if c.callMeta.PrivateAPIAccess() {
 		// If this is an internal service to service call, we want to return the full error
 		// we'll add a header to the response to indicate that the error is a full error
@@ -293,14 +309,14 @@ func (d *Desc[Req, Resp]) handleIncoming(c IncomingContext, reqData Req) (resp *
 		}
 	}
 
-	respData, httpStatus, err := d.executeEndpoint(c.execContext, invokeHandler)
+	respData, httpStatus, err, headers := d.executeEndpoint(c.execContext, invokeHandler)
 
-	resp = newResp(respData, httpStatus, err, d.Raw, c.capturer, respCapturer, c.server.json)
+	resp = newRespWithHeaders(respData, httpStatus, err, headers, d.Raw, c.capturer, respCapturer, c.server.json)
 	return resp, respData
 }
 
 // executeEndpoint executes the given handler, running middleware in the process.
-func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(middleware.Request) middleware.Response) (resp Resp, httpStatus int, respErr error) {
+func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(middleware.Request) middleware.Response) (resp Resp, httpStatus int, respErr error, headers http.Header) {
 	var counter int
 	var nextFn middleware.Next
 
@@ -362,6 +378,7 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 			return middleware.Response{
 				Err:        errs.B().Code(errs.Internal).Msg("middleware called next() too many times").Err(),
 				HTTPStatus: 500,
+				Headers:    make(http.Header),
 			}
 		}
 	}
@@ -373,17 +390,17 @@ func (d *Desc[Req, Resp]) executeEndpoint(c execContext, invokeHandler func(midd
 	mwResp := nextFn(mwReq)
 
 	if mwResp.Err != nil {
-		return resp, mwResp.HTTPStatus, mwResp.Err
+		return resp, mwResp.HTTPStatus, mwResp.Err, mwResp.Headers
 	} else {
 		if resp, ok := mwResp.Payload.(Resp); ok || isVoid[Resp]() {
-			return resp, mwResp.HTTPStatus, mwResp.Err
+			return resp, mwResp.HTTPStatus, mwResp.Err, mwResp.Headers
 		}
 	}
 
 	return resp, 500, errs.B().Code(errs.Internal).Msgf(
 		"invalid middleware: cannot return payload of type %T for endpoint %s.%s (expected type %T)",
 		mwResp.Payload, d.Service, d.Endpoint, resp,
-	).Err()
+	).Err(), mwResp.Headers
 }
 
 // invokeHandlerNonRaw invokes the handler for a regular (non-raw) endpoint. If the endpoint is raw, it panics.
@@ -391,6 +408,10 @@ func (d *Desc[Req, Resp]) invokeHandlerNonRaw(mwReq middleware.Request, reqData 
 	if d.Raw {
 		panic("invokeHandlerNonRaw called on Raw endpoint")
 	}
+
+	// Initialize Headers
+	mwResp.Headers = make(http.Header)
+
 	handlerResp, handlerErr := handler(mwReq.Context(), reqData)
 	if handlerErr != nil {
 		mwResp.Err = errs.Convert(handlerErr)
@@ -411,6 +432,9 @@ func (d *Desc[Req, Resp]) invokeHandlerRaw(mwReq middleware.Request, c IncomingC
 	if !d.Raw {
 		panic("invokeHandlerRaw called on non-Raw endpoint")
 	}
+
+	// Initialize Headers
+	mwResp.Headers = make(http.Header)
 
 	// Middleware can override the context, so check if the context is different
 	// and if so change the request context.
@@ -564,9 +588,10 @@ func (d *Desc[Req, Resp]) mockedCall(c CallContext, mock reflectedAPIMethod[Req,
 		// If we want to run middleware, use the same code path as internalCall but switch out the handler
 		// to our mock.
 		if runMiddleware {
-			return d.executeEndpoint(ec, func(mwReq middleware.Request) (mwResp middleware.Response) {
+			resp, status, err, _ := d.executeEndpoint(ec, func(mwReq middleware.Request) (mwResp middleware.Response) {
 				return d.invokeHandlerNonRaw(mwReq, req, mock)
 			})
+			return resp, status, err
 		}
 
 		respData, err := mock(ec.ctx, req)
@@ -579,9 +604,10 @@ func (d *Desc[Req, Resp]) mockedCall(c CallContext, mock reflectedAPIMethod[Req,
 
 func (d *Desc[Req, Resp]) internalCall(c CallContext, req Req) (respData Resp, respErr error) {
 	return d.runCall(c, req, false, func(ec execContext, req Req) (Resp, int, error) {
-		return d.executeEndpoint(ec, func(mwReq middleware.Request) middleware.Response {
+		resp, status, err, _ := d.executeEndpoint(ec, func(mwReq middleware.Request) middleware.Response {
 			return d.invokeHandlerNonRaw(mwReq, req, d.AppHandler)
 		})
+		return resp, status, err
 	})
 }
 
@@ -896,9 +922,17 @@ func marshalParams[Resp any](json jsoniter.API, resp Resp) []byte {
 func newResp[Resp any](respData Resp, httpStatus int, err error, isRaw bool,
 	reqCapture *rawRequestBodyCapturer, respCapture *rawResponseCapturer, json jsoniter.API,
 ) *model.Response {
+	return newRespWithHeaders(respData, httpStatus, err, nil, isRaw, reqCapture, respCapture, json)
+}
+
+// newRespWithHeaders returns an *model.Response for a response with custom headers.
+func newRespWithHeaders[Resp any](respData Resp, httpStatus int, err error, headers http.Header, isRaw bool,
+	reqCapture *rawRequestBodyCapturer, respCapture *rawResponseCapturer, json jsoniter.API,
+) *model.Response {
 	resp := &model.Response{
 		HTTPStatus: httpStatus,
 		Err:        err,
+		Headers:    headers,
 	}
 
 	if isRaw {

--- a/runtimes/go/appruntime/apisdk/api/handler_test.go
+++ b/runtimes/go/appruntime/apisdk/api/handler_test.go
@@ -533,10 +533,10 @@ func TestMiddlewareHeaders(t *testing.T) {
 			resp := next(req)
 
 			// Set various types of headers
-			resp.Headers.Set("X-Custom-Header", "custom-value")
-			resp.Headers.Add("X-Multi-Header", "value1")
-			resp.Headers.Add("X-Multi-Header", "value2")
-			resp.Headers.Set("X-Middleware-Applied", "true")
+			resp.Header().Set("X-Custom-Header", "custom-value")
+			resp.Header().Add("X-Multi-Header", "value1")
+			resp.Header().Add("X-Multi-Header", "value2")
+			resp.Header().Set("X-Middleware-Applied", "true")
 
 			return resp
 		},
@@ -622,8 +622,8 @@ func TestMiddlewareHeadersOnError(t *testing.T) {
 			resp := next(req)
 
 			// Set headers regardless of success/error
-			resp.Headers.Set("X-Error-Header", "error-value")
-			resp.Headers.Set("X-Always-Present", "always")
+			resp.Header().Set("X-Error-Header", "error-value")
+			resp.Header().Set("X-Always-Present", "always")
 
 			return resp
 		},

--- a/runtimes/go/appruntime/apisdk/api/handler_test.go
+++ b/runtimes/go/appruntime/apisdk/api/handler_test.go
@@ -30,6 +30,7 @@ import (
 	"encore.dev/appruntime/shared/traceprovider/mock_trace"
 	"encore.dev/beta/errs"
 	usermetrics "encore.dev/metrics"
+	"encore.dev/middleware"
 	"encore.dev/pubsub"
 )
 
@@ -512,5 +513,151 @@ func newRawMockAPIDesc(access api.Access, handler http.HandlerFunc) *api.Desc[*r
 		CloneResp: func(resp api.Void) (api.Void, error) {
 			return resp, nil
 		},
+	}
+}
+
+// TestMiddlewareHeaders tests that middleware can set headers and they are properly
+// written to the HTTP response.
+func TestMiddlewareHeaders(t *testing.T) {
+	model.EnableTestMode(t)
+
+	server, _, _ := testServer(t, clock.New(), false)
+
+	// Create a middleware that sets headers
+	headerMiddleware := &api.Middleware{
+		ID:      "test-middleware",
+		PkgName: "test",
+		Name:    "HeaderMiddleware",
+		Global:  false,
+		Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
+			resp := next(req)
+
+			// Set various types of headers
+			resp.Headers.Set("X-Custom-Header", "custom-value")
+			resp.Headers.Add("X-Multi-Header", "value1")
+			resp.Headers.Add("X-Multi-Header", "value2")
+			resp.Headers.Set("X-Middleware-Applied", "true")
+
+			return resp
+		},
+	}
+
+	// Create API desc with the middleware
+	desc := newMockAPIDesc(api.Public)
+	desc.ServiceMiddleware = []*api.Middleware{headerMiddleware}
+
+	tests := []struct {
+		name            string
+		expectSuccess   bool
+		expectedBody    string
+		expectedHeaders map[string][]string
+	}{
+		{
+			name:          "success_with_headers",
+			expectSuccess: true,
+			expectedBody:  `{"Message":"test"}`,
+			expectedHeaders: map[string][]string{
+				"X-Custom-Header":        {"custom-value"},
+				"X-Multi-Header":         {"value1", "value2"},
+				"X-Middleware-Applied":   {"true"},
+				"Content-Type":           {"application/json"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/path/hello", strings.NewReader(`{"Body":"test"}`))
+			req.Header.Set("Content-Type", "application/json")
+			ps := api.UnnamedParams{"hello"}
+
+			desc.Handle(server.NewIncomingContext(w, req, ps, api.CallMeta{}))
+
+			// Check status code
+			if test.expectSuccess && w.Code != 200 {
+				t.Errorf("expected success (200), got %d", w.Code)
+			}
+
+			// Check response body
+			if test.expectedBody != "" {
+				if got := w.Body.String(); got != test.expectedBody {
+					t.Errorf("got body %q, want %q", got, test.expectedBody)
+				}
+			}
+
+			// Check headers
+			for expectedHeader, expectedValues := range test.expectedHeaders {
+				gotValues := w.Header().Values(expectedHeader)
+				if len(gotValues) != len(expectedValues) {
+					t.Errorf("header %s: got %d values %v, want %d values %v",
+						expectedHeader, len(gotValues), gotValues, len(expectedValues), expectedValues)
+					continue
+				}
+				for i, expectedValue := range expectedValues {
+					if gotValues[i] != expectedValue {
+						t.Errorf("header %s[%d]: got %q, want %q",
+							expectedHeader, i, gotValues[i], expectedValue)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestMiddlewareHeadersOnError tests that middleware headers are applied even when an error occurs.
+func TestMiddlewareHeadersOnError(t *testing.T) {
+	model.EnableTestMode(t)
+
+	server, _, _ := testServer(t, clock.New(), false)
+
+	// Create a middleware that sets headers
+	headerMiddleware := &api.Middleware{
+		ID:      "test-middleware",
+		PkgName: "test",
+		Name:    "HeaderMiddleware",
+		Global:  false,
+		Invoke: func(req middleware.Request, next middleware.Next) middleware.Response {
+			resp := next(req)
+
+			// Set headers regardless of success/error
+			resp.Headers.Set("X-Error-Header", "error-value")
+			resp.Headers.Set("X-Always-Present", "always")
+
+			return resp
+		},
+	}
+
+	// Create API desc with the middleware that returns an error
+	desc := newMockAPIDesc(api.Public)
+	desc.ServiceMiddleware = []*api.Middleware{headerMiddleware}
+	desc.AppHandler = func(ctx context.Context, req *mockReq) (*mockResp, error) {
+		return nil, errs.B().Code(errs.Internal).Msg("test error").Err()
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/path/hello", strings.NewReader(`{"Body":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ps := api.UnnamedParams{"hello"}
+
+	desc.Handle(server.NewIncomingContext(w, req, ps, api.CallMeta{}))
+
+	// Check that error status is returned
+	if w.Code != 500 {
+		t.Errorf("expected error status 500, got %d", w.Code)
+	}
+
+	// Check that middleware headers are still applied
+	expectedHeaders := map[string]string{
+		"X-Error-Header":   "error-value",
+		"X-Always-Present": "always",
+	}
+
+	for expectedHeader, expectedValue := range expectedHeaders {
+		gotValue := w.Header().Get(expectedHeader)
+		if gotValue != expectedValue {
+			t.Errorf("header %s: got %q, want %q", expectedHeader, gotValue, expectedValue)
+		}
 	}
 }

--- a/runtimes/go/appruntime/exported/model/request.go
+++ b/runtimes/go/appruntime/exported/model/request.go
@@ -206,6 +206,10 @@ type Response struct {
 	// AuthUID is the resolved user id if this is an auth handler.
 	AuthUID UID
 
+	// Headers are HTTP headers to add to the response, set by middleware.
+	// For non-raw endpoints, these will be merged with the standard headers.
+	Headers http.Header
+
 	// RawRequestPayload contains the captured request payload, for raw requests.
 	// It is nil if nothing was captured.
 	RawRequestPayload           []byte

--- a/runtimes/go/middleware/middleware.go
+++ b/runtimes/go/middleware/middleware.go
@@ -7,6 +7,7 @@ package middleware
 
 import (
 	"context"
+	"net/http"
 
 	encore "encore.dev"
 )
@@ -92,6 +93,14 @@ type Response struct {
 	// For raw handlers middleware cannot modify this as it has already
 	// been written to the network.
 	HTTPStatus int
+
+	// Headers are HTTP headers to add to the response.
+	// These headers will be written to the HTTP response for both successful
+	// and error responses.
+	//
+	// For raw handlers middleware cannot modify this as the response has already
+	// been written to the network.
+	Headers http.Header
 }
 
 // NewRequest constructs a new Request that returns the given context and request data.

--- a/runtimes/go/middleware/middleware.go
+++ b/runtimes/go/middleware/middleware.go
@@ -94,13 +94,28 @@ type Response struct {
 	// been written to the network.
 	HTTPStatus int
 
-	// Headers are HTTP headers to add to the response.
-	// These headers will be written to the HTTP response for both successful
-	// and error responses.
-	//
-	// For raw handlers middleware cannot modify this as the response has already
-	// been written to the network.
-	Headers http.Header
+	// headers are HTTP headers to add to the response, lazily initialized.
+	// Use Header() method to access.
+	headers http.Header
+}
+
+// Header returns the header map that will be sent by the response.
+// The returned map is lazily initialized on first call.
+// Changing the header map after a call to WriteHeader has no effect.
+//
+// For raw handlers middleware cannot modify headers as the response has already
+// been written to the network.
+func (r *Response) Header() http.Header {
+	if r.headers == nil {
+		r.headers = make(http.Header)
+	}
+	return r.headers
+}
+
+// GetHeaders returns the headers map, or nil if no headers have been set.
+// This method is used internally by the Encore runtime.
+func (r *Response) GetHeaders() http.Header {
+	return r.headers
 }
 
 // NewRequest constructs a new Request that returns the given context and request data.


### PR DESCRIPTION
Adds an api like this:

```go
//encore:middleware target=all
func MyMiddleware(req middleware.Request, next middleware.Next) middleware.Response {
	resp := next(req)

	resp.Header().Set("X-Custom-Header", "custom-value")
	resp.Header().Add("X-Multi-Value", "value1")
	resp.Header().Add("X-Multi-Value", "value2")

	return resp
}

```