### PR TITLE
clientgen: fix panic when generation openapi with named unions

### DIFF
--- a/pkg/clientgen/openapi/schema.go
+++ b/pkg/clientgen/openapi/schema.go
@@ -186,12 +186,13 @@ func (g *Generator) schemaType(typ *schema.Type) *openapi3.SchemaRef {
 		}
 
 		// Otherwise, we have to represent this as an anyOf schema.
-		schemas := make([]*openapi3.Schema, 0, len(t.Union.Types))
+		schemaRefs := make([]*openapi3.SchemaRef, 0, len(t.Union.Types))
 		for _, tt := range t.Union.Types {
-			schemas = append(schemas, g.schemaType(tt).Value)
+			schemaRefs = append(schemaRefs, g.schemaType(tt))
 		}
 
-		s := openapi3.NewAnyOfSchema(schemas...)
+		s := openapi3.NewSchema()
+		s.AnyOf = schemaRefs
 		s.Nullable = haveLiteralNull
 		return s.NewRef()
 


### PR DESCRIPTION
Reported in https://discord.com/channels/814482502336905216/1445923767015571599/1448428947607130183

```ts
type FooRequest = {
  foo: string;
};

type ApiRequest = {
  blob: FooRequest | string;
};

export const myApi = api<ApiRequest, void>(
  { expose: true, method: "POST" },
  (req) => {},
);
```

Now yields:
```json
{
  "schema": {
    "properties": {
      "blob": {
        "anyOf": [
          {
            "$ref": "#/components/schemas/hello.FooRequest"
          },
          {
            "type": "string"
          }
        ]
      }
    },
    "required": [
      "blob"
    ],
    "type": "object"
  }
}

```

Possibly also solves #1757 #1521 #1867