### PR TITLE
infracfg: handle disabled in tls_config

### DIFF
--- a/runtimes/core/src/infracfg.rs
+++ b/runtimes/core/src/infracfg.rs
@@ -693,18 +693,18 @@ pub fn map_infra_to_runtime(infra: InfraConfig) -> RuntimeConfig {
                         rid: get_next_rid(),
                         host: server.host,
                         kind: pbruntime::ServerKind::Primary as i32,
-                        tls_config: server.tls_config.map_or_else(
-                            || Some(TlsConfig::default()),
-                            |tls| match tls.disabled {
-                                true => None,
-                                false => Some(TlsConfig {
+                        tls_config: server.tls_config.and_then(|tls| {
+                            if tls.disabled {
+                                None
+                            } else {
+                                Some(TlsConfig {
                                     server_ca_cert: tls.ca,
                                     disable_tls_hostname_verification: tls
                                         .disable_tls_hostname_verification,
                                     disable_ca_validation: tls.disable_ca_validation,
-                                }),
-                            },
-                        ),
+                                })
+                            }
+                        }),
                     }],
                     databases,
                 }
@@ -772,18 +772,18 @@ pub fn map_infra_to_runtime(infra: InfraConfig) -> RuntimeConfig {
                         rid: String::new(), // Assign a unique RID
                         host: redis.host,
                         kind: pbruntime::ServerKind::Primary as i32,
-                        tls_config: redis.tls_config.map_or_else(
-                            || Some(TlsConfig::default()),
-                            |tls| match tls.disabled {
-                                true => None,
-                                false => Some(TlsConfig {
+                        tls_config: redis.tls_config.and_then(|tls| {
+                            if tls.disabled {
+                                None
+                            } else {
+                                Some(TlsConfig {
                                     server_ca_cert: tls.ca,
                                     disable_tls_hostname_verification: tls
                                         .disable_tls_hostname_verification,
                                     disable_ca_validation: tls.disable_ca_validation,
-                                }),
-                            },
-                        ),
+                                })
+                            }
+                        }),
                     }],
                     databases: vec![database],
                     in_memory: redis.in_memory,

--- a/runtimes/core/src/infracfg.rs
+++ b/runtimes/core/src/infracfg.rs
@@ -693,18 +693,18 @@ pub fn map_infra_to_runtime(infra: InfraConfig) -> RuntimeConfig {
                         rid: get_next_rid(),
                         host: server.host,
                         kind: pbruntime::ServerKind::Primary as i32,
-                        tls_config: server.tls_config.and_then(|tls| {
-                            if tls.disabled {
-                                None
-                            } else {
-                                Some(TlsConfig {
+                        tls_config: server.tls_config.map_or_else(
+                            || Some(TlsConfig::default()),
+                            |tls| match tls.disabled {
+                                true => None,
+                                false => Some(TlsConfig {
                                     server_ca_cert: tls.ca,
                                     disable_tls_hostname_verification: tls
                                         .disable_tls_hostname_verification,
                                     disable_ca_validation: tls.disable_ca_validation,
-                                })
-                            }
-                        }),
+                                }),
+                            },
+                        ),
                     }],
                     databases,
                 }
@@ -772,18 +772,18 @@ pub fn map_infra_to_runtime(infra: InfraConfig) -> RuntimeConfig {
                         rid: String::new(), // Assign a unique RID
                         host: redis.host,
                         kind: pbruntime::ServerKind::Primary as i32,
-                        tls_config: redis.tls_config.and_then(|tls| {
-                            if tls.disabled {
-                                None
-                            } else {
-                                Some(TlsConfig {
+                        tls_config: redis.tls_config.map_or_else(
+                            || Some(TlsConfig::default()),
+                            |tls| match tls.disabled {
+                                true => None,
+                                false => Some(TlsConfig {
                                     server_ca_cert: tls.ca,
                                     disable_tls_hostname_verification: tls
                                         .disable_tls_hostname_verification,
                                     disable_ca_validation: tls.disable_ca_validation,
-                                })
-                            }
-                        }),
+                                }),
+                            },
+                        ),
                     }],
                     databases: vec![database],
                     in_memory: redis.in_memory,

--- a/runtimes/go/appruntime/exported/config/infra/config.go
+++ b/runtimes/go/appruntime/exported/config/infra/config.go
@@ -471,6 +471,7 @@ func (s *SQLServer) Validate(v *validator) {
 }
 
 type TLSConfig struct {
+	Disabled                       bool        `json:"disabled,omitempty"`
 	CA                             string      `json:"ca,omitempty"`
 	ClientCert                     *ClientCert `json:"client_cert,omitempty"`
 	DisableTLSHostnameVerification bool        `json:"disable_tls_hostname_verification,omitempty"`

--- a/runtimes/go/appruntime/exported/config/parse.go
+++ b/runtimes/go/appruntime/exported/config/parse.go
@@ -232,7 +232,7 @@ func parseInfraConfigEnv(infraCfgPath string) *Runtime {
 		cfg.SQLServers[i] = &SQLServer{
 			Host: sqlServer.Host,
 		}
-		if sqlServer.TLSConfig != nil {
+		if sqlServer.TLSConfig != nil && !sqlServer.TLSConfig.Disabled {
 			cfg.SQLServers[i].ServerCACert = sqlServer.TLSConfig.CA
 			if sqlServer.TLSConfig.ClientCert != nil {
 				cfg.SQLServers[i].ClientCert = sqlServer.TLSConfig.ClientCert.Cert
@@ -261,7 +261,7 @@ func parseInfraConfigEnv(infraCfgPath string) *Runtime {
 			Host:     redis.Host,
 			InMemory: redis.InMemory,
 		}
-		if redis.TLSConfig != nil {
+		if redis.TLSConfig != nil && !redis.TLSConfig.Disabled {
 			cfg.RedisServers[i].EnableTLS = true
 			cfg.RedisServers[i].ServerCACert = redis.TLSConfig.CA
 			if redis.TLSConfig.ClientCert != nil {


### PR DESCRIPTION
This handles the disabled field from tls_config for sqldb and redis