### PR TITLE
tsparser: add support for local export

### DIFF
--- a/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@reexport_local.txt.snap
+++ b/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@reexport_local.txt.snap
@@ -1,0 +1,31 @@
+---
+source: tsparser/src/parser/types/tests.rs
+expression: result
+input_file: tsparser/src/parser/types/testdata/reexport_local.txt
+---
+{
+    "MyType": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "field",
+                    ),
+                    optional: false,
+                    typ: Named(
+                        Named {
+                            obj: Object {
+                                name: Some(
+                                    "foo",
+                                ),
+                            },
+                            type_arguments: [],
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+}

--- a/tsparser/src/parser/types/testdata/reexport_local.txt
+++ b/tsparser/src/parser/types/testdata/reexport_local.txt
@@ -1,0 +1,11 @@
+import { foo } from "./foo";
+
+export interface MyType {
+    field: foo;
+}
+
+-- foo.ts --
+interface foo {
+  bar: string;
+}
+export { foo };


### PR DESCRIPTION
```
export type { MyType as YourType };

type MyType = {
   field: string; 
};
```