### PR TITLE
Add an opt out boolean for date reviver in TS Api client generation

### DIFF
--- a/pkg/clientgen/testdata/tsapp/expected_list_of_union_shared.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_list_of_union_shared.ts
@@ -77,6 +77,11 @@ export interface ClientOptions {
 
     /** Default RequestInit to be used for the client */
     requestInit?: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
+    /**
+     * Disables the automatic conversion of date strings to Date objects in API responses.
+     * When true, date strings are left as strings.
+     */
+    disableDateReviver?: boolean
 }
 
 /**
@@ -244,10 +249,10 @@ export class StreamInOut<Request, Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            this.buffer.push(JSON.parse(event.data, dateReviver));
+            this.buffer.push(JSON.parse(event.data, reviver));
             this.socket.resolveHasUpdateHandlers();
         });
     }
@@ -288,10 +293,10 @@ export class StreamIn<Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            this.buffer.push(JSON.parse(event.data, dateReviver));
+            this.buffer.push(JSON.parse(event.data, reviver));
             this.socket.resolveHasUpdateHandlers();
         });
     }
@@ -321,13 +326,13 @@ export class StreamOut<Request, Response> {
     public socket: WebSocketConnection;
     private responseValue: Promise<Response>;
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         let responseResolver: (_: any) => void;
         this.responseValue = new Promise((resolve) => responseResolver = resolve);
 
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            responseResolver(JSON.parse(event.data, dateReviver))
+            responseResolver(JSON.parse(event.data, reviver))
         });
     }
 
@@ -370,6 +375,7 @@ class BaseClient {
     readonly fetcher: Fetcher
     readonly headers: Record<string, string>
     readonly requestInit: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
+    readonly reviver: ((key: string, value: any) => any) | undefined
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
@@ -389,6 +395,7 @@ class BaseClient {
         } else {
             this.fetcher = boundFetch
         }
+        this.reviver = options.disableDateReviver ? undefined : dateReviver
     }
 
     async getAuthData(): Promise<CallParameters | undefined> {
@@ -413,7 +420,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers);
+        return new StreamInOut(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
@@ -434,7 +441,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers);
+        return new StreamIn(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
@@ -455,7 +462,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers);
+        return new StreamOut(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // callTypedAPI makes an API call, defaulting content type to "application/json"

--- a/pkg/clientgen/testdata/tsapp/expected_list_of_union_shared.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_list_of_union_shared.ts
@@ -78,10 +78,21 @@ export interface ClientOptions {
     /** Default RequestInit to be used for the client */
     requestInit?: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
     /**
-     * Disables the automatic conversion of date strings to Date objects in API responses.
-     * When true, date strings are left as strings.
+     * Overrides or disables the built-in date reviver for all API calls.
+     * Pass a custom function to use instead, or false to disable date parsing entirely.
      */
-    disableDateReviver?: boolean
+    dateReviver?: ((key: string, value: any) => any) | false
+}
+
+/**
+ * CallOptions allows you to override per-call behaviour within the generated Encore client.
+ */
+export interface CallOptions {
+    /**
+     * Overrides the date reviver for this specific call.
+     * Pass a custom function to transform date strings, or false to disable date parsing.
+     */
+    dateReviver?: ((key: string, value: any) => any) | false
 }
 
 /**
@@ -395,7 +406,7 @@ class BaseClient {
         } else {
             this.fetcher = boundFetch
         }
-        this.reviver = options.disableDateReviver ? undefined : dateReviver
+        this.reviver = options.dateReviver === false ? undefined : (options.dateReviver ?? dateReviver)
     }
 
     async getAuthData(): Promise<CallParameters | undefined> {
@@ -403,7 +414,7 @@ class BaseClient {
     }
 
     // createStreamInOut sets up a stream to a streaming API endpoint.
-    async createStreamInOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamInOut<Request, Response>> {
+    async createStreamInOut<Request, Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamInOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -420,11 +431,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamInOut(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
-    async createStreamIn<Response>(path: string, params?: CallParameters): Promise<StreamIn<Response>> {
+    async createStreamIn<Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamIn<Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -441,11 +452,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamIn(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
-    async createStreamOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamOut<Request, Response>> {
+    async createStreamOut<Request, Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -462,7 +473,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamOut(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // callTypedAPI makes an API call, defaulting content type to "application/json"

--- a/pkg/clientgen/testdata/tsapp/expected_shared.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_shared.ts
@@ -89,6 +89,11 @@ export interface ClientOptions {
      * a function which returns a new object for each request.
      */
     auth?: RequestType<typeof auth_auth> | AuthDataGenerator
