### PR TITLE
cli: make test Postgres connection limits configurable

### DIFF
--- a/cli/daemon/run/infra/infra.go
+++ b/cli/daemon/run/infra/infra.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -295,9 +296,20 @@ func (rm *ResourceManager) UpdateConfig(cfg *config.Runtime, md *meta.Data, dbPr
 			})
 		}
 
-		// Configure max connections based on 96 connections
-		// divided evenly among the databases
-		maxConns := 96 / len(cfg.SQLDatabases)
+		// Configure max connections as a total budget divided evenly among
+		// the databases. Defaults to 96 (leaving headroom below Postgres's
+		// default server-side max_connections of 100). Override with
+		// ENCORE_SQLDB_POOL_SIZE — typically paired with a raised
+		// ENCORE_SQLDB_MAX_CONNECTIONS so the server can actually accept them.
+		totalPoolBudget := 96
+		if v := os.Getenv("ENCORE_SQLDB_POOL_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				totalPoolBudget = n
+			} else {
+				log.Warn().Str("value", v).Msg("ignoring invalid ENCORE_SQLDB_POOL_SIZE; expected positive integer")
+			}
+		}
+		maxConns := max(totalPoolBudget/len(cfg.SQLDatabases), 1)
 		for _, db := range cfg.SQLDatabases {
 			db.MaxConnections = maxConns
 		}

--- a/cli/daemon/run/infra/infra.go
+++ b/cli/daemon/run/infra/infra.go
@@ -3,6 +3,7 @@ package infra
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"sync"
@@ -296,20 +297,9 @@ func (rm *ResourceManager) UpdateConfig(cfg *config.Runtime, md *meta.Data, dbPr
 			})
 		}
 
-		// Configure max connections as a total budget divided evenly among
-		// the databases. Defaults to 96 (leaving headroom below Postgres's
-		// default server-side max_connections of 100). Override with
-		// ENCORE_SQLDB_POOL_SIZE — typically paired with a raised
-		// ENCORE_SQLDB_MAX_CONNECTIONS so the server can actually accept them.
-		totalPoolBudget := 96
-		if v := os.Getenv("ENCORE_SQLDB_POOL_SIZE"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				totalPoolBudget = n
-			} else {
-				log.Warn().Str("value", v).Msg("ignoring invalid ENCORE_SQLDB_POOL_SIZE; expected positive integer")
-			}
-		}
-		maxConns := max(totalPoolBudget/len(cfg.SQLDatabases), 1)
+		// Configure max connections based on 96 connections
+		// divided evenly among the databases
+		maxConns := 96 / len(cfg.SQLDatabases)
 		for _, db := range cfg.SQLDatabases {
 			db.MaxConnections = maxConns
 		}
@@ -412,6 +402,38 @@ func (rm *ResourceManager) SQLDatabaseConfig(db *meta.SQLDatabase) (config.SQLDa
 	}
 
 	return dbCfg, nil
+}
+
+// defaultSQLPoolBudget is the total pgx connection budget shared across
+// the databases in a locally-managed Postgres cluster. It leaves headroom
+// below Postgres's default server-side max_connections of 100 for admin
+// and replication slots.
+const defaultSQLPoolBudget = 96
+
+// SQLDatabaseMaxConnections returns the per-database pgx MaxConns to use
+// for a locally-managed Postgres cluster hosting numLocalDBs databases.
+//
+// Reads ENCORE_SQLDB_POOL_BUDGET to override the total budget; falls back
+// to defaultSQLPoolBudget. The env var is read on every call, but the
+// daemon's environment is frozen at daemon startup — so setting the var
+// in the shell that spawns the daemon is what matters; changing it
+// afterwards requires restarting the daemon to take effect.
+//
+// The result is clamped to int32 to match the SQLConnectionPool proto
+// field on the consuming side.
+func (rm *ResourceManager) SQLDatabaseMaxConnections(numLocalDBs int) int {
+	if numLocalDBs <= 0 {
+		return 0
+	}
+	budget := defaultSQLPoolBudget
+	if v := os.Getenv("ENCORE_SQLDB_POOL_BUDGET"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			budget = n
+		} else {
+			rm.log.Warn().Str("value", v).Msg("ignoring invalid ENCORE_SQLDB_POOL_BUDGET; expected positive integer")
+		}
+	}
+	return min(max(budget/numLocalDBs, 1), math.MaxInt32)
 }
 
 // PubSubProviderConfig returns the PubSub provider configuration.

