### PR TITLE
tsparser: add support for method signatures

### DIFF
--- a/tsparser/src/legacymeta/schema.rs
+++ b/tsparser/src/legacymeta/schema.rs
@@ -197,6 +197,9 @@ impl BuilderCtx<'_, '_> {
                 typ: Some(styp::Typ::Builtin(schema::Builtin::Decimal as i32)),
                 validation: None,
             },
+            Type::Function(_) => {
+                anyhow::bail!("function types are not supported in schemas")
+            }
         })
     }
 

--- a/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@method_signatures.ts.snap
+++ b/tsparser/src/parser/types/snapshots/encore_tsparser__parser__types__tests__resolve_types@method_signatures.ts.snap
@@ -1,0 +1,525 @@
+---
+source: tsparser/src/parser/types/tests.rs
+expression: result
+input_file: tsparser/src/parser/types/testdata/method_signatures.ts
+---
+{
+    "SimpleMethod": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "foo",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Basic(
+                                Void,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "bar",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Basic(
+                                String,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "MethodsWithParams": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "simple",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    typ: Basic(
+                                        String,
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Basic(
+                                Void,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "multiple",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    typ: Basic(
+                                        String,
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                                FunctionParam {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    typ: Basic(
+                                        Number,
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Basic(
+                                Boolean,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "withOptional",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    typ: Basic(
+                                        String,
+                                    ),
+                                    optional: true,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Basic(
+                                Void,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "withRest",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "args",
+                                    ),
+                                    typ: Array(
+                                        Array(
+                                            Basic(
+                                                String,
+                                            ),
+                                        ),
+                                    ),
+                                    optional: false,
+                                    rest: true,
+                                },
+                            ],
+                            return_type: Basic(
+                                Void,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "ComplexReturns": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "returnsObject",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Interface(
+                                Interface {
+                                    fields: [
+                                        InterfaceField {
+                                            name: String(
+                                                "x",
+                                            ),
+                                            optional: false,
+                                            typ: Basic(
+                                                Number,
+                                            ),
+                                        },
+                                    ],
+                                    index: None,
+                                    call: None,
+                                },
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "returnsArray",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Array(
+                                Array(
+                                    Basic(
+                                        String,
+                                    ),
+                                ),
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "returnsUnion",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Union(
+                                Union {
+                                    types: [
+                                        Basic(
+                                            String,
+                                        ),
+                                        Basic(
+                                            Number,
+                                        ),
+                                    ],
+                                },
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "OptionalMethods": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "required",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Basic(
+                                Void,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "optional",
+                    ),
+                    optional: true,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Basic(
+                                Void,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "MixedInterface": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "prop",
+                    ),
+                    optional: false,
+                    typ: Basic(
+                        String,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "method",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Basic(
+                                Number,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "optionalProp",
+                    ),
+                    optional: true,
+                    typ: Basic(
+                        Boolean,
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "optionalMethod",
+                    ),
+                    optional: true,
+                    typ: Function(
+                        FunctionType {
+                            params: [],
+                            return_type: Basic(
+                                String,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "Column": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "mapFromDriverValue",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "value",
+                                    ),
+                                    typ: Generic(
+                                        TypeParam(
+                                            TypeParam {
+                                                idx: 0,
+                                                constraint: None,
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Generic(
+                                TypeParam(
+                                    TypeParam {
+                                        idx: 1,
+                                        constraint: None,
+                                    },
+                                ),
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "mapToDriverValue",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "value",
+                                    ),
+                                    typ: Generic(
+                                        TypeParam(
+                                            TypeParam {
+                                                idx: 1,
+                                                constraint: None,
+                                            },
+                                        ),
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Generic(
+                                TypeParam(
+                                    TypeParam {
+                                        idx: 0,
+                                        constraint: None,
+                                    },
+                                ),
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+    "SqlDialect": Interface(
+        Interface {
+            fields: [
+                InterfaceField {
+                    name: String(
+                        "escape",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "str",
+                                    ),
+                                    typ: Basic(
+                                        String,
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Basic(
+                                String,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "escapeId",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "id",
+                                    ),
+                                    typ: Basic(
+                                        String,
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Basic(
+                                String,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+                InterfaceField {
+                    name: String(
+                        "buildQuery",
+                    ),
+                    optional: false,
+                    typ: Function(
+                        FunctionType {
+                            params: [
+                                FunctionParam {
+                                    name: Some(
+                                        "sql",
+                                    ),
+                                    typ: Basic(
+                                        String,
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                                FunctionParam {
+                                    name: Some(
+                                        "values",
+                                    ),
+                                    typ: Array(
+                                        Array(
+                                            Basic(
+                                                Any,
+                                            ),
+                                        ),
+                                    ),
+                                    optional: false,
+                                    rest: false,
+                                },
+                            ],
+                            return_type: Basic(
+                                String,
+                            ),
+                            type_params: None,
+                        },
+                    ),
+                },
+            ],
+            index: None,
+            call: None,
+        },
+    ),
+}

--- a/tsparser/src/parser/types/testdata/method_signatures.ts
+++ b/tsparser/src/parser/types/testdata/method_signatures.ts
@@ -1,0 +1,47 @@
+// Simple method signatures
+export type SimpleMethod = {
+  foo(): void;
+  bar(): string;
+};
+
+// Methods with parameters
+export type MethodsWithParams = {
+  simple(a: string): void;
+  multiple(a: string, b: number): boolean;
+  withOptional(a?: string): void;
+  withRest(...args: string[]): void;
+};
+
+// Methods with complex return types
+export type ComplexReturns = {
+  returnsObject(): { x: number };
+  returnsArray(): string[];
+  returnsUnion(): string | number;
+};
+
+// Optional methods
+export type OptionalMethods = {
+  required(): void;
+  optional?(): void;
+};
+
+// Mixed properties and methods
+export type MixedInterface = {
+  prop: string;
+  method(): number;
+  optionalProp?: boolean;
+  optionalMethod?(): string;
+};
+
+// Example mimicking the drizzle-orm pattern that was failing
+export type Column<TDriverParam = unknown, TData = TDriverParam> = {
+  mapFromDriverValue(value: TDriverParam): TData;
+  mapToDriverValue(value: TData): TDriverParam;
+};
+
+// More complex example with multiple methods
+export interface SqlDialect {
+  escape(str: string): string;
+  escapeId(id: string): string;
+  buildQuery(sql: string, values: any[]): string;
+}

--- a/tsparser/src/parser/types/type_string.rs
+++ b/tsparser/src/parser/types/type_string.rs
@@ -58,6 +58,7 @@ where
             Type::Validation(v) => self.render_validation(v),
             Type::Validated(v) => self.render_validated(v),
             Type::Custom(c) => self.render_custom(c),
+            Type::Function(func) => self.render_function(func),
         }
     }
 
@@ -238,5 +239,32 @@ where
                 self.render_type(&i.y)
             }
         }
+    }
+
+    fn render_function(&mut self, func: &super::FunctionType) -> std::fmt::Result {
+        self.buf.write_char('(')?;
+
+        for (i, param) in func.params.iter().enumerate() {
+            if i > 0 {
+                self.buf.write_str(", ")?;
+            }
+
+            if let Some(name) = &param.name {
+                self.buf.write_str(name)?;
+                if param.optional {
+                    self.buf.write_char('?')?;
+                }
+                self.buf.write_str(": ")?;
+            }
+
+            if param.rest {
+                self.buf.write_str("...")?;
+            }
+
+            self.render_type(&param.typ)?;
+        }
+
+        self.buf.write_str(") => ")?;
+        self.render_type(&func.return_type)
     }
 }


### PR DESCRIPTION
This doesn't add any new schema features, but makes it possible for the parser to parse method signatures, so that types like these are possible:

```ts
type AType = {
  a: string;
  b: number;
  c(x: string, z: number): boolean;
};

type MyType = Pick<AType, "a" | "b">;
```