### PR TITLE
runtimes/js: rawHeaders should contain names and values

### DIFF
--- a/runtimes/js/encore.dev/internal/api/node_http.ts
+++ b/runtimes/js/encore.dev/internal/api/node_http.ts
@@ -79,7 +79,18 @@ export class RawRequest extends stream.Readable {
       return this._rawHeaders;
     }
 
-    this._rawHeaders = Object.keys(this.headers);
+    const result: string[] = [];
+    const headers = this.headers;
+    for (const [key, value] of Object.entries(headers)) {
+      if (Array.isArray(value)) {
+        for (const v of value) {
+          result.push(key, v);
+        }
+      } else if (value !== undefined) {
+        result.push(key, value);
+      }
+    }
+    this._rawHeaders = result;
     return this._rawHeaders;
   }
 


### PR DESCRIPTION
Fixes #2379