--- a/cli/daemon/run/infra/infra_test.go
+++ b/cli/daemon/run/infra/infra_test.go
@@ -1,0 +1,43 @@
+package infra
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestSQLDatabaseMaxConnections(t *testing.T) {
+	rm := &ResourceManager{log: zerolog.Nop()}
+
+	tests := []struct {
+		name    string
+		envVar  string
+		numDBs  int
+		wantVal int
+	}{
+		{name: "default budget, one db", numDBs: 1, wantVal: 96},
+		{name: "default budget, three dbs", numDBs: 3, wantVal: 32},
+		{name: "default budget, six dbs", numDBs: 6, wantVal: 16},
+		{name: "default budget, zero dbs returns zero", numDBs: 0, wantVal: 0},
+		{name: "default budget, negative dbs returns zero", numDBs: -1, wantVal: 0},
+		{name: "default budget floors at 1 when many dbs", numDBs: 200, wantVal: 1},
+		{name: "custom budget", envVar: "400", numDBs: 10, wantVal: 40},
+		{name: "custom budget floors at 1", envVar: "2", numDBs: 10, wantVal: 1},
+		{name: "invalid env var falls back to default", envVar: "not-a-number", numDBs: 4, wantVal: 24},
+		{name: "zero env var falls back to default", envVar: "0", numDBs: 4, wantVal: 24},
+		{name: "negative env var falls back to default", envVar: "-5", numDBs: 4, wantVal: 24},
+		{name: "budget larger than int32 max clamps to int32 max", envVar: strconv.Itoa(math.MaxInt32 + 1000), numDBs: 1, wantVal: math.MaxInt32},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENCORE_SQLDB_POOL_BUDGET", tc.envVar)
+			if got := rm.SQLDatabaseMaxConnections(tc.numDBs); got != tc.wantVal {
+				t.Fatalf("SQLDatabaseMaxConnections(%d) with env=%q = %d, want %d",
+					tc.numDBs, tc.envVar, got, tc.wantVal)
+			}
+		})
+	}
+}

--- a/cli/daemon/run/runtime_config2.go
+++ b/cli/daemon/run/runtime_config2.go
@@ -63,6 +63,7 @@ type RuntimeConfigGenerator struct {
 		PubSubProviderConfig() (config.PubsubProvider, error)
 
 		SQLDatabaseConfig(db *meta.SQLDatabase) (config.SQLDatabase, error)
+		SQLDatabaseMaxConnections(numLocalDBs int) int
 		PubSubTopicConfig(topic *meta.PubSubTopic) (config.PubsubProvider, config.PubsubTopic, error)
 		PubSubSubscriptionConfig(topic *meta.PubSubTopic, sub *meta.PubSubTopic_Subscription) (config.PubsubSubscription, error)
 		RedisConfig(redis *meta.CacheCluster) (config.RedisServer, config.RedisDatabase, error)
@@ -306,6 +307,18 @@ func (g *RuntimeConfigGenerator) initialize() error {
 				TlsConfig: tlsConfig,
 			})
 