+    /**
+     * Disables the automatic conversion of date strings to Date objects in API responses.
+     * When true, date strings are left as strings.
+     */
+    disableDateReviver?: boolean
 }
 
 /**
@@ -147,13 +152,13 @@ export namespace svc {
 
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/cookie-dummy`, {headers, query, method: "POST", body: JSON.stringify(body)})
-            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_svc_svc_cookieDummy>
+            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_cookieDummy>
         }
 
         public async cookiesOnly(params: RequestType<typeof api_svc_svc_cookiesOnly>): Promise<ResponseType<typeof api_svc_svc_cookiesOnly>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/cookies-only`, {method: "POST", body: undefined})
-            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_svc_svc_cookiesOnly>
+            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_cookiesOnly>
         }
 
         public async dummy(params: RequestType<typeof api_svc_svc_dummy>): Promise<void> {
@@ -185,7 +190,7 @@ export namespace svc {
         public async imported(params: RequestType<typeof api_svc_svc_imported>): Promise<ResponseType<typeof api_svc_svc_imported>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/imported`, {method: "POST", body: JSON.stringify(params)})
-            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_svc_svc_imported>
+            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_imported>
         }
 
         public async multiSetCookie(): Promise<ResponseType<typeof api_svc_svc_multiSetCookie>> {
@@ -193,7 +198,7 @@ export namespace svc {
             const resp = await this.baseClient.callTypedAPI(`/multi-set-cookie`, {method: "POST", body: undefined})
 
             //Populate the return object from the JSON body and received headers
-            const rtn = JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_svc_svc_multiSetCookie>
+            const rtn = JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_multiSetCookie>
             if (!BROWSER) {
                 rtn.tokens = resp.headers.getSetCookie()
             }
@@ -207,7 +212,7 @@ export namespace svc {
         public async onlyPathParams(params: { pathParam: string, pathParam2: string }): Promise<ResponseType<typeof api_svc_svc_onlyPathParams>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/path/${encodeURIComponent(params.pathParam)}/${encodeURIComponent(params.pathParam2)}`, {method: "POST", body: undefined})
-            return JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_svc_svc_onlyPathParams>
+            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_onlyPathParams>
         }
 
         /**
@@ -240,7 +245,7 @@ export namespace svc {
             const resp = await this.baseClient.callTypedAPI(`/single-set-cookie`, {method: "POST", body: undefined})
 
             //Populate the return object from the JSON body and received headers
-            const rtn = JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof api_svc_svc_singleSetCookie>
+            const rtn = JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_singleSetCookie>
             if (!BROWSER) {
                 rtn.token = mustBeSet("Header `set-cookie`", resp.headers.getSetCookie()[0])
             }
@@ -403,10 +408,10 @@ export class StreamInOut<Request, Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            this.buffer.push(JSON.parse(event.data, dateReviver));
+            this.buffer.push(JSON.parse(event.data, reviver));
             this.socket.resolveHasUpdateHandlers();
         });
     }
@@ -447,10 +452,10 @@ export class StreamIn<Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            this.buffer.push(JSON.parse(event.data, dateReviver));
+            this.buffer.push(JSON.parse(event.data, reviver));
             this.socket.resolveHasUpdateHandlers();
         });
     }
@@ -480,13 +485,13 @@ export class StreamOut<Request, Response> {
     public socket: WebSocketConnection;
     private responseValue: Promise<Response>;
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         let responseResolver: (_: any) => void;
         this.responseValue = new Promise((resolve) => responseResolver = resolve);
 
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            responseResolver(JSON.parse(event.data, dateReviver))
+            responseResolver(JSON.parse(event.data, reviver))
         });
     }
 
@@ -535,6 +540,7 @@ class BaseClient {
     readonly headers: Record<string, string>
     readonly requestInit: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
     readonly authGenerator?: AuthDataGenerator
+    readonly reviver: ((key: string, value: any) => any) | undefined
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
@@ -564,6 +570,7 @@ class BaseClient {
                 this.authGenerator = () => auth
             }
         }
+        this.reviver = options.disableDateReviver ? undefined : dateReviver
     }
 
     async getAuthData(): Promise<CallParameters | undefined> {
@@ -611,7 +618,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers);
+        return new StreamInOut(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
@@ -632,7 +639,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers);
+        return new StreamIn(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
@@ -653,7 +660,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers);
+        return new StreamOut(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // callTypedAPI makes an API call, defaulting content type to "application/json"

--- a/pkg/clientgen/testdata/tsapp/expected_shared.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_shared.ts
@@ -90,10 +90,21 @@ export interface ClientOptions {
      */
     auth?: RequestType<typeof auth_auth> | AuthDataGenerator
     /**
-     * Disables the automatic conversion of date strings to Date objects in API responses.
-     * When true, date strings are left as strings.
+     * Overrides or disables the built-in date reviver for all API calls.
+     * Pass a custom function to use instead, or false to disable date parsing entirely.
      */
-    disableDateReviver?: boolean
+    dateReviver?: ((key: string, value: any) => any) | false
+}
+
+/**
+ * CallOptions allows you to override per-call behaviour within the generated Encore client.
+ */
+export interface CallOptions {
+    /**
+     * Overrides the date reviver for this specific call.
+     * Pass a custom function to transform date strings, or false to disable date parsing.
+     */
+    dateReviver?: ((key: string, value: any) => any) | false
 }
 
 /**
@@ -131,7 +142,7 @@ export namespace svc {
             this.singleSetCookie = this.singleSetCookie.bind(this)
         }
 
-        public async cookieDummy(params: RequestType<typeof api_svc_svc_cookieDummy>): Promise<ResponseType<typeof api_svc_svc_cookieDummy>> {
+        public async cookieDummy(params: RequestType<typeof api_svc_svc_cookieDummy>, callOptions?: CallOptions): Promise<ResponseType<typeof api_svc_svc_cookieDummy>> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 baz: params.headerBaz,
@@ -152,13 +163,15 @@ export namespace svc {
 
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/cookie-dummy`, {headers, query, method: "POST", body: JSON.stringify(body)})
-            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_cookieDummy>
+            const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver
+            return JSON.parse(await resp.text(), reviver) as ResponseType<typeof api_svc_svc_cookieDummy>
         }
 
-        public async cookiesOnly(params: RequestType<typeof api_svc_svc_cookiesOnly>): Promise<ResponseType<typeof api_svc_svc_cookiesOnly>> {
+        public async cookiesOnly(params: RequestType<typeof api_svc_svc_cookiesOnly>, callOptions?: CallOptions): Promise<ResponseType<typeof api_svc_svc_cookiesOnly>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/cookies-only`, {method: "POST", body: undefined})
-            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_cookiesOnly>
+            const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver
+            return JSON.parse(await resp.text(), reviver) as ResponseType<typeof api_svc_svc_cookiesOnly>
         }
 
         public async dummy(params: RequestType<typeof api_svc_svc_dummy>): Promise<void> {
@@ -187,18 +200,20 @@ export namespace svc {
          * Imported tests the usage of imported types
          * and this comment is also multiline.
          */
