### PR TITLE
fix: docker base image default value is now correctly displayed for both Go & TS

### DIFF
--- a/cli/cmd/encore/build.go
+++ b/cli/cmd/encore/build.go
@@ -53,6 +53,9 @@ func init() {
 				if !cmd.Flag("base").Changed && file.Lang == appfile.LangTS {
 					p.BaseImg = "node:slim"
 				}
+				else {
+					p.BaseImg = "scratch"
+				}
 				if !cmd.Flag("cgo").Changed {
 					p.CgoEnabled = file.Build.CgoEnabled
 				}
@@ -63,7 +66,7 @@ func init() {
 	}
 
 	dockerBuildCmd.Flags().BoolVarP(&p.Push, "push", "p", false, "push image to remote repository")
-	dockerBuildCmd.Flags().StringVar(&p.BaseImg, "base", "scratch", "base image to build from")
+	dockerBuildCmd.Flags().StringVar(&p.BaseImg, "base", "", "base image to build from (default for TS: \"node:slim\", for Go: \"scratch\")")
 	dockerBuildCmd.Flags().BoolVar(&p.CgoEnabled, "cgo", false, "enable cgo")
 	dockerBuildCmd.Flags().BoolVar(&p.SkipInfraConf, "skip-config", false, "do not read or generate a infra configuration file")
 	dockerBuildCmd.Flags().StringVar(&p.InfraConfPath, "config", "", "infra configuration file path")


### PR DESCRIPTION
I was working on my personal project, when i figured out that Encore uses "node:slim" as base image, rather than "
scratch", which led to encore docker container being unable to launch with TS code, when i used another base image. Thats understandable, just not clear from "help menu" provided in console:

      --base string        base image to build from (default "scratch")

Now it should say:

      --base string        base image to build from (default for TS: "node:slim", for Go: "scratch")

Just a heads up, i havent had experience with Go syntax yet, and that PR is rather compulsive... So please check thoroughly, and thanks for understanding.