+			// Count databases hosted by the locally-managed cluster so the
+			// shared pgx connection budget (see infra.SQLDatabaseMaxConnections)
+			// can be divided evenly among them. External databases connect to
+			// their own Postgres servers and aren't subject to the local budget.
+			numLocalDBs := 0
+			for _, db := range g.md.SqlDatabases {
+				if _, external := g.DefinedSecrets["sqldb::"+db.Name]; !external {
+					numLocalDBs++
+				}
+			}
+			localMaxConns := g.infraManager.SQLDatabaseMaxConnections(numLocalDBs)
+
 			for _, db := range g.md.SqlDatabases {
 				if externalDB, ok := g.DefinedSecrets["sqldb::"+db.Name]; ok {
 					var extCfg struct {
@@ -362,6 +375,10 @@ func (g *RuntimeConfigGenerator) initialize() error {
 						Password:      toSecret([]byte(dbConfig.Password)),
 						ClientCertRid: nil,
 					})
+					maxConns := int32(dbConfig.MaxConnections)
+					if maxConns == 0 {
+						maxConns = int32(localMaxConns)
+					}
 					cluster.SQLDatabase(&runtimev1.SQLDatabase{
 						Rid:        newRid(),
 						EncoreName: dbConfig.EncoreName,
@@ -371,7 +388,7 @@ func (g *RuntimeConfigGenerator) initialize() error {
 						IsReadonly:     false,
 						RoleRid:        roleRid,
 						MinConnections: int32(dbConfig.MinConnections),
-						MaxConnections: int32(dbConfig.MaxConnections),
+						MaxConnections: maxConns,
 					})
 
 				}

--- a/cli/daemon/sqldb/docker/docker.go
+++ b/cli/daemon/sqldb/docker/docker.go
@@ -159,8 +159,10 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 
 		// Allow CI / power users to raise the Postgres server's max_connections
 		// ceiling above its default (100). Only applied when creating a fresh
-		// container — `docker start` on an existing container reuses its original
-		// args, so changing this value locally requires `docker rm` first.
+		// container — the daemon is long-lived and `docker start` on an existing
+		// container reuses its original args. To pick up a new value locally,
+		// stop the daemon and `docker rm` the encore-pg container so the next
+		// run creates a fresh one.
 		if v := os.Getenv("ENCORE_SQLDB_MAX_CONNECTIONS"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				args = append(args, "-c", "max_connections="+strconv.Itoa(n))

--- a/cli/daemon/sqldb/docker/docker.go
+++ b/cli/daemon/sqldb/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -154,6 +155,18 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 			args = append(args,
 				"-v", fmt.Sprintf("%s:%s", volumeName, defaultDataDir),
 				Image)
+		}
+
+		// Allow CI / power users to raise the Postgres server's max_connections
+		// ceiling above its default (100). Only applied when creating a fresh
+		// container — `docker start` on an existing container reuses its original
+		// args, so changing this value locally requires `docker rm` first.
+		if v := os.Getenv("ENCORE_SQLDB_MAX_CONNECTIONS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				args = append(args, "-c", "max_connections="+strconv.Itoa(n))
+			} else {
+				log.Warn().Str("value", v).Msg("ignoring invalid ENCORE_SQLDB_MAX_CONNECTIONS; expected positive integer")
+			}
 		}
 
 		cmd := exec.CommandContext(ctx, "docker", args...)


### PR DESCRIPTION
## Summary

Adds two env vars, read at cluster creation time by the Encore daemon, so CI runners aren't capped by hardcoded defaults when running many parallel test packages:

- **`ENCORE_SQLDB_MAX_CONNECTIONS`** — passed to the Postgres container as `-c max_connections=N` on creation. Lifts the server-side cap above Postgres's default of 100.
- **`ENCORE_SQLDB_POOL_BUDGET`** — total pgx connection budget divided evenly across the local-cluster's databases. Replaces the effective runtime default (pgx's internal 30 per pool) with a configurable total-budget-divided-by-N.

Both default to current behaviour when unset — no migration needed.

## Motivation

On CI runners with significant CPU/memory headroom, `encore test -p=N ./...` trips `SQLSTATE 53300` (too many connections) long before the hardware is saturated. The Postgres container launches with stock `max_connections=100`, and the live runtime-config path (`RuntimeConfigGenerator.initialize` → `SQLDatabaseConfig`) returns `MaxConnections=0`, so the Go runtime falls back to pgx's default of 30 per pool — each service eating a 30-conn slice of a 100-conn server.