-        public async imported(params: RequestType<typeof api_svc_svc_imported>): Promise<ResponseType<typeof api_svc_svc_imported>> {
+        public async imported(params: RequestType<typeof api_svc_svc_imported>, callOptions?: CallOptions): Promise<ResponseType<typeof api_svc_svc_imported>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/imported`, {method: "POST", body: JSON.stringify(params)})
-            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_imported>
+            const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver
+            return JSON.parse(await resp.text(), reviver) as ResponseType<typeof api_svc_svc_imported>
         }
 
-        public async multiSetCookie(): Promise<ResponseType<typeof api_svc_svc_multiSetCookie>> {
+        public async multiSetCookie(callOptions?: CallOptions): Promise<ResponseType<typeof api_svc_svc_multiSetCookie>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/multi-set-cookie`, {method: "POST", body: undefined})
+            const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver
 
             //Populate the return object from the JSON body and received headers
-            const rtn = JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_multiSetCookie>
+            const rtn = JSON.parse(await resp.text(), reviver) as ResponseType<typeof api_svc_svc_multiSetCookie>
             if (!BROWSER) {
                 rtn.tokens = resp.headers.getSetCookie()
             }
@@ -209,10 +224,11 @@ export namespace svc {
             await this.baseClient.callTypedAPI(`/type-less`, {method: "POST", body: undefined})
         }
 
