### PR TITLE
feat(add): Adds endpoints for `dash.go` for localdev 	- `traces/spans/summaries/list`, `traces/spans/events/list`

### DIFF
--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -267,6 +267,38 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		}
 		return reply(ctx, events, err)
 
+	case "traces/spans/summaries/list":
+		telemetry.Send("traces.spans.summaries.list")
+		var params struct {
+			AppID   string `json:"app_id"`
+			TraceID string `json:"trace_id"`
+		}
+		if err := unmarshal(&params); err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		spans, err := h.tr.GetSpanSummaries(ctx, params.AppID, params.TraceID)
+		if err != nil {
+			log.Error().Err(err).Msg("dash: could not list trace spans")
+			return reply(ctx, nil, err)
+		}
+		return reply(ctx, spans, err)
+	case "traces/spans/events/list":
+		telemetry.Send("traces.spans.events.list")
+		var params struct {
+			AppID   string `json:"app_id"`
+			TraceID string `json:"trace_id"`
+			SpanID  string `json:"span_id"`
+		}
+		if err := unmarshal(&params); err != nil {
+			return reply(ctx, nil, err)
+		}
+
+		events, err := h.tr.GetEvents(ctx, params.AppID, params.TraceID, params.SpanID)
+		if err != nil {
+			log.Error().Err(err).Msg("dash: could not get span events")
+		}
+		return reply(ctx, events, err)
 	case "status":
 		var params struct {
 			AppID string

--- a/cli/daemon/engine/trace2/store.go
+++ b/cli/daemon/engine/trace2/store.go
@@ -72,6 +72,11 @@ type Store interface {
 	// If the trace is not found it reports an error matching ErrNotFound.
 	Get(ctx context.Context, appID, traceID string, iter EventIterator) error
 
+	// GetSpanSummaries returns all span summaries for a trace.
+	GetSpanSummaries(ctx context.Context, appID, traceID string) ([]*tracepb2.SpanSummary, error)
+	// GetEvents returns events for a specific span.
+	GetEvents(ctx context.Context, appID, traceID, spanID string) ([]*tracepb2.TraceEvent, error)
+
 	// Listen listens for new spans.
 	Listen(ch chan<- NewSpanEvent)
 


### PR DESCRIPTION
This is work to separate traces into spans and events for the frontend to consume separately.

This is part of the work to get lazy-loading of spans for a specific trace to make the traceviewer more performant on instance which a large amount of spans for one trace.

Tested w. websocket api calls via the console:

```javascript
// Test fetching events for a specific span
const ws = new WebSocket('ws://localhost:9400/__encore');
ws.onmessage = (e) => console.log('Response:', JSON.parse(e.data));
ws.onopen = () => {
  ws.send(JSON.stringify({
    jsonrpc: "2.0",
    id: 1,
    method: "traces/spans/events/list",
    params: {
      app_id: "APP_ID",
      trace_id: "YOUR_TRACE_ID",
      span_id: "YOUR_SPAN_ID"
    }
  }));
};
```