### PR TITLE
Update CONTRIBUTING.md to refer to the `encore` official binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ To do that, run `encore daemon env` and grab the value of `ENCORE_GOROOT`. For e
 export ENCORE_GOROOT=/opt/homebrew/Cellar/encore/0.16.2/libexec/encore-go
 ```
 
+Note: It is easiest to use the office `encore` binary.
+
 ### Running applications when building from source
 Once you've built your own `encore` binary and set the environment variables above, you're ready to go!
 


### PR DESCRIPTION
I found that it would be better to note that the users should use the official `encore` binary for building encore