-        public async onlyPathParams(params: { pathParam: string, pathParam2: string }): Promise<ResponseType<typeof api_svc_svc_onlyPathParams>> {
+        public async onlyPathParams(params: { pathParam: string, pathParam2: string }, callOptions?: CallOptions): Promise<ResponseType<typeof api_svc_svc_onlyPathParams>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/path/${encodeURIComponent(params.pathParam)}/${encodeURIComponent(params.pathParam2)}`, {method: "POST", body: undefined})
-            return JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_onlyPathParams>
+            const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver
+            return JSON.parse(await resp.text(), reviver) as ResponseType<typeof api_svc_svc_onlyPathParams>
         }
 
         /**
@@ -240,12 +256,13 @@ export namespace svc {
             await this.baseClient.callTypedAPI(`/`, {headers, query, method: "POST", body: JSON.stringify(body)})
         }
 
-        public async singleSetCookie(): Promise<ResponseType<typeof api_svc_svc_singleSetCookie>> {
+        public async singleSetCookie(callOptions?: CallOptions): Promise<ResponseType<typeof api_svc_svc_singleSetCookie>> {
             // Now make the actual call to the API
             const resp = await this.baseClient.callTypedAPI(`/single-set-cookie`, {method: "POST", body: undefined})
+            const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver
 
             //Populate the return object from the JSON body and received headers
-            const rtn = JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof api_svc_svc_singleSetCookie>
+            const rtn = JSON.parse(await resp.text(), reviver) as ResponseType<typeof api_svc_svc_singleSetCookie>
             if (!BROWSER) {
                 rtn.token = mustBeSet("Header `set-cookie`", resp.headers.getSetCookie()[0])
             }
@@ -570,7 +587,7 @@ class BaseClient {
                 this.authGenerator = () => auth
             }
         }
-        this.reviver = options.disableDateReviver ? undefined : dateReviver
+        this.reviver = options.dateReviver === false ? undefined : (options.dateReviver ?? dateReviver)
     }
 
     async getAuthData(): Promise<CallParameters | undefined> {
@@ -601,7 +618,7 @@ class BaseClient {
     }
 
     // createStreamInOut sets up a stream to a streaming API endpoint.
-    async createStreamInOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamInOut<Request, Response>> {
+    async createStreamInOut<Request, Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamInOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -618,11 +635,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamInOut(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
-    async createStreamIn<Response>(path: string, params?: CallParameters): Promise<StreamIn<Response>> {
+    async createStreamIn<Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamIn<Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -639,11 +656,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamIn(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
-    async createStreamOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamOut<Request, Response>> {
+    async createStreamOut<Request, Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -660,7 +677,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamOut(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // callTypedAPI makes an API call, defaulting content type to "application/json"

--- a/pkg/clientgen/testdata/tsapp/expected_stream_shared.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_stream_shared.ts
@@ -77,6 +77,11 @@ export interface ClientOptions {
 
     /** Default RequestInit to be used for the client */
     requestInit?: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
+    /**
+     * Disables the automatic conversion of date strings to Date objects in API responses.
+     * When true, date strings are left as strings.
+     */
+    disableDateReviver?: boolean
 }
 
 /**
@@ -329,10 +334,10 @@ export class StreamInOut<Request, Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            this.buffer.push(JSON.parse(event.data, dateReviver));
+            this.buffer.push(JSON.parse(event.data, reviver));
             this.socket.resolveHasUpdateHandlers();
         });
     }
@@ -373,10 +378,10 @@ export class StreamIn<Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            this.buffer.push(JSON.parse(event.data, dateReviver));
+            this.buffer.push(JSON.parse(event.data, reviver));
             this.socket.resolveHasUpdateHandlers();
         });
     }
@@ -406,13 +411,13 @@ export class StreamOut<Request, Response> {
     public socket: WebSocketConnection;
     private responseValue: Promise<Response>;
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any) {
         let responseResolver: (_: any) => void;
         this.responseValue = new Promise((resolve) => responseResolver = resolve);
 
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
-            responseResolver(JSON.parse(event.data, dateReviver))
+            responseResolver(JSON.parse(event.data, reviver))
         });
     }
 
@@ -455,6 +460,7 @@ class BaseClient {
     readonly fetcher: Fetcher
     readonly headers: Record<string, string>
     readonly requestInit: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
+    readonly reviver: ((key: string, value: any) => any) | undefined
 
     constructor(baseURL: string, options: ClientOptions) {
         this.baseURL = baseURL
@@ -474,6 +480,7 @@ class BaseClient {
         } else {
             this.fetcher = boundFetch
         }
+        this.reviver = options.disableDateReviver ? undefined : dateReviver
     }
 
     async getAuthData(): Promise<CallParameters | undefined> {
@@ -498,7 +505,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers);
+        return new StreamInOut(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
@@ -519,7 +526,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers);
+        return new StreamIn(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
@@ -540,7 +547,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers);
+        return new StreamOut(this.baseURL + path + queryString, headers, this.reviver);
     }
 
     // callTypedAPI makes an API call, defaulting content type to "application/json"

--- a/pkg/clientgen/testdata/tsapp/expected_stream_shared.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_stream_shared.ts
@@ -78,10 +78,21 @@ export interface ClientOptions {
     /** Default RequestInit to be used for the client */
     requestInit?: Omit<RequestInit, "headers"> & { headers?: Record<string, string> }
     /**
-     * Disables the automatic conversion of date strings to Date objects in API responses.
-     * When true, date strings are left as strings.
+     * Overrides or disables the built-in date reviver for all API calls.
+     * Pass a custom function to use instead, or false to disable date parsing entirely.
      */
-    disableDateReviver?: boolean
+    dateReviver?: ((key: string, value: any) => any) | false
+}
+
+/**
+ * CallOptions allows you to override per-call behaviour within the generated Encore client.
+ */
+export interface CallOptions {
+    /**
+     * Overrides the date reviver for this specific call.
+     * Pass a custom function to transform date strings, or false to disable date parsing.
+     */
+    dateReviver?: ((key: string, value: any) => any) | false
 }
 
 /**
@@ -118,7 +129,7 @@ export namespace svc {
         /**
          * InOut stream type variants
          */
-        public async inOutWithHandshake(params: RequestType<typeof api_svc_svc_inOutWithHandshake>): Promise<StreamInOut<StreamRequest<typeof api_svc_svc_inOutWithHandshake>, StreamResponse<typeof api_svc_svc_inOutWithHandshake>>> {
+        public async inOutWithHandshake(params: RequestType<typeof api_svc_svc_inOutWithHandshake>, callOptions?: CallOptions): Promise<StreamInOut<StreamRequest<typeof api_svc_svc_inOutWithHandshake>, StreamResponse<typeof api_svc_svc_inOutWithHandshake>>> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "some-header": params.headerValue,
@@ -128,17 +139,17 @@ export namespace svc {
                 "some-query": params.queryValue,
             })
 
-            return await this.baseClient.createStreamInOut(`/inout/${encodeURIComponent(params.pathParam)}`, {headers, query})
+            return await this.baseClient.createStreamInOut(`/inout/${encodeURIComponent(params.pathParam)}`, {headers, query}, callOptions?.dateReviver)
         }
 
-        public async inOutWithoutHandshake(): Promise<StreamInOut<StreamRequest<typeof api_svc_svc_inOutWithoutHandshake>, StreamResponse<typeof api_svc_svc_inOutWithoutHandshake>>> {
-            return await this.baseClient.createStreamInOut(`/inout/noHandshake`)
+        public async inOutWithoutHandshake(callOptions?: CallOptions): Promise<StreamInOut<StreamRequest<typeof api_svc_svc_inOutWithoutHandshake>, StreamResponse<typeof api_svc_svc_inOutWithoutHandshake>>> {
+            return await this.baseClient.createStreamInOut(`/inout/noHandshake`, undefined, callOptions?.dateReviver)
         }
 
         /**
          * In stream type variants
          */
-        public async inWithHandshake(params: RequestType<typeof api_svc_svc_inWithHandshake>): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithHandshake>, void>> {
+        public async inWithHandshake(params: RequestType<typeof api_svc_svc_inWithHandshake>, callOptions?: CallOptions): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithHandshake>, void>> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "some-header": params.headerValue,
@@ -148,14 +159,14 @@ export namespace svc {
                 "some-query": params.queryValue,
             })
 
-            return await this.baseClient.createStreamOut(`/in/${encodeURIComponent(params.pathParam)}`, {headers, query})
+            return await this.baseClient.createStreamOut(`/in/${encodeURIComponent(params.pathParam)}`, {headers, query}, callOptions?.dateReviver)
         }
 
-        public async inWithResponse(): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithResponse>, StreamResponse<typeof api_svc_svc_inWithResponse>>> {
-            return await this.baseClient.createStreamOut(`/in/withResponse`)
+        public async inWithResponse(callOptions?: CallOptions): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithResponse>, StreamResponse<typeof api_svc_svc_inWithResponse>>> {
+            return await this.baseClient.createStreamOut(`/in/withResponse`, undefined, callOptions?.dateReviver)
         }
 
-        public async inWithResponseAndHandshake(params: RequestType<typeof api_svc_svc_inWithResponseAndHandshake>): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithResponseAndHandshake>, StreamResponse<typeof api_svc_svc_inWithResponseAndHandshake>>> {
+        public async inWithResponseAndHandshake(params: RequestType<typeof api_svc_svc_inWithResponseAndHandshake>, callOptions?: CallOptions): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithResponseAndHandshake>, StreamResponse<typeof api_svc_svc_inWithResponseAndHandshake>>> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "some-header": params.headerValue,
@@ -166,17 +177,17 @@ export namespace svc {
                 "some-query": params.queryValue,
             })
 
-            return await this.baseClient.createStreamOut(`/in/withResponseAndHandshake`, {headers, query})
+            return await this.baseClient.createStreamOut(`/in/withResponseAndHandshake`, {headers, query}, callOptions?.dateReviver)
         }
 
-        public async inWithoutHandshake(): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithoutHandshake>, void>> {
-            return await this.baseClient.createStreamOut(`/in/noHandshake`)
+        public async inWithoutHandshake(callOptions?: CallOptions): Promise<StreamOut<StreamRequest<typeof api_svc_svc_inWithoutHandshake>, void>> {
+            return await this.baseClient.createStreamOut(`/in/noHandshake`, undefined, callOptions?.dateReviver)
         }
 
         /**
          * Out stream type variants
          */
-        public async outWithHandshake(params: RequestType<typeof api_svc_svc_outWithHandshake>): Promise<StreamIn<StreamResponse<typeof api_svc_svc_outWithHandshake>>> {
+        public async outWithHandshake(params: RequestType<typeof api_svc_svc_outWithHandshake>, callOptions?: CallOptions): Promise<StreamIn<StreamResponse<typeof api_svc_svc_outWithHandshake>>> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "some-header": params.headerValue,
@@ -186,11 +197,11 @@ export namespace svc {
                 "some-query": params.queryValue,
             })
 
-            return await this.baseClient.createStreamIn(`/out/${encodeURIComponent(params.pathParam)}`, {headers, query})
+            return await this.baseClient.createStreamIn(`/out/${encodeURIComponent(params.pathParam)}`, {headers, query}, callOptions?.dateReviver)
         }
 
-        public async outWithoutHandshake(): Promise<StreamIn<StreamResponse<typeof api_svc_svc_outWithoutHandshake>>> {
-            return await this.baseClient.createStreamIn(`/out/noHandshake`)
+        public async outWithoutHandshake(callOptions?: CallOptions): Promise<StreamIn<StreamResponse<typeof api_svc_svc_outWithoutHandshake>>> {
+            return await this.baseClient.createStreamIn(`/out/noHandshake`, undefined, callOptions?.dateReviver)
         }
     }
 }
@@ -480,7 +491,7 @@ class BaseClient {
         } else {
             this.fetcher = boundFetch
         }
-        this.reviver = options.disableDateReviver ? undefined : dateReviver
+        this.reviver = options.dateReviver === false ? undefined : (options.dateReviver ?? dateReviver)
     }
 
     async getAuthData(): Promise<CallParameters | undefined> {
@@ -488,7 +499,7 @@ class BaseClient {
     }
 
     // createStreamInOut sets up a stream to a streaming API endpoint.
-    async createStreamInOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamInOut<Request, Response>> {
+    async createStreamInOut<Request, Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamInOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -505,11 +516,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamInOut(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
-    async createStreamIn<Response>(path: string, params?: CallParameters): Promise<StreamIn<Response>> {
+    async createStreamIn<Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamIn<Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -526,11 +537,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamIn(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
-    async createStreamOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamOut<Request, Response>> {
+    async createStreamOut<Request, Response>(path: string, params?: CallParameters, reviver?: ((key: string, value: any) => any) | false): Promise<StreamOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -547,7 +558,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers, this.reviver);
+        return new StreamOut(this.baseURL + path + queryString, headers, reviver === false ? undefined : (reviver ?? this.reviver));
     }
 
     // callTypedAPI makes an API call, defaulting content type to "application/json"

--- a/pkg/clientgen/typescript.go
+++ b/pkg/clientgen/typescript.go
@@ -447,6 +447,14 @@ func (ts *typescript) writeService(svc *meta.Service, p clientgentypes.ServiceSe
 			}
 		}
 
+		if ts.sharedTypes && !isRaw && (isStream || rpc.ResponseSchema != nil) {
+			wroteParam := inlinePathParams || (!isStream && rpc.RequestSchema != nil) || (isStream && hasHandshake)
+			if wroteParam {
+				ts.WriteString(", ")
+			}
+			ts.WriteString("callOptions?: CallOptions")
+		}
+
 		ts.WriteString("): Promise<")
 
 		if isStream {
@@ -599,6 +607,12 @@ func (ts *typescript) streamCallSite(w *indentWriter, rpc *meta.RPC, rpcPath str
 		}
 
 		createStream += "}"
+	} else if ts.sharedTypes {
+		createStream += ", undefined"
+	}
+
+	if ts.sharedTypes {
+		createStream += ", callOptions?.dateReviver"
 	}
 	createStream += ")"
 
@@ -764,12 +778,16 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 
 	w.WriteStringf("// Now make the actual call to the API\nconst resp = await %s\n", callAPI)
 
+	if ts.sharedTypes {
+		w.WriteString("const reviver = callOptions?.dateReviver !== undefined ? (callOptions.dateReviver || undefined) : this.baseClient.reviver\n")
+	}
+
 	respEnc := rpcEncoding.ResponseEncoding
 
 	// If we don't need to do anything with the body, we can just return the response
 	if len(respEnc.HeaderParameters) == 0 {
 		if ts.sharedTypes {
-			w.WriteString("return JSON.parse(await resp.text(), this.baseClient.reviver) as ")
+			w.WriteString("return JSON.parse(await resp.text(), reviver) as ")
 			fmt.Fprintf(ts, "ResponseType<typeof %s>", rpcImportName(rpc))
 		} else {
 			w.WriteString("return await resp.json() as ")
@@ -783,7 +801,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 	w.WriteString("\n//Populate the return object from the JSON body and received headers\n")
 
 	if ts.sharedTypes {
-		w.WriteStringf("const rtn = JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof %s>", rpcImportName(rpc))
+		w.WriteStringf("const rtn = JSON.parse(await resp.text(), reviver) as ResponseType<typeof %s>", rpcImportName(rpc))
 	} else {
 		w.WriteString("const rtn = await resp.json() as ")
 		ts.writeTyp(ns, rpc.ResponseSchema, 0)
@@ -1272,16 +1290,31 @@ export interface ClientOptions {
 
 	if ts.sharedTypes {
 		w.WriteString(`    /**
-     * Disables the automatic conversion of date strings to Date objects in API responses.
-     * When true, date strings are left as strings.
+     * Overrides or disables the built-in date reviver for all API calls.
+     * Pass a custom function to use instead, or false to disable date parsing entirely.
      */
-    disableDateReviver?: boolean
+    dateReviver?: ((key: string, value: any) => any) | false
 `)
 	}
 
 	w.WriteString(`}
 
 `)
+
+	if ts.sharedTypes {
+		w.WriteString(`/**
+ * CallOptions allows you to override per-call behaviour within the generated Encore client.
+ */
+export interface CallOptions {
+    /**
+     * Overrides the date reviver for this specific call.
+     * Pass a custom function to transform date strings, or false to disable date parsing.
+     */
+    dateReviver?: ((key: string, value: any) => any) | false
+}
+
+`)
+	}
 }
 
 func (ts *typescript) writeBaseClient(appSlug string) error {
@@ -1373,7 +1406,7 @@ class BaseClient {
 
 	if ts.sharedTypes {
 		ts.WriteString(`
