### PR TITLE
runtimes/go: fix custom http status on external service to service calls

### DIFF
--- a/runtimes/go/appruntime/apisdk/api/handler.go
+++ b/runtimes/go/appruntime/apisdk/api/handler.go
@@ -813,7 +813,7 @@ func (d *Desc[Req, Resp]) externalCall(c CallContext, service config.Service, re
 		}
 		defer func() { _ = httpResp.Body.Close() }()
 
-		if httpResp.StatusCode != http.StatusOK {
+		if httpResp.StatusCode >= 400 {
 			return resp, unmarshalErrorResponse(httpResp)
 		}
 

--- a/v2/codegen/apigen/endpointgen/response.go
+++ b/v2/codegen/apigen/endpointgen/response.go
@@ -172,6 +172,12 @@ func (d *responseDesc) DecodeExternalResp() *Statement {
 		enc := d.ep.ResponseEncoding()
 		dec := d.gu.NewTypeUnmarshaller("dec")
 		g.Add(dec.Init())
+
+		if enc.HTTPStatusField != "" {
+			g.Line().Comment("Set HTTP status field")
+			g.Id("resp").Dot(enc.HTTPStatusField).Op("=").Id("httpResp").Dot("StatusCode")
+		}
+
 		apigenutil.DecodeHeaders(g, Id("httpResp").Dot("Header"), Id("resp"), dec, enc.HeaderParameters)
 		apigenutil.DecodeBody(g, Id("httpResp").Dot("Body"), Id("resp"), dec, enc.BodyParameters)
 

--- a/v2/codegen/apigen/endpointgen/response.go
+++ b/v2/codegen/apigen/endpointgen/response.go
@@ -120,18 +120,18 @@ func (d *responseDesc) EncodeResponse() *Statement {
 		}
 
 		g.Line().Comment("Set HTTP status code")
-		if resp.HTTPStatusField != "" {
+		if resp.HTTPStatusParameter != nil {
 			g.Id("statusCode").Op(":=").Id("status")
 
 			var statusFieldCond *Statement
 			if schemautil.IsPointer(d.ep.Response) {
-				statusFieldCond = Id("resp").Op("!=").Nil().Op("&&").Id("resp").Dot(resp.HTTPStatusField).Op("!=").Lit(0)
+				statusFieldCond = Id("resp").Op("!=").Nil().Op("&&").Id("resp").Dot(resp.HTTPStatusParameter.SrcName).Op("!=").Lit(0)
 			} else {
-				statusFieldCond = Id("resp").Dot(resp.HTTPStatusField).Op("!=").Lit(0)
+				statusFieldCond = Id("resp").Dot(resp.HTTPStatusParameter.SrcName).Op("!=").Lit(0)
 			}
 
 			g.If(statusFieldCond).Block(
-				Id("statusCode").Op("=").Int().Call(Id("resp").Dot(resp.HTTPStatusField)),
+				Id("statusCode").Op("=").Int().Call(Id("resp").Dot(resp.HTTPStatusParameter.SrcName)),
 			)
 
 			g.If(Id("statusCode").Op("!=").Lit(0)).Block(
@@ -173,9 +173,10 @@ func (d *responseDesc) DecodeExternalResp() *Statement {
 		dec := d.gu.NewTypeUnmarshaller("dec")
 		g.Add(dec.Init())
 
-		if enc.HTTPStatusField != "" {
+		if enc.HTTPStatusParameter != nil {
 			g.Line().Comment("Set HTTP status field")
-			g.Id("resp").Dot(enc.HTTPStatusField).Op("=").Id("httpResp").Dot("StatusCode")
+			statusType := d.gu.Type(enc.HTTPStatusParameter.Type)
+			g.Id("resp").Dot(enc.HTTPStatusParameter.SrcName).Op("=").Add(statusType).Call(Id("httpResp").Dot("StatusCode"))
 		}
 
 		apigenutil.DecodeHeaders(g, Id("httpResp").Dot("Header"), Id("resp"), dec, enc.HeaderParameters)

--- a/v2/codegen/apigen/endpointgen/testdata/response_status.txt
+++ b/v2/codegen/apigen/endpointgen/testdata/response_status.txt
@@ -79,6 +79,9 @@ var EncoreInternal_api_APIDesc_Foo = &__api.Desc[*EncoreInternal_FooReq, EncoreI
 	DecodeExternalResp: func(httpResp *http.Response, json jsoniter.API) (resp EncoreInternal_FooResp, err error) {
 		resp = new(Params)
 		dec := new(__etype.Unmarshaller)
+
+		// Set HTTP status field
+		resp.Int = int(httpResp.StatusCode)
 		// Decode request body
 		payload := dec.ReadBody(httpResp.Body)
 		iter := jsoniter.ParseBytes(json, payload)

--- a/v2/internals/schema/schemautil/schemautil.go
+++ b/v2/internals/schema/schemautil/schemautil.go
@@ -186,7 +186,7 @@ func concretize(errs *perr.List, referencedFrom ast.Node, typ schema.Type, typeA
 		}
 	case schema.StructType:
 		result := schema.StructType{
-			AST:    nil,
+			AST:    typ.AST,
 			Fields: make([]schema.StructField, len(typ.Fields)),
 		}
 		for i, f := range typ.Fields {

--- a/v2/parser/apis/api/apienc/errors.go
+++ b/v2/parser/apis/api/apienc/errors.go
@@ -28,7 +28,7 @@ var (
 
 	errResponseTypeMustOnlyBeBodyOrHeaders = errRange.New(
 		"Invalid response type",
-		"API response type must only contain a body or headers parameters.",
+		"API response type must only contain a body, headers or status parameters.",
 	)
 
 	errRequestMustBeNamedStruct = errRange.New(


### PR DESCRIPTION
When hosting one process per service we failed the request as it wasn't 200, and we didnt decode the field into the struct 

Refactored the http status field code to be more similar to the rest of the parameter encoding fields, so that we can get the type in the code gen and cast the status to it