### PR TITLE
feat(sqldb): support ENCORE_DOCKER_NETWORK env var

### DIFF
--- a/cli/daemon/sqldb/docker/docker.go
+++ b/cli/daemon/sqldb/docker/docker.go
@@ -140,6 +140,9 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 			"-e", "PGDATA=" + defaultDataDir,
 			"--name", cnames[0],
 		}
+		if net := os.Getenv("ENCORE_DOCKER_NETWORK"); net != "" {
+			args = append(args, "--network", net)
+		}
 		if p.Memfs {
 			args = append(args,
 				"--mount", "type=tmpfs,destination="+defaultDataDir,


### PR DESCRIPTION
## Summary

- Pass `--network` to `docker run` when `ENCORE_DOCKER_NETWORK` is set
- Fixes #2382: Postgres containers are unreachable in Google Cloud Build, where build steps run on the `cloudbuild` Docker network

## Usage

```yaml
# Google Cloud Build
- id: test
  name: my-builder-image
  env:
    - ENCORE_DOCKER_NETWORK=cloudbuild
  args: [-c, encore test ./...]
```