### PR TITLE
chore: updated self-hosting documentation to address SQL migration issue

### DIFF
--- a/docs/go/self-host/self-host.md
+++ b/docs/go/self-host/self-host.md
@@ -7,7 +7,11 @@ lang: go
 
 Encore supports building Docker images directly from the CLI, which can then be self-hosted on your own infrastructure of choice.
 
-This can be a good choice if Encore Cloud isn't a good fit for your use case, or if you want to [migrate away](/docs/go/migration/migrate-away).
+This can be a good choice if [Encore Cloud](/docs/platform) isn't a good fit for your use case, or if you want to [migrate away](/docs/go/migration/migrate-away).
+
+## Feature parity
+
+Some aspects of how Encore Cloud and Encore Local Dashboard work are not applicable for self-hosted instances - for example, when you self-host, you should provide your own database container, and do SQL migrations manually. But do not worry, it would be explained further how to do it!
 
 ## Building your own Docker image
 
@@ -28,6 +32,57 @@ The image will default to run on port 8080, but you can customize it by setting 
 ```bash
 docker run -e PORT=8081 -p 8081:8081 MY-IMAGE:TAG
 ```
+
+## How to do SQL migrations
+
+ For PostgreSQL, it is easily done with the help of separate one-shot container, based on postgres image you would already have for your DB. This is a minimal example with all services configured (except for PostgreSQL) correctly to ensure successfull migration workflow:
+
+**docker_compose.yml:**
+```yaml
+services:
+  migrate:
+    image: postgres:16-alpine
+    container_name: your-api-migrate
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: YOUR_PASSWORD
+    volumes:
+      - ./your-api/src/services/migrations:/migrations:ro
+      - ./scripts/migrate.sh:/migrate.sh:ro
+    command: ["sh", "/migrate.sh"]
+  your-api:
+    image: MY-IMAGE:TAG
+    container_name: your-api-encore
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+  postgres:
+    image: postgres:16-alpine
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    #...other postgres-related options
+```
+
+And `migrate.sh` would be the script, used for actual migration.
+Minimal viable example:
+
+```bash
+for f in /migrations/*.up.sql; do
+  [ -f "$f" ] || continue
+  log "[migrate] applying [$f]"
+  # -v ON_ERROR_STOP=1 makes psql exit non-zero on first error.
+  psql -v ON_ERROR_STOP=1 -h postgres -U postgres -d your-api_db -f "$f"
+done
+```
+
+Insides of the script can be replaced depending on what migration tool you want to use.
 
 Congratulations, you've built your own Docker image! 🎉
 Continue to learn how to [configure infrastructure](/docs/go/self-host/configure-infra).

--- a/docs/ts/self-host/build.md
+++ b/docs/ts/self-host/build.md
@@ -9,6 +9,10 @@ Encore supports building Docker images directly from the CLI, which can then be 
 
 This can be a good choice if [Encore Cloud](/docs/platform) isn't a good fit for your use case, or if you want to [migrate away](/docs/ts/migration/migrate-away).
 
+## Feature parity
+
+Some aspects of how Encore Cloud and Encore Local Dashboard work are not applicable for self-hosted instances - for example, when you self-host, you should provide your own database container, and do SQL migrations manually. But do not worry, it would be explained further how to do it!
+
 ## Building your own Docker image
 
 To build your own Docker image, use `encore build docker MY-IMAGE:TAG` from the CLI.
@@ -28,6 +32,57 @@ The image will default to run on port 8080, but you can customize it by setting 
 ```bash
 docker run -e PORT=8081 -p 8081:8081 MY-IMAGE:TAG
 ```
+
+## How to do SQL migrations
+
+ For PostgreSQL, it is easily done with the help of separate one-shot container, based on postgres image you would already have for your DB. This is a minimal example with all services configured (except for PostgreSQL) correctly to ensure successfull migration workflow:
+
+**docker_compose.yml:**
+```yaml
+services:
+  migrate:
+    image: postgres:16-alpine
+    container_name: your-api-migrate
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: YOUR_PASSWORD
+    volumes:
+      - ./your-api/src/services/migrations:/migrations:ro
+      - ./scripts/migrate.sh:/migrate.sh:ro
+    command: ["sh", "/migrate.sh"]
+  your-api:
+    image: MY-IMAGE:TAG
+    container_name: your-api-encore
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+  postgres:
+    image: postgres:16-alpine
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    #...other postgres-related options
+```
+
+And `migrate.sh` would be the script, used for actual migration.
+Minimal viable example:
+
+```bash
+for f in /migrations/*.up.sql; do
+  [ -f "$f" ] || continue
+  log "[migrate] applying [$f]"
+  # -v ON_ERROR_STOP=1 makes psql exit non-zero on first error.
+  psql -v ON_ERROR_STOP=1 -h postgres -U postgres -d your-api_db -f "$f"
+done
+```
+
+Insides of the script can be replaced depending on what migration tool you want to use.
 
 Congratulations, you've built your own Docker image! 🎉
 Continue to learn how to [configure infrastructure](/docs/ts/self-host/configure-infra).


### PR DESCRIPTION
There is thread in Encore's Discord server, which says that Encore migrations are not running inside self-hosted docker containers:

https://discord.com/channels/814482502336905216/1424912435139317890

(if you prefer not to use random links on the internet, title of the question in #help channel is: "Self-hosted migrations are not running")

There was a talk about adding info about it into the docs, but it seems that no one did it. So i did it myself, and added working, but anonymized example from my project, on how to apply SQL migrations (at least one of the ways).

I can feel that its maybe not the best placement of such info, but still better than nothing.