-        this.reviver = options.disableDateReviver ? undefined : dateReviver`)
+        this.reviver = options.dateReviver === false ? undefined : (options.dateReviver ?? dateReviver)`)
 	}
 
 	ts.WriteString(`
@@ -1468,14 +1501,16 @@ class BaseClient {
     }
 `)
 
-	streamReviverArg := ""
+	streamParamSuffix := ""
+	streamReturnReviver := "headers"
 	if ts.sharedTypes {
-		streamReviverArg = ", this.reviver"
+		streamParamSuffix = ", reviver?: ((key: string, value: any) => any) | false"
+		streamReturnReviver = "headers, reviver === false ? undefined : (reviver ?? this.reviver)"
 	}
 
 	fmt.Fprintf(ts, `
     // createStreamInOut sets up a stream to a streaming API endpoint.
-    async createStreamInOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamInOut<Request, Response>> {
+    async createStreamInOut<Request, Response>(path: string, params?: CallParameters%s): Promise<StreamInOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -1492,11 +1527,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers%s);
+        return new StreamInOut(this.baseURL + path + queryString, %s);
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
-    async createStreamIn<Response>(path: string, params?: CallParameters): Promise<StreamIn<Response>> {
+    async createStreamIn<Response>(path: string, params?: CallParameters%s): Promise<StreamIn<Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -1513,11 +1548,11 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers%s);
+        return new StreamIn(this.baseURL + path + queryString, %s);
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
-    async createStreamOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamOut<Request, Response>> {
+    async createStreamOut<Request, Response>(path: string, params?: CallParameters%s): Promise<StreamOut<Request, Response>> {
         let { query, headers } = params ?? {};
 
         // Fetch auth data if there is any
@@ -1534,9 +1569,9 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers%s);
+        return new StreamOut(this.baseURL + path + queryString, %s);
     }
-`, streamReviverArg, streamReviverArg, streamReviverArg)
+`, streamParamSuffix, streamReturnReviver, streamParamSuffix, streamReturnReviver, streamParamSuffix, streamReturnReviver)
 
 	callParams := "method: string, path: string, body?: RequestInit[\"body\"], params?: CallParameters"
 	callAPIParams := "method, path, body"

--- a/pkg/clientgen/typescript.go
+++ b/pkg/clientgen/typescript.go
@@ -769,7 +769,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 	// If we don't need to do anything with the body, we can just return the response
 	if len(respEnc.HeaderParameters) == 0 {
 		if ts.sharedTypes {
-			w.WriteString("return JSON.parse(await resp.text(), dateReviver) as ")
+			w.WriteString("return JSON.parse(await resp.text(), this.baseClient.reviver) as ")
 			fmt.Fprintf(ts, "ResponseType<typeof %s>", rpcImportName(rpc))
 		} else {
 			w.WriteString("return await resp.json() as ")
@@ -783,7 +783,7 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 	w.WriteString("\n//Populate the return object from the JSON body and received headers\n")
 
 	if ts.sharedTypes {
-		w.WriteStringf("const rtn = JSON.parse(await resp.text(), dateReviver) as ResponseType<typeof %s>", rpcImportName(rpc))
+		w.WriteStringf("const rtn = JSON.parse(await resp.text(), this.baseClient.reviver) as ResponseType<typeof %s>", rpcImportName(rpc))
 	} else {
 		w.WriteString("const rtn = await resp.json() as ")
 		ts.writeTyp(ns, rpc.ResponseSchema, 0)
@@ -934,8 +934,10 @@ type StreamResponse<Type> = Type extends
 	}
 
 	parse := "JSON.parse(event.data)"
+	ctorParams := "url: string, headers?: Record<string, string>"
 	if ts.sharedTypes {
-		parse = "JSON.parse(event.data, dateReviver)"
+		parse = "JSON.parse(event.data, reviver)"
+		ctorParams = "url: string, headers?: Record<string, string>, reviver?: (key: string, value: any) => any"
 	}
 
 	send := `
