### PR TITLE
runtimes: auth handler sampling decision

### DIFF
--- a/runtimes/core/src/api/auth/remote.rs
+++ b/runtimes/core/src/api/auth/remote.rs
@@ -82,17 +82,10 @@ impl RemoteAuthHandler {
         let caller = Caller::APIEndpoint(EndpointName::new("gateway", "__encore/authhandler"));
 
         let meta = &req.call_meta;
-        // Always include the trace ID so traceparent is sent, even without a parent span.
-        // This ensures the tracestate (with the sampling decision) is read by the receiver,
-        // which is necessary on non-GCP environments where Cloud Run doesn't inject a traceparent.
-        let zero_span = crate::model::SpanId([0u8; 8]);
-        let parent_span = Some(
-            meta.trace_id
-                .with_span(meta.parent_span_id.unwrap_or(zero_span)),
-        );
         let desc: CallDesc<()> = CallDesc {
             caller: &caller,
-            parent_span,
+            trace_id: Some(meta.trace_id),
+            parent_span: meta.parent_span_id.map(|sp| meta.trace_id.with_span(sp)),
             parent_event_id: None,
             ext_correlation_id: meta
                 .ext_correlation_id

--- a/runtimes/core/src/api/auth/remote.rs
+++ b/runtimes/core/src/api/auth/remote.rs
@@ -82,9 +82,17 @@ impl RemoteAuthHandler {
         let caller = Caller::APIEndpoint(EndpointName::new("gateway", "__encore/authhandler"));
 
         let meta = &req.call_meta;
+        // Always include the trace ID so traceparent is sent, even without a parent span.
+        // This ensures the tracestate (with the sampling decision) is read by the receiver,
+        // which is necessary on non-GCP environments where Cloud Run doesn't inject a traceparent.
+        let zero_span = crate::model::SpanId([0u8; 8]);
+        let parent_span = Some(
+            meta.trace_id
+                .with_span(meta.parent_span_id.unwrap_or(zero_span)),
+        );
         let desc: CallDesc<()> = CallDesc {
             caller: &caller,
-            parent_span: meta.parent_span_id.map(|sp| meta.trace_id.with_span(sp)),
+            parent_span,
             parent_event_id: None,
             ext_correlation_id: meta
                 .ext_correlation_id

--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -15,7 +15,7 @@ use crate::api::reqauth::meta::MetaKey;
 use crate::api::reqauth::{service_auth_method, svcauth};
 use crate::api::schema::{JSONPayload, ToOutgoingRequest};
 use crate::api::{schema, APIResult, Endpoint, EndpointMap};
-use crate::model::{SpanKey, TraceEventId};
+use crate::model::{SpanId, SpanKey, TraceEventId, TraceId};
 use crate::names::EndpointName;
 use crate::trace::Tracer;
 use crate::{api, encore, model, secrets, EncoreName, Hosted};
@@ -479,6 +479,7 @@ impl ServiceRegistry {
         let desc = CallDesc {
             caller: &caller,
             svc_auth_method: svc_auth_method.as_ref(),
+            trace_id: source.map(|r| r.span.0),
             parent_span: source.map(|r| r.span),
             parent_event_id,
             ext_correlation_id: source.and_then(|r| {
@@ -500,6 +501,9 @@ impl ServiceRegistry {
 pub struct CallDesc<'a, AuthData> {
     pub caller: &'a Caller,
 
+    /// The trace ID for this call. Used to send the traceparent header
+    /// even when there is no parent span (e.g. remote auth handler calls).
+    pub trace_id: Option<TraceId>,
     pub parent_span: Option<SpanKey>,
     pub parent_event_id: Option<TraceEventId>,
     pub ext_correlation_id: Option<Cow<'a, str>>,
@@ -520,22 +524,26 @@ where
     pub fn add_meta<R: MetaMapMut>(self, headers: &mut R) -> anyhow::Result<()> {
         headers.set(MetaKey::Version, "1".to_string())?;
 
-        if let Some(span) = self.parent_span {
+        if let Some(trace_id) = self.trace_id {
+            // Send traceparent with the parent span ID if available, or zero.
+            let span_id = self.parent_span.map(|s| s.1).unwrap_or(SpanId([0u8; 8]));
+
             headers.set(
                 MetaKey::TraceParent,
                 format!(
                     "00-{}-{}-{}",
-                    span.0.serialize_std(),
-                    span.1.serialize_std(),
+                    trace_id.serialize_std(),
+                    span_id.serialize_std(),
                     if self.traced { "01" } else { "00" },
                 ),
             )?;
 
+            // Build tracestate with span-id (if non-zero), event-id, and sampled.
             let mut trace_state = String::new();
 
-            if !span.1.is_zero() {
+            if !span_id.is_zero() {
                 trace_state.push_str("encore/span-id=");
-                trace_state.push_str(&span.1.serialize_std());
+                trace_state.push_str(&span_id.serialize_std());
             }
 
             if let Some(event_id) = self.parent_event_id.map(|id| id.serialize()) {
@@ -546,7 +554,7 @@ where
                 trace_state.push_str(event_id.to_string().as_str());
             }
 
-            // Propagate our sampling decision via tracestate since GCP Cloud Run
+            // Always propagate our sampling decision via tracestate since GCP Cloud Run
             // can modify the traceparent sampled flag between services.
             if !trace_state.is_empty() {
                 trace_state.push(',');
@@ -555,14 +563,6 @@ where
             trace_state.push_str(if self.traced { "1" } else { "0" });
 
             headers.set(MetaKey::TraceState, trace_state)?;
-        } else {
-            // Even without a parent span, always propagate the sampling decision
-            // via tracestate. GCP Cloud Run can modify the traceparent sampled flag,
-            // so we need tracestate as the authoritative source.
-            headers.set(
-                MetaKey::TraceState,
-                format!("encore/sampled={}", if self.traced { "1" } else { "0" }),
-            )?;
         }
 
         if let Some(corr_id) = self.ext_correlation_id {

--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -531,16 +531,27 @@ where
                 ),
             )?;
 
-            let mut trace_state = format!("encore/span-id={}", span.1.serialize_std());
+            let mut trace_state = String::new();
+
+            if !span.1.is_zero() {
+                trace_state.push_str("encore/span-id=");
+                trace_state.push_str(&span.1.serialize_std());
+            }
 
             if let Some(event_id) = self.parent_event_id.map(|id| id.serialize()) {
-                trace_state.push_str(",encore/event-id=");
+                if !trace_state.is_empty() {
+                    trace_state.push(',');
+                }
+                trace_state.push_str("encore/event-id=");
                 trace_state.push_str(event_id.to_string().as_str());
             }
 
             // Propagate our sampling decision via tracestate since GCP Cloud Run
             // can modify the traceparent sampled flag between services.
-            trace_state.push_str(",encore/sampled=");
+            if !trace_state.is_empty() {
+                trace_state.push(',');
+            }
+            trace_state.push_str("encore/sampled=");
             trace_state.push_str(if self.traced { "1" } else { "0" });
 
             headers.set(MetaKey::TraceState, trace_state)?;

--- a/runtimes/core/src/api/call.rs
+++ b/runtimes/core/src/api/call.rs
@@ -544,10 +544,15 @@ where
             trace_state.push_str(if self.traced { "1" } else { "0" });
 
             headers.set(MetaKey::TraceState, trace_state)?;
+        } else {
+            // Even without a parent span, always propagate the sampling decision
+            // via tracestate. GCP Cloud Run can modify the traceparent sampled flag,
+            // so we need tracestate as the authoritative source.
+            headers.set(
+                MetaKey::TraceState,
+                format!("encore/sampled={}", if self.traced { "1" } else { "0" }),
+            )?;
         }
-
-        // TODO handle GCP span propagation with tracestate key.
-        // headers.set(MetaKey::TraceState, "")?;
 
         if let Some(corr_id) = self.ext_correlation_id {
             headers.set(MetaKey::XCorrelationId, corr_id.into_owned())?;

--- a/runtimes/core/src/api/gateway/mod.rs
+++ b/runtimes/core/src/api/gateway/mod.rs
@@ -451,6 +451,7 @@ impl ProxyHttp for Gateway {
             });
             let mut desc = CallDesc {
                 caller: &caller,
+                trace_id: Some(call_meta.trace_id),
                 parent_span: call_meta
                     .parent_span_id
                     .map(|sp| call_meta.trace_id.with_span(sp)),

--- a/runtimes/core/src/api/reqauth/mod.rs
+++ b/runtimes/core/src/api/reqauth/mod.rs
@@ -231,20 +231,17 @@ impl CallMeta {
 
                     // If the caller is a gateway, ignore the parent span id
                     // as gateways don't record a span.
-                    // Also clear for remote auth handler calls, which are
-                    // conceptually root requests from the gateway.
                     if let Some(internal) = &meta.internal {
-                        let clear_parent = match &internal.caller {
-                            Caller::Gateway { .. } => true,
-                            Caller::APIEndpoint(name) => {
-                                name.service() == "gateway"
-                                    && name.endpoint() == "__encore/authhandler"
-                            }
-                            _ => false,
-                        };
-                        if clear_parent {
+                        if matches!(internal.caller, Caller::Gateway { .. }) {
                             meta.parent_span_id = None;
                         }
+                    }
+
+                    // If this is an internal call but the tracestate didn't contain
+                    // encore/span-id, any parent_span_id from the traceparent was
+                    // injected by infrastructure (e.g. GCP Cloud Run), not by Encore.
+                    if meta.internal.is_some() && tracestate.span_id.is_none() {
+                        meta.parent_span_id = None;
                     }
                 }
             }

--- a/runtimes/core/src/api/reqauth/mod.rs
+++ b/runtimes/core/src/api/reqauth/mod.rs
@@ -203,7 +203,7 @@ impl CallMeta {
                     {
                         meta.trace_id = trace_id;
                         meta.caller_trace_id = Some(trace_id);
-                        meta.parent_span_id = Some(parent_span_id);
+                        meta.parent_span_id = parent_span_id;
                         meta.trace_sampled = Some(sampled);
                     }
 
@@ -254,7 +254,9 @@ impl CallMeta {
     }
 }
 
-fn parse_traceparent(s: &str) -> anyhow::Result<(model::TraceId, model::SpanId, bool)> {
+/// Parse a W3C traceparent header. Returns the trace ID, parent span ID (None if zero),
+/// and the sampled flag.
+fn parse_traceparent(s: &str) -> anyhow::Result<(model::TraceId, Option<model::SpanId>, bool)> {
     let version = "00";
     let trace_id_len = 32;
     let span_id_len = 16;
@@ -299,6 +301,11 @@ fn parse_traceparent(s: &str) -> anyhow::Result<(model::TraceId, model::SpanId, 
     let trace_flags = u8::from_str_radix(trace_flags, 16).context("invalid trace flags")?;
     let sampled = trace_flags & 0x01 != 0;
 
+    let span_id = if span_id.is_zero() {
+        None
+    } else {
+        Some(span_id)
+    };
     Ok((trace_id, span_id, sampled))
 }
 

--- a/runtimes/core/src/api/reqauth/mod.rs
+++ b/runtimes/core/src/api/reqauth/mod.rs
@@ -203,7 +203,11 @@ impl CallMeta {
                     {
                         meta.trace_id = trace_id;
                         meta.caller_trace_id = Some(trace_id);
-                        meta.parent_span_id = Some(parent_span_id);
+                        meta.parent_span_id = if parent_span_id.is_zero() {
+                            None
+                        } else {
+                            Some(parent_span_id)
+                        };
                         meta.trace_sampled = Some(sampled);
                     }
 

--- a/runtimes/core/src/api/reqauth/mod.rs
+++ b/runtimes/core/src/api/reqauth/mod.rs
@@ -203,11 +203,7 @@ impl CallMeta {
                     {
                         meta.trace_id = trace_id;
                         meta.caller_trace_id = Some(trace_id);
-                        meta.parent_span_id = if parent_span_id.is_zero() {
-                            None
-                        } else {
-                            Some(parent_span_id)
-                        };
+                        meta.parent_span_id = Some(parent_span_id);
                         meta.trace_sampled = Some(sampled);
                     }
 

--- a/runtimes/core/src/api/reqauth/mod.rs
+++ b/runtimes/core/src/api/reqauth/mod.rs
@@ -227,8 +227,18 @@ impl CallMeta {
 
                     // If the caller is a gateway, ignore the parent span id
                     // as gateways don't record a span.
+                    // Also clear for remote auth handler calls, which are
+                    // conceptually root requests from the gateway.
                     if let Some(internal) = &meta.internal {
-                        if matches!(internal.caller, Caller::Gateway { .. }) {
+                        let clear_parent = match &internal.caller {
+                            Caller::Gateway { .. } => true,
+                            Caller::APIEndpoint(name) => {
+                                name.service() == "gateway"
+                                    && name.endpoint() == "__encore/authhandler"
+                            }
+                            _ => false,
+                        };
+                        if clear_parent {
                             meta.parent_span_id = None;
                         }
                     }

--- a/runtimes/core/src/model/mod.rs
+++ b/runtimes/core/src/model/mod.rs
@@ -83,6 +83,10 @@ impl TraceId {
 pub struct InvalidBase32;
 
 impl SpanId {
+    pub fn is_zero(&self) -> bool {
+        self.0 == [0u8; 8]
+    }
+
     pub fn generate() -> Self {
         let mut span_id = [0u8; 8];
         rand::thread_rng().fill_bytes(&mut span_id);

--- a/runtimes/go/appruntime/apisdk/api/auth_remote.go
+++ b/runtimes/go/appruntime/apisdk/api/auth_remote.go
@@ -60,6 +60,9 @@ func (r *remoteAuthHandler) Authenticate(c IncomingContext) (model.AuthInfo, err
 		// also receive full marshalled errors back from the auth handler (as ApiCaller's are allowed PrivateAPIAccess)
 		Caller: ApiCaller{ServiceName: "gateway", Endpoint: "__encore/authhandler"},
 	}
+	// Use the endpoint's trace sampling decision (set in processRequest /
+	// createGatewayHandlerAdapter) so the remote auth handler inherits it.
+	meta.TraceSampled = c.callMeta.TraceSampled
 	if err := meta.AddToRequest(r.server, r.hostingService, transport.HTTPRequest(authReq)); err != nil {
 		r.logger.Err(err).Msg("unable to add call metadata to auth request")
 		return model.AuthInfo{}, errs.Wrap(err, "unable to add call metadata to auth request")
@@ -123,8 +126,12 @@ func (s *Server) handleRemoteAuthCall(w http.ResponseWriter, req *http.Request, 
 	// this is used for returnError to marshal the full error
 	originalC := s.NewIncomingContext(w, req, nil, meta)
 
-	// Remove the internal call metadata, so it doesn't get passed to the auth handler
+	// Remove the internal call metadata, so it doesn't get passed to the auth handler.
+	// Also clear the parent span ID since the auth handler is a root span —
+	// any parent span ID here is injected by infrastructure (e.g. GCP Cloud Run),
+	// not a real Encore parent span.
 	meta.Internal = nil
+	meta.ParentSpanID = model.SpanID{}
 
 	// Create a new IncomingContext
 	c := s.NewIncomingContext(w, req, nil, meta)

--- a/runtimes/go/appruntime/apisdk/api/call_meta.go
+++ b/runtimes/go/appruntime/apisdk/api/call_meta.go
@@ -146,6 +146,11 @@ func (meta CallMeta) AddToRequest(server *Server, targetService config.Service, 
 			} else {
 				req.SetMeta(transport.TraceStateKey, fmt.Sprintf("%s=%s,%s=%s", eventTraceStateEventIDKey, eventID, eventTraceStateSampledKey, sampledTS))
 			}
+		} else {
+			// Even without a parent span, always propagate the sampling decision
+			// via tracestate. GCP Cloud Run can modify the traceparent sampled flag,
+			// so we need tracestate as the authoritative source.
+			req.SetMeta(transport.TraceStateKey, fmt.Sprintf("%s=%s", eventTraceStateSampledKey, sampledTS))
 		}
 	}
 

--- a/runtimes/go/appruntime/apisdk/api/gateway.go
+++ b/runtimes/go/appruntime/apisdk/api/gateway.go
@@ -13,6 +13,7 @@ import (
 	"encore.dev/appruntime/apisdk/api/transport"
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/beta/errs"
+	"encore.dev/internal/platformauth"
 )
 
 // IsGateway returns true if this instance of the container is acting as an API
@@ -45,10 +46,17 @@ func (s *Server) createGatewayHandlerAdapter(h Handler) httprouter.Handle {
 
 		meta := CallMetaFromContext(req.Context())
 
+		// Pre-compute the endpoint's trace sampling decision.
+		// This is used by both the auth handler and the proxy to the target service.
+		meta.TraceSampled = s.shouldTrace(
+			h.ServiceName(), h.EndpointName(),
+			req.Header,
+			platformauth.IsEncorePlatformRequest(req.Context()),
+			meta.ParentSpanID.IsZero(),
+			meta.TraceSampled,
+		)
+
 		ic := s.NewIncomingContext(w, req, toUnnamedParams(ps), meta)
-		traced := s.endpointTraceSampled(h, ic)
-		ic.callMeta.TraceSampled = traced
-		meta.TraceSampled = traced // also update for the proxy's AddToRequest
 		info, proceed := s.runAuthHandler(h, ic)
 		if proceed {
 			meta.Internal = &InternalCallMeta{

--- a/runtimes/go/appruntime/apisdk/api/gateway.go
+++ b/runtimes/go/appruntime/apisdk/api/gateway.go
@@ -45,7 +45,11 @@ func (s *Server) createGatewayHandlerAdapter(h Handler) httprouter.Handle {
 
 		meta := CallMetaFromContext(req.Context())
 
-		info, proceed := s.runAuthHandler(h, s.NewIncomingContext(w, req, toUnnamedParams(ps), meta))
+		ic := s.NewIncomingContext(w, req, toUnnamedParams(ps), meta)
+		traced := s.endpointTraceSampled(h, ic)
+		ic.callMeta.TraceSampled = traced
+		meta.TraceSampled = traced // also update for the proxy's AddToRequest
+		info, proceed := s.runAuthHandler(h, ic)
 		if proceed {
 			meta.Internal = &InternalCallMeta{
 				Caller: GatewayCaller{

--- a/runtimes/go/appruntime/apisdk/api/handler.go
+++ b/runtimes/go/appruntime/apisdk/api/handler.go
@@ -275,9 +275,10 @@ func (d *Desc[Req, Resp]) begin(c IncomingContext) (reqData Req, beginErr error)
 			ServiceToServiceCall: c.callMeta.IsServiceToService(),
 		},
 
-		ExtRequestID:        clampTo64Chars(c.req.Header.Get("X-Request-ID")),
-		ExtCorrelationID:    clampTo64Chars(c.req.Header.Get("X-Correlation-ID")),
-		AdditionalLogFields: cloudtrace.StructuredLogFields(c.req),
+		ExtRequestID:            clampTo64Chars(c.req.Header.Get("X-Request-ID")),
+		ExtCorrelationID:        clampTo64Chars(c.req.Header.Get("X-Correlation-ID")),
+		AdditionalLogFields:     cloudtrace.StructuredLogFields(c.req),
+		TraceSampledPrecomputed: c.traceSampledPrecomputed,
 	})
 	if err != nil {
 		beginErr = errs.B().Code(errs.Internal).Msg("internal error").Err()

--- a/runtimes/go/appruntime/apisdk/api/reqtrack.go
+++ b/runtimes/go/appruntime/apisdk/api/reqtrack.go
@@ -64,6 +64,12 @@ type beginRequestParams struct {
 	// This is mainly used to add the trace identifiers to the log messages
 	// so the clouds logging can correlate the logs with the trace.
 	AdditionalLogFields map[string]string
+
+	// TraceSampledPrecomputed indicates that ParentSampled was pre-computed
+	// by processRequest and should be used as-is, skipping the normal
+	// sampling logic. This ensures the auth handler and endpoint handler
+	// use the exact same sampling decision.
+	TraceSampledPrecomputed bool
 }
 
 // shouldTrace determines whether a request should be traced based on the
@@ -98,9 +104,9 @@ func (s *Server) beginRequest(ctx context.Context, p *beginRequestParams) (*mode
 	}
 
 	var traced bool
-	if p.Type == model.AuthHandler {
-		// Auth handlers inherit the trace sampling decision from the caller,
-		// which is set to the target endpoint's decision by processRequest.
+	if p.Type == model.AuthHandler || p.TraceSampledPrecomputed {
+		// Use the pre-computed sampling decision from processRequest.
+		// This ensures the auth handler and endpoint use the same decision.
 		traced = p.ParentSampled
 	} else {
 		traced = s.shouldTrace(

--- a/runtimes/go/appruntime/apisdk/api/reqtrack.go
+++ b/runtimes/go/appruntime/apisdk/api/reqtrack.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"sync/atomic"
 	"time"
@@ -65,6 +66,18 @@ type beginRequestParams struct {
 	AdditionalLogFields map[string]string
 }
 
+// shouldTrace determines whether a request should be traced based on the
+// platform auth status, cron scheduling, parent span, and sampling config.
+func (s *Server) shouldTrace(service, endpoint string, headers http.Header, fromPlatform, isRoot bool, parentSampled bool) bool {
+	isCronScheduled := headers.Get("X-Encore-Cron-Trigger") == "scheduled"
+	if fromPlatform && !isCronScheduled {
+		return true
+	} else if isRoot {
+		return s.rt.SampleTrace(service, endpoint)
+	}
+	return parentSampled
+}
+
 func (s *Server) beginRequest(ctx context.Context, p *beginRequestParams) (*model.Request, error) {
 	traceID := p.TraceID
 	if traceID.IsZero() {
@@ -84,15 +97,19 @@ func (s *Server) beginRequest(ctx context.Context, p *beginRequestParams) (*mode
 		spanID = id
 	}
 
-	isCronScheduled := p.Data.RequestHeaders.Get("X-Encore-Cron-Trigger") == "scheduled"
-
 	var traced bool
-	if p.Data.FromEncorePlatform && !isCronScheduled {
-		traced = true
-	} else if p.ParentSpanID.IsZero() {
-		traced = s.rt.SampleTrace(p.Data.Desc.Service, p.Data.Desc.Endpoint)
-	} else {
+	if p.Type == model.AuthHandler {
+		// Auth handlers inherit the trace sampling decision from the caller,
+		// which is set to the target endpoint's decision by processRequest.
 		traced = p.ParentSampled
+	} else {
+		traced = s.shouldTrace(
+			p.Data.Desc.Service, p.Data.Desc.Endpoint,
+			p.Data.RequestHeaders,
+			p.Data.FromEncorePlatform,
+			p.ParentSpanID.IsZero(),
+			p.ParentSampled,
+		)
 	}
 
 	req := &model.Request{

--- a/runtimes/go/appruntime/apisdk/api/server.go
+++ b/runtimes/go/appruntime/apisdk/api/server.go
@@ -72,6 +72,11 @@ type execContext struct {
 	auth   model.AuthInfo
 
 	callMeta CallMeta
+
+	// traceSampledPrecomputed is true when callMeta.TraceSampled has been
+	// pre-computed by processRequest. When set, beginRequest uses it directly
+	// instead of re-evaluating the sampling decision.
+	traceSampledPrecomputed bool
 }
 
 type IncomingContext struct {
@@ -558,7 +563,7 @@ func (s *Server) newExecContext(ctx context.Context, ps UnnamedParams, callMeta 
 			UserData: callMeta.Internal.AuthData,
 		}
 	}
-	return execContext{s, ctx, ps, auth, callMeta}
+	return execContext{s, ctx, ps, auth, callMeta, false}
 }
 
 func (s *Server) NewIncomingContext(w http.ResponseWriter, req *http.Request, ps UnnamedParams, callMeta CallMeta) IncomingContext {

--- a/runtimes/go/appruntime/apisdk/api/services.go
+++ b/runtimes/go/appruntime/apisdk/api/services.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+
+	"encore.dev/internal/platformauth"
 )
 
 func (s *Server) createServiceHandlerAdapter(h Handler) httprouter.Handle {
@@ -45,9 +47,27 @@ func (s *Server) processRequest(h Handler, c IncomingContext) {
 	c.server.beginOperation()
 	defer c.server.finishOperation()
 
+	// Pre-compute the endpoint's trace sampling decision and store it in
+	// callMeta.TraceSampled. The auth handler uses this (via ParentSampled)
+	// instead of making its own sampling decision, which would use the auth
+	// handler's endpoint name and typically fall through to the default rate.
+	c.callMeta.TraceSampled = s.endpointTraceSampled(h, c)
+
 	info, proceed := s.runAuthHandler(h, c)
 	if proceed {
 		c.auth = info
 		h.Handle(c)
 	}
+}
+
+// endpointTraceSampled computes the trace sampling decision for the
+// given endpoint handler, using the same logic as beginRequest.
+func (s *Server) endpointTraceSampled(h Handler, c IncomingContext) bool {
+	return s.shouldTrace(
+		h.ServiceName(), h.EndpointName(),
+		c.req.Header,
+		platformauth.IsEncorePlatformRequest(c.req.Context()),
+		c.callMeta.ParentSpanID.IsZero(),
+		c.callMeta.TraceSampled,
+	)
 }

--- a/runtimes/go/appruntime/apisdk/api/services.go
+++ b/runtimes/go/appruntime/apisdk/api/services.go
@@ -52,6 +52,7 @@ func (s *Server) processRequest(h Handler, c IncomingContext) {
 	// instead of making its own sampling decision, which would use the auth
 	// handler's endpoint name and typically fall through to the default rate.
 	c.callMeta.TraceSampled = s.endpointTraceSampled(h, c)
+	c.traceSampledPrecomputed = true
 
 	info, proceed := s.runAuthHandler(h, c)
 	if proceed {
@@ -63,6 +64,14 @@ func (s *Server) processRequest(h Handler, c IncomingContext) {
 // endpointTraceSampled computes the trace sampling decision for the
 // given endpoint handler, using the same logic as beginRequest.
 func (s *Server) endpointTraceSampled(h Handler, c IncomingContext) bool {
+	// If the request was forwarded by a gateway, the gateway already made the
+	// sampling decision and propagated it via tracestate. Use it directly
+	// instead of re-evaluating, so the auth handler and endpoint agree.
+	if c.callMeta.Internal != nil {
+		if _, ok := c.callMeta.Internal.Caller.(GatewayCaller); ok {
+			return c.callMeta.TraceSampled
+		}
+	}
 	return s.shouldTrace(
 		h.ServiceName(), h.EndpointName(),
 		c.req.Header,


### PR DESCRIPTION
Fixes the go local auth handler so that it uses the same trace sampling decision as from the endpoint. The same with remote auth handlers for both core and go runtime (though we dont actually use the remote auth handler in core)