### PR TITLE
traces: Update trace version to 15 for core runtime

### DIFF
--- a/runtimes/core/src/trace/protocol.rs
+++ b/runtimes/core/src/trace/protocol.rs
@@ -36,6 +36,8 @@ pub enum EventType {
     CacheCallStart = 0x14,
     CacheCallEnd = 0x15,
     BodyStream = 0x16,
+    // NOTE: We don't have an easy way of implementing test tracing for rust (i.e. typescript)
+    // so that's why we haven't implemented emitting TestStart/TestEnd etc.
     TestStart = 0x17,
     TestEnd = 0x18,
     BucketObjectUploadStart = 0x19,


### PR DESCRIPTION
Trace version was updated to 15 in go https://github.com/encoredev/encore/pull/1012, to include TestSpan as part of the Spans that we support. The trace version for core runtime was not updated in the same PR.

The core runtime would be harder to support TestSpans, hence the version was not updated. The TestSpan is not currently implemented. 

This PR:
- bumps the version to 15
- adds `mocked` field for RequestSpan which was included in the version updated
- comments about the methods for TestSpan not being implemented for `Tracer`
