### PR TITLE
go: dont override name from tag if tag name is empty

### DIFF
--- a/parser/encoding/rpc.go
+++ b/parser/encoding/rpc.go
@@ -743,11 +743,13 @@ func describeParam(lang meta.Lang, encodingHints *encodingHints, field *schema.F
 			usedOverrideTag = tag.Key
 		}
 		if tagHint.location == location {
-			param.Name = tag.Name
-			if tagHint.wireFormatter != nil {
-				param.WireFormat = tagHint.wireFormatter(tag.Name)
-			} else {
-				param.WireFormat = tag.Name
+			if tag.Name != "" {
+				param.Name = tag.Name
+				if tagHint.wireFormatter != nil {
+					param.WireFormat = tagHint.wireFormatter(tag.Name)
+				} else {
+					param.WireFormat = tag.Name
+				}
 			}
 		}
 		if tagHint.omitEmptyOption != "" {


### PR DESCRIPTION
Fixes #2197 