### PR TITLE
objects/s3: add force_path_style option and use path-style addressing when set (MinIO compatibility)

### DIFF
--- a/proto/encore/runtime/v1/infra.proto
+++ b/proto/encore/runtime/v1/infra.proto
@@ -332,6 +332,13 @@ message BucketCluster {
     // as opposed to resolving using AWS's default credential chain.
     optional string access_key_id = 3;
     optional SecretData secret_access_key = 4;
+
+    // If true, use path-style bucket addressing instead of virtual-hosted-style.
+    // When enabled, the bucket name will be placed in the request path
+    // (https://endpoint/bucket/key) instead of as a subdomain
+    // (https://bucket.endpoint/key). This is useful for S3-compatible providers
+    // like MinIO or local testing endpoints.
+    bool force_path_style = 5;
   }
 
   message GCS {

--- a/runtimes/core/src/infracfg.rs
+++ b/runtimes/core/src/infracfg.rs
@@ -50,6 +50,8 @@ pub struct S3 {
     pub endpoint: Option<String>,
     pub access_key_id: Option<String>,
     pub secret_access_key: Option<EnvString>,
+    #[serde(default)]
+    pub force_path_style: bool,
     pub buckets: HashMap<String, Bucket>,
 }
 
@@ -475,6 +477,7 @@ pub fn map_infra_to_runtime(infra: InfraConfig) -> RuntimeConfig {
                                 .secret_access_key
                                 .as_ref()
                                 .map(map_env_string_to_secret_data),
+                            force_path_style: s3.force_path_style,
                         },
                     )),
                     buckets: s3

--- a/runtimes/core/src/objects/s3/mod.rs
+++ b/runtimes/core/src/objects/s3/mod.rs
@@ -78,7 +78,12 @@ impl LazyS3Client {
                 }
 
                 let cfg = builder.load().await;
-                Arc::new(s3::Client::new(&cfg))
+                let mut s3conf = aws_sdk_s3::config::Builder::from(&cfg);
+                if self.cfg.force_path_style {
+                    s3conf = s3conf.force_path_style(true);
+                }
+                let s3client = s3::Client::from_conf(s3conf.build());
+                Arc::new(s3client)
             })
             .await
     }


### PR DESCRIPTION
Summary:
Add a force_path_style option to the S3 provider and use it to switch the AWS SDK to path-style bucket addressing. This enables compatibility with MinIO and other S3-compatible endpoints that don’t support virtual-hosted-style URLs.

Changes:

Proto: add BucketCluster.S3.force_path_style.
Infra mapping: accept force_path_style in JSON and pass it to runtime.
S3 client: enable AWS SDK path-style when force_path_style is true.
Why:

MinIO and some custom/local endpoints require path-style (https://endpoint/bucket/key) instead of virtual-hosted-style.
Usage:

Set force_path_style: true in your S3 provider config.
Example:
"force_path_style": true
Backwards compatibility:

Default is false; behavior unchanged unless enabled.