### PR TITLE
Add config option to disable request logging

### DIFF
--- a/cli/daemon/run/runtime_config2.go
+++ b/cli/daemon/run/runtime_config2.go
@@ -155,8 +155,9 @@ func (g *RuntimeConfigGenerator) initialize() error {
 		}
 		for _, svc := range g.md.Svcs {
 			cfg := &runtimev1.HostedService{
-				Name:      svc.Name,
-				LogConfig: ptrOrNil(appFile.LogLevel),
+				Name:               svc.Name,
+				LogConfig:          ptrOrNil(appFile.LogLevel),
+				DisableRequestLogs: ptrOrNil(appFile.DisableRequestLogs),
 			}
 
 			if appFile.Build.WorkerPooling {

--- a/pkg/appfile/appfile.go
+++ b/pkg/appfile/appfile.go
@@ -64,6 +64,10 @@ type File struct {
 	// LogLevel is the minimum log level for the app.
 	// If empty it defaults to "trace".
 	LogLevel string `json:"log_level,omitempty"`
+
+	// DisableRequestLogs disables the "starting request" and "request completed"
+	// log messages that are emitted for each API request.
+	DisableRequestLogs bool `json:"disable_request_logs,omitempty"`
 }
 
 type Build struct {

--- a/pkg/rtconfgen/convert.go
+++ b/pkg/rtconfgen/convert.go
@@ -150,6 +150,14 @@ func (c *legacyConverter) Convert() (*config.Runtime, error) {
 			currLevel = zerolog.TraceLevel
 		}
 		cfg.LogConfig = currLevel.String()
+
+		// Check if any service has disabled request logs.
+		for _, svc := range deployment.HostedServices {
+			if svc.DisableRequestLogs != nil && *svc.DisableRequestLogs {
+				cfg.DisableRequestLogs = true
+				break
+			}
+		}
 	}
 
 	// Infrastructure handling.

--- a/proto/encore/runtime/v1/runtime.pb.go
+++ b/proto/encore/runtime/v1/runtime.pb.go
@@ -495,6 +495,8 @@ type HostedService struct {
 	// The log configuration to use for this service.
 	// If unset it defaults to "trace".
 	LogConfig *string `protobuf:"bytes,3,opt,name=log_config,json=logConfig,proto3,oneof" json:"log_config,omitempty"`
+	// Whether to disable request lifecycle logs ("starting request", "request completed").
+	DisableRequestLogs *bool `protobuf:"varint,4,opt,name=disable_request_logs,json=disableRequestLogs,proto3,oneof" json:"disable_request_logs,omitempty"`
 }
 
 func (x *HostedService) Reset() {
@@ -548,6 +550,13 @@ func (x *HostedService) GetLogConfig() string {
 		return *x.LogConfig
 	}
 	return ""
+}
+
+func (x *HostedService) GetDisableRequestLogs() bool {
+	if x != nil && x.DisableRequestLogs != nil {
+		return *x.DisableRequestLogs
+	}
+	return false
 }
 
 type ServiceAuth struct {

--- a/proto/encore/runtime/v1/runtime.proto
+++ b/proto/encore/runtime/v1/runtime.proto
@@ -92,6 +92,9 @@ message HostedService {
   // The log configuration to use for this service.
   // If unset it defaults to "trace".
   optional string log_config = 3;
+
+  // Whether to disable request lifecycle logs ("starting request", "request completed").
+  optional bool disable_request_logs = 4;
 }
 
 message ServiceAuth {

--- a/runtimes/go/appruntime/exported/config/config.go
+++ b/runtimes/go/appruntime/exported/config/config.go
@@ -92,6 +92,10 @@ type Runtime struct {
 	// Log configuration to set for the application.
 	// If empty it defaults to "trace".
 	LogConfig string `json:"log_config"`
+
+	// DisableRequestLogs disables the "starting request" and "request completed"
+	// log messages that are emitted for each API request.
+	DisableRequestLogs bool `json:"disable_request_logs,omitempty"`
 }
 
 // GracefulShutdownTimings defines the timings for the graceful shutdown process.

--- a/runtimes/go/appruntime/exported/config/infra/config.go
+++ b/runtimes/go/appruntime/exported/config/infra/config.go
@@ -25,6 +25,10 @@ type InfraConfig struct {
 	// If empty it defaults to "trace".
 	LogConfig string `json:"log_config,omitemty"`
 
+	// DisableRequestLogs disables the "starting request" and "request completed"
+	// log messages that are emitted for each API request.
+	DisableRequestLogs bool `json:"disable_request_logs,omitempty"`
+
 	// Number of worker threads to use for the application.
 	// If unset it defaults to a single worker thread.
 	// If set to 0 it defaults to the number of CPUs.

--- a/runtimes/go/appruntime/exported/config/parse.go
+++ b/runtimes/go/appruntime/exported/config/parse.go
@@ -154,6 +154,7 @@ func parseInfraConfigEnv(infraCfgPath string) *Runtime {
 	cfg.EnvCloud = infraCfg.Metadata.Cloud
 	cfg.APIBaseURL = infraCfg.Metadata.BaseURL
 	cfg.LogConfig = infraCfg.LogConfig
+	cfg.DisableRequestLogs = infraCfg.DisableRequestLogs
 
 	// Map graceful shutdown configuration
 	if infraCfg.GracefulShutdown != nil {


### PR DESCRIPTION
We are flooded by request logging requests when developing locally, it's impossible to find useful information between noisy log lines, and setting WARN level is not an option because our app emits mist of the logs on the INFO level. Let's add an option to disable request logging.

<img width="1662" height="300" alt="image" src="https://github.com/user-attachments/assets/dc87437a-adda-41a6-8e3c-abd42a67e6a1" />
