### PR TITLE
export: parse metrics collection interval correctly

### DIFF
--- a/runtimes/core/src/metrics/manager.rs
+++ b/runtimes/core/src/metrics/manager.rs
@@ -170,8 +170,8 @@ impl Manager {
                 .first()
                 .and_then(|p| p.collection_interval.as_ref())
                 .and_then(|d| Duration::try_from(d.clone()).ok())
+                .filter(|d| !d.is_zero())
                 .unwrap_or(Duration::from_secs(60)); // Default to 1 minute
-
             manager.start_collection_loop(runtime_handle, collection_interval);
         }
 

--- a/runtimes/go/appruntime/exported/config/infra/config.go
+++ b/runtimes/go/appruntime/exported/config/infra/config.go
@@ -355,16 +355,18 @@ func (m *Metrics) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON custom unmarshaller to handle dynamic types in Metrics.
 func (m *Metrics) UnmarshalJSON(data []byte) error {
-	// Anonymous struct to capture the "type" field first
+	// Anonymous struct to capture the base fields first
 	var aux struct {
-		Type string `json:"type,omitempty"`
+		Type               string `json:"type,omitempty"`
+		CollectionInterval int    `json:"collection_interval,omitempty"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
-	// Set the Type field
+	// Set the base fields
 	m.Type = aux.Type
+	m.CollectionInterval = aux.CollectionInterval
 
 	// Unmarshal based on the "type" field
 	switch aux.Type {


### PR DESCRIPTION
parse collection interval from infra config and also handle zero collection interval in ts the same way we do in go

fixes #2245