(Note: `ResourceManager.UpdateConfig` in `infra.go` still contains a `96/N` heuristic, but it's dead code — `Manager.generateConfig` has zero callers. Out of scope for this PR; leaving it for a follow-up cleanup.)

## Design notes

- **Two independent knobs.** The client-side pool budget is bounded above by the server's `max_connections`, so CI generally sets them together (e.g. `ENCORE_SQLDB_MAX_CONNECTIONS=500 ENCORE_SQLDB_POOL_BUDGET=480`). Keeping them as separate vars avoids hard-coding a server-vs-client ratio.
- **Env vars, not a CLI flag.** `cli/cmd/encore/test.go` uses `DisableFlagParsing` and forwards everything to `go test`. Threading a new flag would mean touching the `daemonpb.TestRequest` proto + daemon + driver plumbing. Env vars read at the edges match the existing `ENCORE_SQLDB_HOST/DATABASE/USER/PASSWORD` family in `cli/cmd/encore/daemon/daemon.go` and are trivial to set in CI.
- **Override semantics.** The budget is applied in `runtime_config2.go` only when `SQLDatabaseConfig()` returned `MaxConnections=0`, so a future explicit per-DB override still wins.
- **int32 clamp.** `ENCORE_SQLDB_POOL_BUDGET` parses to a Go `int` but the proto field is `int32`; the helper clamps before returning to avoid silent wrap on pathological inputs.
- **Daemon-lifetime caveat.** The daemon's environment is frozen at startup; changing the env var in a later shell requires restarting the daemon. `ENCORE_SQLDB_MAX_CONNECTIONS` additionally only takes effect on a fresh container — `docker start` reuses an existing container's args. Fine for ephemeral CI runners; flagged in code comments for local dev.

## Code layout

- `cli/daemon/run/infra/infra.go`: new helper `SQLDatabaseMaxConnections(numLocalDBs int) int` alongside `SQLDatabaseConfig`.
- `cli/daemon/run/runtime_config2.go`: adds the helper to the `infraManager` interface; counts local (non-external) DBs once in `initialize()`; applies the per-DB cap at the `SQLConnectionPool` construction site.
- `cli/daemon/sqldb/docker/docker.go`: appends `-c max_connections=N` to the `docker run` args when the env var is set.
- `cli/daemon/run/infra/infra_test.go`: table-driven tests covering defaults, custom budgets, floor-at-1, zero/negative counts, invalid env values, and int32 overflow clamping.

## Example usage

```bash
ENCORE_SQLDB_MAX_CONNECTIONS=500 \
ENCORE_SQLDB_POOL_BUDGET=480 \
encore test -p=8 ./...
```

## Local verification

Confirmed end-to-end with a three-service sample app:

| Scenario | Docker args | `SHOW max_connections` | Per-DB pool |
|---|---|---|---|
| Both env vars set | `-c fsync=off -c max_connections=500` | `500` | `160` (= 480/3) |
| Both env vars unset | `-c fsync=off` | `100` | `32` (= 96/3) |

Unit tests: 12 cases pass (`go test ./cli/daemon/run/infra/...`).

## Test plan

- [x] `go build ./cli/...` passes
- [x] `go test ./cli/daemon/run/... ./cli/daemon/sqldb/...` passes
- [x] End-to-end verified via `docker inspect` and `psql SHOW max_connections` on a 3-service sample app
- [x] Defaults preserved when env vars unset (byte-identical emitted args)
- [x] `rm.log` used for warnings (carries `app_id` context, matching file conventions)

## Notes for reviewers

1. The existing `96/N` heuristic in `ResourceManager.UpdateConfig` is dead code. Happy to remove it in a follow-up if desired.
2. The `external` detection (`g.DefinedSecrets["sqldb::"+db.Name]`) is duplicated just to count local DBs. There's no existing helper in the `run` layer; `cluster`-side `IsExternalDB` uses the same `sqldb::` secret-membership check. Can extract into a small helper if preferred.