### PR TITLE
gateway-forwarded requests incorrectly marked as non-root

### DIFF
--- a/runtimes/core/src/api/reqauth/mod.rs
+++ b/runtimes/core/src/api/reqauth/mod.rs
@@ -207,16 +207,6 @@ impl CallMeta {
                         meta.trace_sampled = Some(sampled);
                     }
 
-                    // If the caller is a gateway, ignore the parent span id and trace sampling
-                    // decision as gateways don't record a span. The endpoint will make its own
-                    // sampling decision instead.
-                    if let Some(internal) = &meta.internal {
-                        if matches!(internal.caller, Caller::Gateway { .. }) {
-                            meta.parent_span_id = None;
-                            meta.trace_sampled = None;
-                        }
-                    }
-
                     // Parse the trace state.
                     let tracestate = parse_tracestate(headers.meta_values(MetaKey::TraceState));
 
@@ -233,6 +223,14 @@ impl CallMeta {
                     // the traceparent header since it might be tampered by GCP infra.
                     if let Some(sampled) = tracestate.sampled {
                         meta.trace_sampled = Some(sampled);
+                    }
+
+                    // If the caller is a gateway, ignore the parent span id
+                    // as gateways don't record a span.
+                    if let Some(internal) = &meta.internal {
+                        if matches!(internal.caller, Caller::Gateway { .. }) {
+                            meta.parent_span_id = None;
+                        }
                     }
                 }
             }

--- a/runtimes/go/appruntime/apisdk/api/call_meta.go
+++ b/runtimes/go/appruntime/apisdk/api/call_meta.go
@@ -248,12 +248,6 @@ func (s *Server) MetaFromRequest(req transport.Transport) (meta CallMeta, err er
 		var sampledFromTraceParent bool
 		meta.TraceID, meta.ParentSpanID, sampledFromTraceParent, _ = parseTraceParent(traceParent)
 
-		// If the caller is a gateway, ignore the parent span id as gateways don't currently record a span.
-		// If we include it the root request won't be tagged as such.
-		if _, isGateway := meta.Internal.Caller.(GatewayCaller); isGateway {
-			meta.ParentSpanID = model.SpanID{}
-		}
-
 		// Default to the traceparent sampled flag.
 		meta.TraceSampled = sampledFromTraceParent
 
@@ -275,6 +269,13 @@ func (s *Server) MetaFromRequest(req transport.Transport) (meta CallMeta, err er
 			if sampledFromTraceState != nil {
 				meta.TraceSampled = *sampledFromTraceState
 			}
+		}
+
+		// If the caller is a gateway, ignore the parent span id as gateways
+		// don't record a span. We keep the trace sampling decision since the
+		// gateway already made the sampling decision.
+		if _, isGateway := meta.Internal.Caller.(GatewayCaller); isGateway {
+			meta.ParentSpanID = model.SpanID{}
 		}
 	}
 


### PR DESCRIPTION
The tracestate refactoring in 851a7159 caused the gateway's parent span ID to be restored from encore/span-id after it was already cleared, making the request non-root. Move the gateway check after tracestate parsing so it has final say on parent_span_id.