### PR TITLE
Fix option value marshalling

### DIFF
--- a/pkg/option/option.go
+++ b/pkg/option/option.go
@@ -21,7 +21,7 @@ type Option[T any] struct {
 	present bool
 }
 
-func (o *Option[T]) MarshalJSON() ([]byte, error) {
+func (o Option[T]) MarshalJSON() ([]byte, error) {
 	if !o.present {
 		return []byte("null"), nil
 	}


### PR DESCRIPTION
MarshalJSON was registered as a pointer receiver which made json marshal values as '{}'
