### PR TITLE
encore test: fix conflict with pre-installed go versions

### DIFF
--- a/v2/compiler/build/tests.go
+++ b/v2/compiler/build/tests.go
@@ -189,15 +189,25 @@ func (b *builder) generateTestSpec(testCfg *GenerateTestSpecConfig) *TestSpec {
 		env = append(env, "CGO_ENABLED=0")
 	}
 
+	environ := append(os.Environ(), env...)
+
+	// Get the last PATH= item
+	var originalPath string
+	for _, e := range environ {
+		if path, ok := strings.CutPrefix(e, "PATH="); ok {
+			originalPath = path
+		}
+	}
+
 	// prefix PATH with encore-go, so it doesnt conflict with other installed go versions
 	// if not set causes problems when running cover tests in go
-	path := goroot.Join("bin").ToIO() + string(filepath.ListSeparator) + os.Getenv("PATH")
-	env = append(env, "PATH="+path)
+	path := goroot.Join("bin").ToIO() + string(filepath.ListSeparator) + originalPath
+	environ = append(environ, "PATH="+path)
 
 	return &TestSpec{
 		Command: goroot.Join("bin", "go"+b.exe()).ToIO(),
 		Args:    args,
-		Environ: append(os.Environ(), env...),
+		Environ: environ,
 		cfg:     b.cfg,
 	}
 }


### PR DESCRIPTION
In some corner case where a package didnt have any tests, running `encore test ./... -cover` caused errors like:
```
compile: version "go1.25.4-encore X:cacheprog" does not match go tool version "go1.25.4"
```

this is due a version conflict with a pre-installed go version. This makes sure we set the encore-go bin as the first item in the PATH so that wont happen