### PR TITLE
fix swc build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "ast_node"
 version = "0.9.5"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "better_scoped_tls"
 version = "0.1.1"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "scoped-tls",
 ]
@@ -1167,7 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1841,7 +1841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1937,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "from_variant"
 version = "0.1.6"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -3074,7 +3074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4369,7 +4369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -4389,7 +4389,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -4917,7 +4917,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "string_enum"
 version = "0.4.1"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5690,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "swc_atoms"
 version = "0.6.4"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "hstr",
  "once_cell",
@@ -5701,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "swc_cached"
 version = "0.3.18"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5714,7 +5714,7 @@ dependencies = [
 [[package]]
 name = "swc_common"
 version = "0.33.8"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "ast_node",
  "atty",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_ast"
 version = "0.110.9"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "bitflags 2.6.0",
  "is-macro",
@@ -5757,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_loader"
 version = "0.45.9"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_parser"
 version = "0.141.21"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -5796,7 +5796,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_transforms_base"
 version = "0.134.30"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.6.0",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_utils"
 version = "0.124.26"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -5835,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "swc_ecma_visit"
 version = "0.96.9"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -5848,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "swc_eq_ignore_macros"
 version = "0.1.2"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5859,7 +5859,7 @@ dependencies = [
 [[package]]
 name = "swc_macros_common"
 version = "0.3.8"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -5870,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "swc_visit"
 version = "0.5.7"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "swc_visit_macros"
 version = "0.5.8"
-source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#58b2ecd6e73a8616f2c6b45cbca0dd9252389e80"
+source = "git+https://github.com/encoredev/swc?branch=node-resolve-exports#3ccddcb7d70380b6952296717b2d9f2056f4c2ac"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -6019,7 +6019,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7087,7 +7087,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
cherry-picked https://github.com/swc-project/swc/pull/11094

fixes this error when building:
```
error[E0432]: unresolved import `serde::__private`
 --> /home/fredr/.cargo/git/checkouts/swc-804afb9566b98614/58b2ecd/crates/swc_common/src/private/mod.rs:3:9
  |
3 | pub use serde::__private as serde;
  |         ^^^^^^^---------^^^^^^^^^
  |         |      |
  |         |      help: a similar name exists in the module: `private`
  |         no `__private` in the root
  
```

https://github.com/encoredev/swc/commit/3ccddcb7d70380b6952296717b2d9f2056f4c2ac