### PR TITLE
Some trivial staticcheck fixes

### DIFF
--- a/cli/cmd/encore/cmdutil/stream.go
+++ b/cli/cmd/encore/cmdutil/stream.go
@@ -71,7 +71,6 @@ func StreamCommandOutput(stream CommandOutputStream, converter OutputConverter) 
 						// The scanner failed, likely due to a too-long line. Log an error
 						// and create a new scanner since the old one is in an unrecoverable state.
 						fmt.Fprintln(os.Stderr, "failed to read output:", err)
-						scanner = bufio.NewScanner(read)
 						continue
 					} else {
 						break

--- a/cli/cmd/encore/k8s/config.go
+++ b/cli/cmd/encore/k8s/config.go
@@ -200,24 +200,24 @@ func readKubeConfig(file string) (*Cfg, error) {
 	}
 
 	if clusters, ok := kubeConfig["clusters"]; ok {
-		if clusters, ok := clusters.([]any); ok {
-			cfg.clusters = clusters
+		if clustersSlice, ok := clusters.([]any); ok {
+			cfg.clusters = clustersSlice
 		} else {
 			return nil, errors.Newf("clusters is not an array got %T", clusters)
 		}
 	}
 
 	if users, ok := kubeConfig["users"]; ok {
-		if users, ok := users.([]any); ok {
-			cfg.users = users
+		if usersSlice, ok := users.([]any); ok {
+			cfg.users = usersSlice
 		} else {
 			return nil, errors.Newf("users is not an array got %T", users)
 		}
 	}
 
 	if contexts, ok := kubeConfig["contexts"]; ok {
-		if contexts, ok := contexts.([]any); ok {
-			cfg.contexts = contexts
+		if contextsSlice, ok := contexts.([]any); ok {
+			cfg.contexts = contextsSlice
 		} else {
 			return nil, errors.Newf("contexts is not an array got %T", contexts)
 		}

--- a/cli/cmd/encore/sqlc.go
+++ b/cli/cmd/encore/sqlc.go
@@ -115,6 +115,9 @@ func init() {
 				return fmt.Errorf("sqlc exited with code %d", res)
 			}
 			reqBlob, err := os.ReadFile(filepath.Join(outPath, "output.pb"))
+			if err != nil {
+				return err
+			}
 			if !useProto {
 				req := &daemon.SQLCPlugin_GenerateRequest{}
 				if err := proto.Unmarshal(reqBlob, req); err != nil {

--- a/cli/daemon/dash/ai/parser.go
+++ b/cli/daemon/dash/ai/parser.go
@@ -184,8 +184,8 @@ func parseCode(ctx context.Context, app *apps.Instance, services []Service) (rtn
 				}
 				e := overlay.endpoint
 
-				pathDocs := map[string]string{}
 				e.Doc, e.Errors = parseErrorList(r.Doc)
+				var pathDocs map[string]string
 				e.Doc, pathDocs = parsePathList(e.Doc)
 				e.Name = r.Name
 				e.Method = r.HTTPMethods[0]

--- a/cli/daemon/dash/ai/parser.go
+++ b/cli/daemon/dash/ai/parser.go
@@ -56,6 +56,7 @@ func parseDocList(doc, section string) (string, []docListItem) {
 	lines := strings.Split(doc, "\n")
 	start := -1
 	end := -1
+loop:
 	for i, line := range lines {
 		end = i
 		if strings.HasPrefix(strings.TrimSpace(line), section+":") {
@@ -68,7 +69,7 @@ func parseDocList(doc, section string) (string, []docListItem) {
 			case "-", "":
 			default:
 				end = i - 1
-				break
+				break loop
 			}
 		}
 		lines[i] = strings.TrimSpace(line)

--- a/cli/daemon/dash/ai/parser_test.go
+++ b/cli/daemon/dash/ai/parser_test.go
@@ -1,0 +1,26 @@
+package ai
+
+import (
+	"testing"
+)
+
+func TestParseDocList_StopsAtNonListLine(t *testing.T) {
+	doc := `Some preamble
+Errors:
+- foo: something
+- bar: another thing
+Next section starts here
+- baz: should not be included`
+
+	_, items := parseDocList(doc, "Errors")
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d: %+v", len(items), items)
+	}
+	if items[0].Key != "foo" || items[0].Doc != "something" {
+		t.Errorf("unexpected item[0]: %+v", items[0])
+	}
+	if items[1].Key != "bar" || items[1].Doc != "another thing" {
+		t.Errorf("unexpected item[1]: %+v", items[1])
+	}
+}

--- a/cli/daemon/engine/trace2/sqlite/write.go
+++ b/cli/daemon/engine/trace2/sqlite/write.go
@@ -90,6 +90,10 @@ func (s *Store) DoClean(ctx context.Context, triggerAt, eventsToKeep, batchSize 
 			continue
 		}
 		traceIDs, err := scanRows[string](rows)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to scan trace ids")
+			continue
+		}
 		if len(traceIDs) == 0 {
 			continue
 		}

--- a/cli/daemon/export/download.go
+++ b/cli/daemon/export/download.go
@@ -77,7 +77,6 @@ func tryCleanupPreviousVersions(binDir dockerbuild.HostPath) {
 			}
 		}
 	}
-	return
 }
 
 func downloadFile(url, dest string) error {

--- a/cli/daemon/mcp/src_tools.go
+++ b/cli/daemon/mcp/src_tools.go
@@ -38,6 +38,9 @@ func (m *Manager) getMetadata(ctx context.Context, request mcp.CallToolRequest) 
 		return nil, fmt.Errorf("failed to get metadata: %w", err)
 	}
 	data, err := protojson.Marshal(md)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
 
 	return mcp.NewToolResultText(string(data)), nil
 }

--- a/cli/daemon/namespace/namespace.go
+++ b/cli/daemon/namespace/namespace.go
@@ -194,6 +194,9 @@ func (m *Manager) Delete(ctx context.Context, app *apps.Instance, name Name) err
 		WHERE app_id = ? AND name = ?
 		RETURNING id, name, active, created_at, last_active_at
 	`, app.PlatformOrLocalID(), name).Scan(&ns.ID, &ns.Name, &ns.Active, &ns.CreatedAt, &ns.LastActiveAt)
+	if err != nil {
+		return errors.Newf("failed to delete namespace: %v", err)
+	}
 	if ns.Active {
 		return ErrActive
 	}

--- a/cli/daemon/run/runtime_config2.go
+++ b/cli/daemon/run/runtime_config2.go
@@ -634,9 +634,7 @@ func (g *RuntimeConfigGenerator) ProcPerServiceWithNewRuntimeConfig(proxy *svcpr
 	sd := &runtimev1.ServiceDiscovery{Services: make(map[string]*runtimev1.ServiceDiscovery_Location)}
 
 	svcListenAddr := make(map[string]netip.AddrPort)
-	var svcNames []string
 	for _, svc := range g.md.Svcs {
-		svcNames = append(svcNames, svc.Name)
 		listenAddr, err := freeLocalhostAddress()
 		if err != nil {
 			return nil, nil, nil, errors.Wrap(err, "failed to find free localhost address")

--- a/cli/daemon/run/tests.go
+++ b/cli/daemon/run/tests.go
@@ -125,7 +125,7 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 		}
 		secrets = secretData.Values
 		// remove db override secrets for tests
-		for k, _ := range secrets {
+		for k := range secrets {
 			if strings.HasPrefix(k, "sqldb::") {
 				delete(secrets, k)
 			}

--- a/cli/internal/dedent/dedent.go
+++ b/cli/internal/dedent/dedent.go
@@ -41,9 +41,7 @@ var (
 // the display, while still presenting them in the source code in indented
 // form.
 func Dedent(text string) string {
-	if strings.HasPrefix(text, "\n") {
-		text = strings.TrimPrefix(text, "\n")
-	}
+	text = strings.TrimPrefix(text, "\n")
 
 	var margin string
 

--- a/internal/optracker/optracker.go
+++ b/internal/optracker/optracker.go
@@ -52,7 +52,7 @@ func (t *OpTracker) AllDone() {
 	defer t.mu.Unlock()
 
 	// If we've already quit, don't do anything
-	if t.quit == true {
+	if t.quit {
 		return
 	}
 

--- a/pkg/clientgen/golang.go
+++ b/pkg/clientgen/golang.go
@@ -1443,12 +1443,12 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 			for _, field := range auth.QueryParameters {
 				if field.Type.GetList() != nil {
 					// If we have a slice, we need to encode each bit
-					slice, err := enc.ToStringSlice(
+					slice, errConv := enc.ToStringSlice(
 						field.Type,
 						Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 					)
-					if err != nil {
-						err = errors.Wrapf(err, "unable to encode query fields %s", field.SrcName)
+					if errConv != nil {
+						err = errors.Wrapf(errConv, "unable to encode query fields %s", field.SrcName)
 						return
 					}
 
@@ -1464,12 +1464,12 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 						Id("val").Op(":=").Add(Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase))),
 						Id("val").Op("!=").Nil(),
 					).BlockFunc(func(g *Group) {
-						val, err := enc.ToString(
+						val, errConv := enc.ToString(
 							field.Type,
 							Id("val"),
 						)
-						if err != nil {
-							err = errors.Wrapf(err, "unable to encode query field %s", field.SrcName)
+						if errConv != nil {
+							err = errors.Wrapf(errConv, "unable to encode query field %s", field.SrcName)
 							return
 						}
 						g.Add(Id("query").Dot("Set").Call(
@@ -1479,12 +1479,12 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					}))
 				} else {
 					// Otherwise, we can just append the field
-					val, err := enc.ToString(
+					val, errConv := enc.ToString(
 						field.Type,
 						Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 					)
-					if err != nil {
-						err = errors.Wrapf(err, "unable to encode query field %s", field.SrcName)
+					if errConv != nil {
+						err = errors.Wrapf(errConv, "unable to encode query field %s", field.SrcName)
 						return
 					}
 
@@ -1506,12 +1506,12 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 			for _, field := range auth.HeaderParameters {
 				if field.Type.GetList() != nil {
 					// If we have a slice, we need to encode each bit
-					slice, err := enc.ToStringSlice(
+					slice, errConv := enc.ToStringSlice(
 						field.Type,
 						Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 					)
-					if err != nil {
-						err = errors.Wrapf(err, "unable to encode header fields %s", field.SrcName)
+					if errConv != nil {
+						err = errors.Wrapf(errConv, "unable to encode header fields %s", field.SrcName)
 						return
 					}
 
@@ -1527,12 +1527,12 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 						Id("val").Op(":=").Add(Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase))),
 						Id("val").Op("!=").Nil(),
 					).BlockFunc(func(g *Group) {
-						val, err := enc.ToString(
+						val, errConv := enc.ToString(
 							field.Type,
 							Id("val"),
 						)
-						if err != nil {
-							err = errors.Wrapf(err, "unable to encode header field %s", field.SrcName)
+						if errConv != nil {
+							err = errors.Wrapf(errConv, "unable to encode header field %s", field.SrcName)
 							return
 						}
 						enc.Add(Id("req").Dot("Header").Dot("Set").Call(
@@ -1542,12 +1542,12 @@ func (g *golang) addAuthData(grp *Group) (err error) {
 					}))
 				} else {
 					// Otherwise, we can just append the field
-					val, err := enc.ToString(
+					val, errConv := enc.ToString(
 						field.Type,
 						Id("authData").Dot(idents.Convert(field.SrcName, idents.PascalCase)),
 					)
-					if err != nil {
-						err = errors.Wrapf(err, "unable to encode header field %s", field.SrcName)
+					if errConv != nil {
+						err = errors.Wrapf(errConv, "unable to encode header field %s", field.SrcName)
 						return
 					}
 

--- a/pkg/cueutil/build.go
+++ b/pkg/cueutil/build.go
@@ -198,7 +198,7 @@ func addOrphanedFiles(i *build.Instance) (err error) {
 				return err
 			}
 		default:
-			return errors.New(fmt.Sprintf("unsupported encoding: %s", f.Encoding))
+			return fmt.Errorf("unsupported encoding: %s", f.Encoding)
 		}
 
 		if err != nil {

--- a/pkg/encorebuild/gentypedefs/gentypedefs.go
+++ b/pkg/encorebuild/gentypedefs/gentypedefs.go
@@ -299,9 +299,7 @@ func correctStringIndent(src string, indent int) string {
 	}
 
 	res := result.String()
-	if strings.HasSuffix(res, "\n") {
-		res = res[:len(res)-1]
-	}
+	res = strings.TrimSuffix(res, "\n")
 
 	return res
 }

--- a/pkg/errinsrc/utils.go
+++ b/pkg/errinsrc/utils.go
@@ -52,10 +52,10 @@ func ExtractFromPanic(recovered any) error {
 			switch err := unwrapped.(type) {
 			case *ErrInSrc:
 				return err
-			case ErrorList:
-				return err
 			case Bailout:
 				return err.List
+			case ErrorList:
+				return err
 			case interface{ Unwrap() error }:
 				unwrapped = err.Unwrap()
 			default:

--- a/pkg/make-release/utils.go
+++ b/pkg/make-release/utils.go
@@ -180,6 +180,9 @@ func downloadLatestGithubRelease(org, repo, os, arch string) (pathToFile string,
 
 	// Create the file
 	downloadFile, err := osPkg.Create(downloadPath)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create download file")
+	}
 	defer func() {
 		_ = downloadFile.Close()
 		if rtnErr != nil {

--- a/pkg/tarstream/tarstream.go
+++ b/pkg/tarstream/tarstream.go
@@ -171,7 +171,7 @@ func Validate(r io.Reader) (*tar.Header, error) {
 	// hopefully thats what we want here
 	hdr, err := tr.Next()
 	if err != nil {
-		return &tar.Header{}, errors.Wrap(err, fmt.Sprintf("read header"))
+		return &tar.Header{}, errors.Wrap(err, "read header")
 	}
 	return hdr, nil
 }

--- a/tools/publicapigen/main.go
+++ b/tools/publicapigen/main.go
@@ -760,8 +760,8 @@ type keepDirective string
 
 const (
 	none     keepDirective = "none"
-	mustKeep               = "keep"
-	mustDrop               = "drop"
+	mustKeep keepDirective = "keep"
+	mustDrop keepDirective = "drop"
 )
 
 // directiveCache caches the directive for a given comment group,

--- a/v2/app/legacymeta/legacymeta.go
+++ b/v2/app/legacymeta/legacymeta.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"go/token"
-	gotoken "go/token"
 	"slices"
 	"sort"
 
@@ -548,7 +547,7 @@ func (b *builder) Build() *meta.Data {
 	return md
 }
 
-func (b *builder) apiPath(pos gotoken.Pos, path *resourcepaths.Path) *meta.Path {
+func (b *builder) apiPath(pos token.Pos, path *resourcepaths.Path) *meta.Path {
 	res := &meta.Path{
 		Type: meta.Path_URL,
 	}

--- a/v2/parser/infra/internal/literals/literals.go
+++ b/v2/parser/infra/internal/literals/literals.go
@@ -53,8 +53,8 @@ elemLoop:
 	for _, elem := range cl.Elts {
 		switch elem := elem.(type) {
 		case *ast.KeyValueExpr:
-			ident, ok := elem.Key.(*ast.Ident)
-			if !ok {
+			ident, subOk := elem.Key.(*ast.Ident)
+			if !subOk {
 				errs.Add(errExpectedKeyToBeIdentifier(reflect.TypeOf(elem.Key)).AtGoNode(elem.Key))
 				continue elemLoop
 			}


### PR DESCRIPTION
A myriad of small bug and cosmetic fixes found by staticcheck.

- **cli/cmd/encore/cmdutil: scanner not used**
- **cli/cmd/encore/k8s: fix variable shadowing**
- **cli/cmd/encore: add missing error check**
- **cli/daemon/dash/ai: fix break inside a switch**
- **cli/daemon/dash/ai: remove unused assignment**
- **cli/daemon/engine/trace2/sqlite: add missing err check**
- **cli/daemon/export: remove redunant return**
- **cli/daemon/mcp: add missing err check**
- **cli/daemon/namespace: add missing err check**
- **cli/daemon/run: remove unused code**
- **cli/internal/dedent: simplify code**
- **internal/optracker: simplify code**
- **pkg/clientgen: handle discarded errs**
- **pkg/cueutil: use fmt.Errorf**
- **pkg/encorebuild/gentypedefs: simplify code**
- **pkg/errinsrc: fix unreachable case clause**
- **pkg/make-release: check err result**
- **pkg/tarstream: simplify code**
- **tools/publicapigen: fix explicit types**
- **v2/app/legacymeta: remove double import**
- **v2/parser/infra/internal/literals: fix ok shadowing issue**
