### PR TITLE
cli/daemon/engine/trace2/sqlite: fix updateSpanEndIndex

### DIFF
--- a/cli/daemon/engine/trace2/sqlite/write.go
+++ b/cli/daemon/engine/trace2/sqlite/write.go
@@ -310,7 +310,8 @@ func (s *Store) updateSpanEndIndex(ctx context.Context, meta *trace2.Meta, ev *t
 				caller_event_id = excluded.caller_event_id
 		`, meta.AppID, traceID, spanID,
 			tracepbcli.SpanSummary_REQUEST, true,
-			end.Error != nil, end.DurationNanos)
+			end.Error != nil, end.DurationNanos, req.CallerEventId,
+		)
 		if err != nil {
 			return errors.Wrap(err, "insert trace span event")
 		}


### PR DESCRIPTION
A recent change added a placeholder but no corresponding argument.