### PR TITLE
runtime/js: type constructors fix

### DIFF
--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -103,12 +103,11 @@ impl Runtime {
             .get_or_init(|| Ok(Arc::new(init_runtime(false)?)))
             .clone()?;
 
-        if TYPE_CONSTRUCTORS.get().is_none() {
-            let refs = TypeConstructorRefs {
-                decimal: env.create_reference(options.type_constructors.decimal)?,
-            };
-            let _ = TYPE_CONSTRUCTORS.set(refs);
-        }
+        TYPE_CONSTRUCTORS.get_or_init(|| TypeConstructorRefs {
+            decimal: env
+                .create_reference(options.type_constructors.decimal)
+                .expect("couldn't create reference to Decimal"),
+        });
 
         Ok(Self { runtime })
     }


### PR DESCRIPTION
Dont create references if type constructors are already initialized