### PR TITLE
healthz: add app_slug and env_name to response

### DIFF
--- a/runtimes/core/src/api/encore_routes/healthz.rs
+++ b/runtimes/core/src/api/encore_routes/healthz.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct Handler {
     pub app_revision: String,
     pub deploy_id: String,
+    pub app_slug: String,
+    pub env_name: String,
 }
 
 impl Handler {
@@ -15,6 +17,8 @@ impl Handler {
             code: "ok".into(),
             message: "Your Encore app is up and running!".into(),
             details: Details {
+                app_slug: self.app_slug,
+                env_name: self.env_name,
                 app_revision: self.app_revision,
                 encore_compiler: "".into(),
                 deploy_id: self.deploy_id,
@@ -45,6 +49,8 @@ pub struct Response {
 
 #[derive(Serialize, Deserialize)]
 pub struct Details {
+    pub app_slug: String,
+    pub env_name: String,
     pub app_revision: String,
     pub encore_compiler: String,
     pub deploy_id: String,

--- a/runtimes/core/src/api/manager.rs
+++ b/runtimes/core/src/api/manager.rs
@@ -104,6 +104,8 @@ impl ManagerConfig<'_> {
                 .strip_prefix("roll_")
                 .unwrap_or(&self.deploy_id)
                 .to_string(),
+            app_slug: self.environment.app_slug.clone(),
+            env_name: self.environment.env_name.clone(),
         };
 
         let hosted_services = Hosted::from_iter(self.hosted_services.into_iter().map(|s| s.name));

--- a/runtimes/go/appruntime/apisdk/api/encore_routes.go
+++ b/runtimes/go/appruntime/apisdk/api/encore_routes.go
@@ -54,12 +54,16 @@ func (s *Server) handleHealthz(w http.ResponseWriter, req *http.Request) {
 		Code:    statusStr,
 		Message: "Your Encore app is up and running!",
 		Details: struct {
+			AppSlug            string        `json:"app_slug"`
+			EnvName            string        `json:"env_name"`
 			AppRevision        string        `json:"app_revision"`
 			EncoreCompiler     string        `json:"encore_compiler"`
 			DeployId           string        `json:"deploy_id"`
 			Checks             []checkResult `json:"checks"`
 			EnabledExperiments []string      `json:"enabled_experiments"`
 		}{
+			AppSlug:            s.runtime.AppSlug,
+			EnvName:            s.runtime.EnvName,
 			AppRevision:        s.static.AppCommit.AsRevisionString(),
 			EncoreCompiler:     s.static.EncoreCompiler,
 			DeployId:           s.runtime.DeployID,

--- a/supervisor/src/proxy.rs
+++ b/supervisor/src/proxy.rs
@@ -32,6 +32,10 @@ pub struct HealthzResponse {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct HealthzDetails {
+    #[serde(default)]
+    pub app_slug: String,
+    #[serde(default)]
+    pub env_name: String,
     pub app_revision: String,
     pub encore_compiler: String,
     pub deploy_id: String,
@@ -102,6 +106,8 @@ impl GatewayProxy {
                     code: "unhealthy".to_string(),
                     message: "healhtcheck failed".to_string(),
                     details: HealthzDetails {
+                        app_slug: "".to_string(),
+                        env_name: "".to_string(),
                         app_revision: "".to_string(),
                         encore_compiler: "".to_string(),
                         deploy_id: "".to_string(),


### PR DESCRIPTION
## Summary
- Adds `app_slug` and `env_name` fields to the `__encore/healthz` endpoint response details across the Rust runtime, Go runtime, and supervisor proxy.
- The values are sourced from the runtime environment configuration.
- The supervisor proxy uses `#[serde(default)]` for backward compatibility when deserializing responses.