### PR TITLE
feat(cache): add support for Redis MGET

### DIFF
--- a/runtimes/go/storage/cache/basic_test.go
+++ b/runtimes/go/storage/cache/basic_test.go
@@ -131,6 +131,30 @@ func TestFloatKeyspace(t *testing.T) {
 	}
 }
 
+func TestMultiGet(t *testing.T) {
+	kt := newStringTest(t)
+	ks, ctx := kt.ks, kt.ctx
+
+	// Set up test data
+	kt.Set("key1", "value1")
+	kt.Set("key2", "value2")
+
+	results := must(ks.MultiGet(ctx, "key1", "key2", "missing"))
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	if results[0].Err != nil || results[0].Value != "value1" {
+		t.Errorf("key1: got Err=%v, Value=%q, want Err=nil, Value=%q", results[0].Err, results[0].Value, "value1")
+	}
+	if results[1].Err != nil || results[1].Value != "value2" {
+		t.Errorf("key2: got Err=%v, Value=%q, want Err=nil, Value=%q", results[1].Err, results[1].Value, "value2")
+	}
+	if !errors.Is(results[2].Err, Miss) {
+		t.Errorf("missing: got Err=%v, want Miss", results[2].Err)
+	}
+}
+
 func newStringTest(t *testing.T) *stringTester {
 	cluster, srv := newTestCluster(t)
 	ks := NewStringKeyspace[string](cluster, KeyspaceConfig{

--- a/runtimes/go/storage/cache/cache.go
+++ b/runtimes/go/storage/cache/cache.go
@@ -135,6 +135,17 @@ var Miss = errors.New("cache miss")
 // It must be checked against with errors.Is.
 var KeyExists = errors.New("key already exists")
 
+// Result represents the result of a cache operation that may or may not have found a value.
+// If Err is nil, Value contains the cached value.
+// If Err matches Miss, the key was not found in the cache.
+// Otherwise Err contains the error that occurred.
+type Result[V any] struct {
+	// Value holds the cached value if Err is nil, otherwise the zero value.
+	Value V
+	// Err is nil on success, Miss if the key was not found, or another error.
+	Err error
+}
+
 // An WriteOption customizes the behavior of a single cache write operation.
 type WriteOption interface {
 	//publicapigen:keep

--- a/runtimes/go/storage/cache/struct.go
+++ b/runtimes/go/storage/cache/struct.go
@@ -49,6 +49,16 @@ func (s *StructKeyspace[K, V]) Get(ctx context.Context, key K) (V, error) {
 	return s.basicKeyspace.Get(ctx, key)
 }
 
+// MultiGet gets the values stored at multiple keys.
+// For each key, the result contains an Err field indicating success or failure.
+// If Err is nil, Value contains the cached value.
+// If Err matches Miss, the key was not found.
+//
+// See https://redis.io/commands/mget/ for more information.
+func (s *StructKeyspace[K, V]) MultiGet(ctx context.Context, keys ...K) ([]Result[V], error) {
+	return s.basicKeyspace.MultiGet(ctx, keys...)
+}
+
 // Set updates the value stored at key to val.
 //
 // See https://redis.io/commands/set/ for more information.


### PR DESCRIPTION
Tried to keep the change minimal:

* Follows existing precedent of using first key for errors (Delete)
* Result[V] type which propagates redis.Miss errors
