### PR TITLE
Fix ability to pass arguments to `vitest` when using `pnpm`

### DIFF
--- a/tsparser/src/builder/package_mgmt.rs
+++ b/tsparser/src/builder/package_mgmt.rs
@@ -360,9 +360,6 @@ impl PackageManager for PnpmPackageManager {
                 "pnpm".to_string(),
                 "run".to_string(),
                 "test".to_string(),
-                // Specify '--' so that additional arguments added from the test runner
-                // aren't interpreted by npm.
-                "--".to_string(),
             ],
             env: vec![],
             prioritized_files: vec![],


### PR DESCRIPTION
Removed unnecessary `--` argument from command. Unlike `npm`, `pnpm` passes `--` through down to `vitest`:

*NPM behavior:*

```bash
$ npm run test -- service/service.test.ts

> service@1.0.0 test
> vitest run service/service.test.ts
```

*PNPM behavior:*

```bash
$ pnpm test -- service/service.test.ts

> service@1.0.0 test
> vitest run -- service/service.test.ts
```

*Current Encore with PNPM behavior:*

```bash
$ encore test -- service/service.test.ts

> service@1.0.0 test
> vitest run -- -- service/service.test.ts
```

```bash
$ encore test service/service.test.ts

> service@1.0.0 test
> vitest run -- service/service.test.ts
```

*Encore with PNPM behavior with new changes:*

```bash
$ encore test service/service.test.ts

> service@1.0.0 test
> vitest run service/service.test.ts
```