### PR TITLE
clientgen: handle nil when generating typescript client

### DIFF
--- a/pkg/clientgen/typescript.go
+++ b/pkg/clientgen/typescript.go
@@ -858,8 +858,11 @@ func (ts *typescript) writeDeclDef(ns string, decl *schema.Decl) {
 	} else {
 		fmt.Fprintf(ts, "    export type %s%s = ", ts.typeName(decl.Name), typeParams.String())
 	}
+
+	prev := ts.currDecl
 	ts.currDecl = decl
 	ts.writeTyp(ns, decl.Type, 1)
+	ts.currDecl = prev
 	ts.WriteString("\n")
 }
 


### PR DESCRIPTION
Handles nil when not writing a decl, and also properly resets `currDecl`, which hid this bug if currDecl was ever set