### PR TITLE
rename MCP server from encore-mcp to encore-local

### DIFF
--- a/cli/cmd/encore/llm_rules/tool.go
+++ b/cli/cmd/encore/llm_rules/tool.go
@@ -107,8 +107,7 @@ func SetupLLMRules(llmRules Tool, lang cmdutil.Language, appRootRelpath string, 
 			// https://cursor.com/docs/context/mcp#using-mcpjson
 			mcpPath := filepath.Join(cursorDir, "mcp.json")
 			err = updateJsonFile(mcpPath, "mcpServers", func(mcpServers map[string]any) {
-				// Add encore-mcp configuration
-				mcpServers["encore-mcp"] = map[string]any{
+				mcpServers["encore-local"] = map[string]any{
 					"command": "encore",
 					"args":    []string{"mcp", "run", "--app=" + appSlug},
 				}
@@ -129,8 +128,7 @@ func SetupLLMRules(llmRules Tool, lang cmdutil.Language, appRootRelpath string, 
 			// https://code.claude.com/docs/en/mcp#project-scope
 			mcpPath := filepath.Join(appRootRelpath, ".mcp.json")
 			err = updateJsonFile(mcpPath, "mcpServers", func(mcpServers map[string]any) {
-				// Add encore-mcp configuration
-				mcpServers["encore-mcp"] = map[string]any{
+				mcpServers["encore-local"] = map[string]any{
 					"command": "encore",
 					"args":    []string{"mcp", "run", "--app=" + appSlug},
 				}
@@ -170,8 +168,7 @@ func SetupLLMRules(llmRules Tool, lang cmdutil.Language, appRootRelpath string, 
 		// https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_configuration-format
 		mcpPath := filepath.Join(vscodePath, "mcp.json")
 		err = updateJsonFile(mcpPath, "servers", func(servers map[string]any) {
-			// Add encore-mcp configuration
-			servers["encore-mcp"] = map[string]any{
+			servers["encore-local"] = map[string]any{
 				"command": "encore",
 				"args":    []string{"mcp", "run", "--app=" + appSlug},
 			}
@@ -204,8 +201,7 @@ func SetupLLMRules(llmRules Tool, lang cmdutil.Language, appRootRelpath string, 
 			// https://zed.dev/docs/ai/mcp#as-custom-servers
 			settingsPath := filepath.Join(zedDir, "settings.json")
 			err = updateJsonFile(settingsPath, "context_servers", func(contextServers map[string]any) {
-				// Add encore-mcp configuration
-				contextServers["encore-mcp"] = map[string]any{
+				contextServers["encore-local"] = map[string]any{
 					"command": "encore",
 					"args":    []string{"mcp", "run", "--app=" + appSlug},
 					"env":     map[string]any{},

--- a/docs/go/ai-integration.md
+++ b/docs/go/ai-integration.md
@@ -81,14 +81,14 @@ This displays connection information. Keep it running while using your AI tools.
 
 **Quick setup:** Use this button (update `your-app-id` to your actual app ID):
 
-<a href="https://cursor.com/en/install-mcp?name=encore-mcp&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-mcp MCP server to Cursor" height="32" class="noshadow" /></a>
+<a href="https://cursor.com/en/install-mcp?name=encore-local&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-local MCP server to Cursor" height="32" class="noshadow" /></a>
 
 **Manual setup:** Create `.cursor/mcp.json`:
 
 ```json
 {
   "mcpServers": {
-    "encore-mcp": {
+    "encore-local": {
       "command": "encore",
       "args": ["mcp", "run", "--app=your-app-id"]
     }
@@ -103,10 +103,10 @@ Find your app ID in the `encore.app` file or in the [Encore dashboard](https://a
 From your Encore app directory:
 
 ```bash
-claude mcp add --transport stdio encore-mcp -- encore mcp run --app=your-app-id
+claude mcp add --transport stdio encore-local -- encore mcp run --app=your-app-id
 ```
 
-Verify with `claude mcp list`. You should see `encore-mcp` in the list.
+Verify with `claude mcp list`. You should see `encore-local` in the list.
 
 ## What AI Can Do
 

--- a/docs/go/cli/mcp.md
+++ b/docs/go/cli/mcp.md
@@ -28,14 +28,14 @@ Copy the appropriate URL or command to your MCP host's configuration, and you're
 
 In order to add the Encore MCP server to Cursor, the fastest way is via the button below (make sure to update `your-app-id` in the configuration to your actual Encore app ID).
 
-<a href="https://cursor.com/en/install-mcp?name=encore-mcp&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-mcp MCP server to Cursor" height="32" class="noshadow" /></a>
+<a href="https://cursor.com/en/install-mcp?name=encore-local&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-local MCP server to Cursor" height="32" class="noshadow" /></a>
 
 If you prefer to configure it manually, create the file `.cursor/mcp.json` with the following settings:
 
 ```json
 {
     "mcpServers": {
-        "encore-mcp": {
+        "encore-local": {
             "command": "encore",
             "args": ["mcp", "run", "--app=your-app-id"]
         }

--- a/docs/ts/ai-integration.md
+++ b/docs/ts/ai-integration.md
@@ -81,14 +81,14 @@ This displays connection information. Keep it running while using your AI tools.
 
 **Quick setup:** Use this button (update `your-app-id` to your actual app ID):
 
-<a href="https://cursor.com/en/install-mcp?name=encore-mcp&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-mcp MCP server to Cursor" height="32" class="noshadow" /></a>
+<a href="https://cursor.com/en/install-mcp?name=encore-local&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-local MCP server to Cursor" height="32" class="noshadow" /></a>
 
 **Manual setup:** Create `.cursor/mcp.json`:
 
 ```json
 {
   "mcpServers": {
-    "encore-mcp": {
+    "encore-local": {
       "command": "encore",
       "args": ["mcp", "run", "--app=your-app-id"]
     }
@@ -103,10 +103,10 @@ Find your app ID in the `encore.app` file or in the [Encore dashboard](https://a
 From your Encore app directory:
 
 ```bash
-claude mcp add --transport stdio encore-mcp -- encore mcp run --app=your-app-id
+claude mcp add --transport stdio encore-local -- encore mcp run --app=your-app-id
 ```
 
-Verify with `claude mcp list`. You should see `encore-mcp` in the list.
+Verify with `claude mcp list`. You should see `encore-local` in the list.
 
 ## What AI Can Do
 

--- a/docs/ts/cli/mcp.md
+++ b/docs/ts/cli/mcp.md
@@ -28,14 +28,14 @@ Copy the appropriate URL or command to your MCP host's configuration, and you're
 
 In order to add the Encore MCP server to Cursor, the fastest way is via the button below (make sure to update `your-app-id` in the configuration to your actual Encore app ID).
 
-<a href="https://cursor.com/en/install-mcp?name=encore-mcp&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-mcp MCP server to Cursor" height="32" class="noshadow" /></a>
+<a href="https://cursor.com/en/install-mcp?name=encore-local&config=eyJjb21tYW5kIjoiZW5jb3JlIG1jcCBydW4gLS1hcHA9eW91ci1hcHAtaWQifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add encore-local MCP server to Cursor" height="32" class="noshadow" /></a>
 
 If you prefer to configure it manually, create the file `.cursor/mcp.json` with the following settings:
 
 ```json
 {
     "mcpServers": {
-        "encore-mcp": {
+        "encore-local": {
              "command": "encore",
              "args": ["mcp", "run", "--app=your-app-id"]
         }


### PR DESCRIPTION
## Summary
Renames the MCP server name written to `.mcp.json` (and the equivalent config files for Cursor, VS Code, and Zed) from `encore-mcp` to `encore-local`. Applies both when creating a new app and when running `encore llm-rules init`. Documentation in `docs/{ts,go}/ai-integration.md` and `docs/{ts,go}/cli/mcp.md` is updated to match, including the Cursor install deeplink.

## Test plan
- [ ] `encore app create` writes `encore-local` into the generated MCP config files
- [ ] `encore llm-rules init` writes `encore-local` for Cursor / Claude Code / VS Code / Zed