@@ -1032,7 +1034,7 @@ export class StreamInOut<Request, Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(` + ctorParams + `) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
             this.buffer.push(` + parse + `);
@@ -1051,7 +1053,7 @@ export class StreamIn<Response> {
     public socket: WebSocketConnection;
     private buffer: Response[] = [];
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(` + ctorParams + `) {
         this.socket = new WebSocketConnection(url, headers);
         this.socket.on("message", (event: any) => {
             this.buffer.push(` + parse + `);
@@ -1069,7 +1071,7 @@ export class StreamOut<Request, Response> {
     public socket: WebSocketConnection;
     private responseValue: Promise<Response>;
 
-    constructor(url: string, headers?: Record<string, string>) {
+    constructor(` + ctorParams + `) {
         let responseResolver: (_: any) => void;
         this.responseValue = new Promise((resolve) => responseResolver = resolve);
 
@@ -1268,6 +1270,15 @@ export interface ClientOptions {
 		w.WriteString(" | AuthDataGenerator\n")
 	}
 
+	if ts.sharedTypes {
+		w.WriteString(`    /**
+     * Disables the automatic conversion of date strings to Date objects in API responses.
+     * When true, date strings are left as strings.
+     */
+    disableDateReviver?: boolean
+`)
+	}
+
 	w.WriteString(`}
 
 `)
@@ -1321,6 +1332,10 @@ class BaseClient {
 		ts.WriteString("\n    readonly authGenerator?: AuthDataGenerator")
 	}
 
+	if ts.sharedTypes {
+		ts.WriteString("\n    readonly reviver: ((key: string, value: any) => any) | undefined")
+	}
+
 	ts.WriteString(`
 
     constructor(baseURL: string, options: ClientOptions) {
@@ -1354,6 +1369,11 @@ class BaseClient {
                 this.authGenerator = () => auth
             }
         }`)
+	}
+
+	if ts.sharedTypes {
+		ts.WriteString(`
+        this.reviver = options.disableDateReviver ? undefined : dateReviver`)
 	}
 
 	ts.WriteString(`
@@ -1448,7 +1468,12 @@ class BaseClient {
     }
 `)
 
-	ts.WriteString(`
+	streamReviverArg := ""
+	if ts.sharedTypes {
+		streamReviverArg = ", this.reviver"
+	}
+
+	fmt.Fprintf(ts, `
     // createStreamInOut sets up a stream to a streaming API endpoint.
     async createStreamInOut<Request, Response>(path: string, params?: CallParameters): Promise<StreamInOut<Request, Response>> {
         let { query, headers } = params ?? {};
@@ -1467,7 +1492,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamInOut(this.baseURL + path + queryString, headers);
+        return new StreamInOut(this.baseURL + path + queryString, headers%s);
     }
 
     // createStreamIn sets up a stream to a streaming API endpoint.
@@ -1488,7 +1513,7 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamIn(this.baseURL + path + queryString, headers);
+        return new StreamIn(this.baseURL + path + queryString, headers%s);
     }
 
     // createStreamOut sets up a stream to a streaming API endpoint.
@@ -1509,9 +1534,9 @@ class BaseClient {
         }
 
         const queryString = query ? '?' + encodeQuery(query) : ''
-        return new StreamOut(this.baseURL + path + queryString, headers);
+        return new StreamOut(this.baseURL + path + queryString, headers%s);
     }
-`)
+`, streamReviverArg, streamReviverArg, streamReviverArg)
 
 	callParams := "method: string, path: string, body?: RequestInit[\"body\"], params?: CallParameters"
 	callAPIParams := "method, path, body"


### PR DESCRIPTION
This pull request adds support for customizing or disabling date parsing (the "date reviver") when using the generated TypeScript Encore client. It introduces new options at both the client and per-call levels, and ensures streaming APIs also respect these settings. The changes improve flexibility for users who need to control how date strings are parsed in API responses.

**Customizable Date Parsing Support:**

* Added a new `dateReviver` option to the `ClientOptions` interface, allowing users to provide a custom date reviver function or disable date parsing globally for all API calls. [[1]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456R80-R95) [[2]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126R92-R107)
* Introduced a `CallOptions` interface that supports a per-call `dateReviver` override, giving fine-grained control over date parsing on individual requests. [[1]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456R80-R95) [[2]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126R92-R107)

**Streaming API Enhancements:**

* Updated constructors for `StreamInOut`, `StreamIn`, and `StreamOut` classes to accept an optional `reviver` parameter, ensuring that streaming responses also use the correct date parsing logic. [[1]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456L247-R266) [[2]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456L291-R310) [[3]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456L324-R346) [[4]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L406-R431) [[5]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L450-R475) [[6]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L483-R511)
* Modified `BaseClient` streaming methods (`createStreamInOut`, `createStreamIn`, `createStreamOut`) to accept and propagate the `reviver` option, defaulting to the client-level setting if not specified per call. [[1]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456R409-R417) [[2]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456L416-R438) [[3]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456L437-R459) [[4]](diffhunk://#diff-ab2440a69e308ed9e32620a749b36c3f8e54f4895caf9bd876cdd0da37e48456L458-R476) [[5]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126R560) [[6]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126R590) [[7]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L597-R621) [[8]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L614-R642) [[9]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L635-R663)

**Per-Call Date Reviver in Service Methods:**

* Updated generated service methods to accept an optional `callOptions` parameter, using its `dateReviver` if provided, or falling back to the client-level setting. This ensures all API calls (including those returning cookies or using imported types) consistently respect the user's date parsing preferences. [[1]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L129-R145) [[2]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L150-R174) [[3]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L185-R216) [[4]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L207-R231) [[5]](diffhunk://#diff-79d7901a425984a8c806414f550dbcae7725d45a13a4ba42910c764c5f323126L238-R265)

These changes make the Encore TypeScript client more flexible and robust when handling date values in API responses.

 Here are sample API responses that show why the reviver matters and what each option does to the parsed output:                                     
                                         
 ```
 Raw JSON from the server (always a string over the wire):                                                                                           
  {
    "id": "order-123",                                                                                                                                
    "createdAt": "2024-03-15T10:30:00Z",                    
    "updatedAt": "2024-03-15T14:22:11.847Z",
    "scheduledFor": "2024-03-16T09:00:00Z",                                                                                                           
    "metadata": {                                                                                                                                     
      "processedAt": "2024-03-15T14:22:11.000Z",                                                                                                      
      "version": "1.0.2"                                                                                                                              
    },                                                                                                                                                
    "tags": ["urgent", "2024-03-15"]
  }                                                                                                                                                   
                                                                                                                                                      
  ---
  Default (dateReviver active) — what you get today:                                                                                                  
  {                                                                                                                                                   
    "id": "order-123",
    "createdAt": "Date object: Fri Mar 15 2024 10:30:00 GMT+0000",                                                                                    
    "updatedAt": "Date object: Fri Mar 15 2024 14:22:11 GMT+0000",
    "scheduledFor": "Date object: Sat Mar 16 2024 09:00:00 GMT+0000",                                                                                 
    "metadata": {                                                                                                                                     
      "processedAt": "Date object: Fri Mar 15 2024 14:22:11 GMT+0000",                                                                                
      "version": "1.0.2"                                                                                                                              
    },                                                                                                                                                
    "tags": ["urgent", "Date object: Fri Mar 15 2024 00:00:00 GMT+0000"]
  }                                                                                                                                                   
                                                                                                                                                      
  "2024-03-15" in tags[1] gets converted too — it passes the date check even though it's probably just a label string.
                                                                                                                                                      
  ---                                                       
  { dateReviver: false } — opt-out, everything stays a string:                                                                                        
  {                                                                                                                                                   
    "id": "order-123",
    "createdAt": "2024-03-15T10:30:00Z",                                                                                                              
    "updatedAt": "2024-03-15T14:22:11.847Z",                
    "scheduledFor": "2024-03-16T09:00:00Z", 
    "metadata": {                                                                                                                                     
      "processedAt": "2024-03-15T14:22:11.000Z",
      "version": "1.0.2"                                                                                                                              
    },                                                                                                                                                
    "tags": ["urgent", "2024-03-15"]
  }                                                                                                                                                   
                                                            
  ---
  { dateReviver: myReviver } — custom reviver that only converts fields ending in At:
  {                                                                                                                                                   
    "id": "order-123",
    "createdAt": "Date object: Fri Mar 15 2024 10:30:00 GMT+0000",                                                                                    
    "updatedAt": "Date object: Fri Mar 15 2024 14:22:11 GMT+0000",
    "scheduledFor": "2024-03-16T09:00:00Z",                                                                                                           
    "metadata": {                          
      "processedAt": "Date object: Fri Mar 15 2024 14:22:11 GMT+0000",                                                                                
      "version": "1.0.2"                                              
    },                                                                                                                                                
    "tags": ["urgent", "2024-03-15"]                                                                                                                  
  }                                 
                                                                                                                                                      
  The custom reviver for that last example:                 
  const myReviver = (key: string, value: any) => {                                                                                                    
      if (typeof value === "string" && key.endsWith("At")) {
          const d = new Date(value)                                                                                                                   
          if (!isNaN(d.getTime())) return d                                                                                                           
      }                                    
      return value                                                                                                                                    
  }                                                         
   
  const order = await client.orders.get({ id: "order-123" }, { dateReviver: myReviver })                                                              
                                                                                                                                                      
  scheduledFor stays a string, tags[1] stays a string, only the *At fields become Date objects. This is the case the built-in reviver can't handle —  
  it converts anything that looks like a date, which causes false positives on string-typed tag values like "2024-03-15".     
```