### PR TITLE
Prompt to set up LLM instructions on encore run

### DIFF
--- a/cli/cmd/encore/llm_rules/init.go
+++ b/cli/cmd/encore/llm_rules/init.go
@@ -56,6 +56,17 @@ func init() {
 	llmRulesToolFlag.AddFlag(llmRules)
 }
 
+// RunInit runs the interactive LLM rules initialization flow.
+// It can be called from other commands (e.g. "encore run") to prompt the user.
+func RunInit() error {
+	var tool Tool
+	cfg, err := userconfig.Global().Get()
+	if err == nil {
+		tool = Tool(cfg.LLMRules)
+	}
+	return initLLMRules(tool)
+}
+
 func initLLMRules(tool Tool) error {
 	if tool == "" {
 		var llmRulesModel ToolSelectModel

--- a/cli/cmd/encore/llm_rules/tool.go
+++ b/cli/cmd/encore/llm_rules/tool.go
@@ -294,6 +294,23 @@ func writeNewFileOrSkip(filePath string, data []byte) error {
 	return nil
 }
 
+// HasLLMRules checks if any LLM rules files have been set up in the given app root.
+func HasLLMRules(appRoot string) bool {
+	paths := []string{
+		filepath.Join(appRoot, ".cursor", "rules", "encore.mdc"),
+		filepath.Join(appRoot, ".claude", "CLAUDE.md"),
+		filepath.Join(appRoot, ".github", "copilot-instructions.md"),
+		filepath.Join(appRoot, "AGENTS.md"),
+		filepath.Join(appRoot, ".rules"),
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func downloadLLMInstructions(lang cmdutil.Language) (string, error) {
 	fmt.Println("Downloading LLM Instructions...")
 	var url string

--- a/cli/cmd/encore/run.go
+++ b/cli/cmd/encore/run.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 
 	"github.com/logrusorgru/aurora/v3"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
 	"encr.dev/cli/cmd/encore/cmdutil"
+	"encr.dev/cli/cmd/encore/llm_rules"
 	"encr.dev/cli/cmd/encore/root"
 	"encr.dev/cli/internal/onboarding"
 	daemonpb "encr.dev/proto/encore/daemon"
@@ -124,6 +126,9 @@ func runApp(appRoot, wd string) {
 		debugMode = daemonpb.RunRequest_DEBUG_BREAK
 	}
 
+	// Prompt to set up LLM rules if not already done.
+	promptLLMRulesSetup(appRoot)
+
 	daemon := setupDaemon(ctx)
 	stream, err := daemon.Run(ctx, &daemonpb.RunRequest{
 		AppRoot:            appRoot,
@@ -159,6 +164,52 @@ func runApp(appRoot, wd string) {
 		}
 	}
 	os.Exit(code)
+}
+
+// promptLLMRulesSetup prompts the user to set up LLM rules if they haven't been
+// initialized for this app and we haven't prompted before.
+func promptLLMRulesSetup(appRoot string) {
+	// Only prompt in interactive terminals.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return
+	}
+
+	// Check if LLM rules are already set up.
+	if llm_rules.HasLLMRules(appRoot) {
+		return
+	}
+
+	// Check if we've already prompted about this app.
+	state, err := onboarding.Load()
+	if err != nil {
+		return
+	}
+	prop := state.Property("llm_rules_hint:" + appRoot)
+	if prop.IsSet() {
+		return
+	}
+
+	// Mark that we've prompted, regardless of the answer.
+	prop.Set()
+	_ = state.Write()
+
+	fmt.Println(aurora.Sprintf("Hint: You can add LLM instructions to improve AI code generation for your Encore app."))
+	fmt.Print(aurora.Sprintf("Set up LLM instructions now? (Y/n): "))
+
+	var input string
+	_, _ = fmt.Scanln(&input)
+	input = strings.TrimSpace(input)
+
+	switch input {
+	case "Y", "y", "yes", "":
+		if err := llm_rules.RunInit(); err != nil {
+			fmt.Fprintln(os.Stderr, aurora.Sprintf(aurora.Yellow("Warning: failed to set up LLM rules: %v"), err))
+		}
+		fmt.Println()
+	default:
+		fmt.Println(aurora.Sprintf(aurora.Faint("Skipped. You can run %s later to set up LLM instructions."), aurora.Cyan("encore llm-rules init")))
+		fmt.Println()
+	}
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- When running `encore run` on an app that hasn't had `encore llm-rules init` run, the CLI now prompts the user to set up LLM instructions (same interactive tool selector as during app creation)
- Detection checks for the presence of any LLM rules files (`.cursor/rules/encore.mdc`, `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, `AGENTS.md`, `.rules`)
- The prompt is tracked per-app via the onboarding state, so each app is only prompted once
- Only prompts in interactive terminals