### PR TITLE
feat: set error for incorrect usage of Set-Cookie response header

### DIFF
--- a/v2/parser/apis/api/apienc/encoding.go
+++ b/v2/parser/apis/api/apienc/encoding.go
@@ -534,6 +534,16 @@ func describeParam(errs *perr.List, encodingHints *encodingHints, field schema.S
 		}
 	}
 
+	// Validate Set-Cookie array types
+	if location == Header && strings.ToLower(param.WireName) == "set-cookie" {
+		if kind, isList, ok := schemautil.IsBuiltinOrList(param.Type); ok {
+			if isList && kind != schema.String {
+				errs.Addf(field.Type.ASTExpr().Pos(), "Set-Cookie header arrays must be []string, got []%s", kind)
+				return nil, false
+			}
+		}
+	}
+
 	param.Location = location
 	return &param, true
 }


### PR DESCRIPTION
Follow up to my previous commit in #2111. 

Now that it []string is a valid cookie type, the framework should validate that only string types can be valid inputs.

<img width="863" height="263" alt="image" src="https://github.com/user-attachments/assets/74c35729-f377-486e-9284-bf383a6fa424" />
