### PR TITLE
runtimes/js (sqldb): expose column metadata (OID, type name) on `rawQueryAll` results

### DIFF
--- a/runtimes/core/src/sqldb/client.rs
+++ b/runtimes/core/src/sqldb/client.rs
@@ -135,6 +135,16 @@ pub struct Row {
     row: tokio_postgres::Row,
 }
 
+/// Metadata about a column in a query result.
+pub struct ColumnInfo {
+    pub name: String,
+    pub type_oid: u32,
+    pub type_name: String,
+    /// The OID of the table the column belongs to, if any.
+    /// This is useful for disambiguating columns with the same name from different tables in JOIN results.
+    pub table_oid: Option<u32>,
+}
+
 impl Row {
     pub fn values(&self) -> anyhow::Result<HashMap<String, RowValue>> {
         let cols = self.row.columns();
@@ -148,6 +158,19 @@ impl Row {
             map.insert(name, value);
         }
         Ok(map)
+    }
+
+    /// Returns metadata about the columns in this row.
+    pub fn columns(&self) -> Vec<ColumnInfo> {
+        self.row.columns()
+            .iter()
+            .map(|col| ColumnInfo {
+                name: col.name().to_string(),
+                type_oid: col.type_().oid(),
+                type_name: col.type_().name().to_string(),
+                table_oid: col.table_oid(),
+            })
+            .collect()
     }
 }
 

--- a/runtimes/core/src/sqldb/mod.rs
+++ b/runtimes/core/src/sqldb/mod.rs
@@ -4,7 +4,7 @@ pub mod numeric;
 mod transaction;
 mod val;
 
-pub use client::{Connection, Cursor, Pool, Row};
+pub use client::{ColumnInfo, Connection, Cursor, Pool, Row};
 pub use manager::{Database, DatabaseImpl, Manager, ManagerConfig};
 pub use transaction::Transaction;
 pub use val::RowValue;

--- a/runtimes/js/encore.dev/storage/sqldb/database.ts
+++ b/runtimes/js/encore.dev/storage/sqldb/database.ts
@@ -18,6 +18,29 @@ const driverName = "node-pg";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Row = Record<string, any>;
 
+/**
+ * Metadata about a column in a query result
+ */
+export interface ColumnInfo {
+  /** The name of the column */
+  name: string;
+  /** The PostgreSQL type OID */
+  typeOid: number;
+  /** The PostgreSQL type name (e.g., "int4", "text", "jsonb") */
+  typeName: string;
+  /** 
+   * The OID of the table the column belongs to, if any.
+   * Useful for disambiguating columns with the same name from different tables in JOIN results.
+   */
+  tableOid: number | null;
+}
+
+/**
+ * Result of a query that returns all rows as an array,
+ * with an additional `columns` property containing column metadata.
+ */
+export type QueryResult<T> = T[] & { columns: ColumnInfo[] };
+
 /** Represents a type that can be used in query template literals */
 export type Primitive =
   | string
@@ -123,18 +146,24 @@ class BaseQueryExecutor {
   async queryAll<T extends Row = Record<string, any>>(
     strings: TemplateStringsArray,
     ...params: Primitive[]
-  ): Promise<T[]> {
+  ): Promise<QueryResult<T>> {
     const query = buildQuery(strings, params);
     const args = buildQueryArgs(params);
     const source = getCurrentRequest();
     const cursor = await this.impl.query(query, args, source);
     const result: T[] = [];
+    let columns: ColumnInfo[] = [];
     while (true) {
       const row = await cursor.next();
       if (row === null) break;
+      if (result.length === 0) {
+        // Get columns from first row
+        columns = row.columns() as ColumnInfo[];
+      }
       result.push(row.values() as T);
     }
-    return result;
+    (result as QueryResult<T>).columns = columns;
+    return result as QueryResult<T>;
   }
 
   /**
@@ -152,17 +181,23 @@ class BaseQueryExecutor {
   async rawQueryAll<T extends Row = Record<string, any>>(
     query: string,
     ...params: Primitive[]
-  ): Promise<T[]> {
+  ): Promise<QueryResult<T>> {
     const args = buildQueryArgs(params);
     const source = getCurrentRequest();
     const cursor = await this.impl.query(query, args, source);
     const result: T[] = [];
+    let columns: ColumnInfo[] = [];
     while (true) {
       const row = await cursor.next();
       if (row === null) break;
+      if (result.length === 0) {
+        // Get columns from first row
+        columns = row.columns() as ColumnInfo[];
+      }
       result.push(row.values() as T);
     }
-    return result;
+    (result as QueryResult<T>).columns = columns;
+    return result as QueryResult<T>;
   }
 
   /**

--- a/runtimes/js/src/sqldb.rs
+++ b/runtimes/js/src/sqldb.rs
@@ -8,6 +8,16 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::{Arc, OnceLock};
 
+#[napi(object)]
+pub struct ColumnInfo {
+    pub name: String,
+    pub type_oid: u32,
+    pub type_name: String,
+    /// The OID of the table the column belongs to, if any.
+    /// Useful for disambiguating columns with the same name from different tables in JOIN results.
+    pub table_oid: Option<u32>,
+}
+
 #[napi]
 pub struct SQLDatabase {
     db: Arc<dyn sqldb::Database>,
@@ -220,6 +230,19 @@ impl Row {
             map.insert(key, val);
         }
         Ok(map)
+    }
+
+    #[napi]
+    pub fn columns(&self) -> Vec<ColumnInfo> {
+        self.row.columns()
+            .into_iter()
+            .map(|c| ColumnInfo {
+                name: c.name,
+                type_oid: c.type_oid,
+                type_name: c.type_name,
+                table_oid: c.table_oid,
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Context

I am building a Prisma driver adapter that lets Encore.ts `SQLDatabase` instances be used as the underlying connection for Prisma ORM. The main objective is to enable tracing and make debugging easier, as queries sent via regular `prisma-pg` adapter go invisible in the dashboard. 

Prisma's driver adapter interface requires each query result to include a `columnTypes` array alongside `columnNames` and `rows`. The `columnTypes` values come from Prisma's `ColumnTypeEnum` and tell Prisma how to interpret each value before handing it to the application — for example, whether to call `JSON.parse`, whether to convert to `BigInt`, or whether to pass the value through as-is.

Without type metadata from the driver, the adapter has no reliable way to populate `columnTypes` correctly. I have tried to automate data type guessing, as it's generally not hard, but there are instances where a single shape can be representing two different column types, and Prisma expects them to be returned in a different format. 

This is what it looks like for queries that work:
<img width="554" height="288" alt="Screenshot 2026-04-20 at 4 08 29 PM" src="https://github.com/user-attachments/assets/e438340d-d3de-4ebb-9a21-34c2a71f7ab9" />
<img width="867" height="328" alt="Screenshot 2026-04-20 at 4 10 01 PM" src="https://github.com/user-attachments/assets/5f698f5f-6cb5-4d16-b7a8-716c4ce548e8" />


---

## The Problem: JSONB Without Type Metadata

PostgreSQL's `JSONB` type is where this gap is most visible. Encore automatically deserializes JSONB column values into native JavaScript types — objects become plain JS objects, arrays become JS arrays, strings become JS strings. This is convenient in general, but creates an ambiguity for the adapter:

- A `jsonb` column returning `[1, 2, 3]` looks identical to an `int4[]` column returning `[1, 2, 3]`
- A `jsonb` column returning `"hello"` looks identical to a `text` column returning `"hello"`
- A `jsonb` column returning `{ "key": 1 }` looks identical to any other column returning a plain JS object

Without knowing the column's actual PostgreSQL type, the adapter must guess — and guessing wrong produces silent data corruption in the application layer.

---

## What Breaks Without Type Information

### JSONB arrays returned as native arrays

Prisma processes `Json` schema fields using template literal coercion: `` `${value}` ``. For a plain JS object this produces a valid JSON string. For a JS array it does not:

```
`${[1, 2, 3]}` → "1,2,3"   // not valid JSON
```

Prisma then calls `JSON.parse("1,2,3")` which throws. The result: a `findMany` on a model with a `Json` field that holds an array value crashes, or returns corrupted data.

### JSONB strings returned as bare JS strings

A JSONB string value `"hello"` (stored as `"hello"` in PostgreSQL) is returned by Encore as the plain JS string `hello`. Prisma's template literal gives:

```
`${"hello"}` → "hello"     // not valid JSON
JSON.parse("hello")        // throws SyntaxError
```

The application receives an error or an empty value instead of the string `"hello"`.

### Typed arrays misidentified as JSONB

The reverse is also a problem: an `int4[]` column returning `[1, 2, 3]` might be mistakenly treated as JSONB by a heuristic, causing the adapter to `JSON.stringify` the array before returning it. Prisma then receives `"[1,2,3]"` instead of `[1, 2, 3]`, and integer array fields return the wrong type to the application.

---

## What Column Metadata Enables

With `typeOid`, `tableOid` (null for generated columns), and `typeName` available on the result, the adapter can:

1. **Return correct `ColumnTypeEnum` values** — `jsonb` (OID 3802) maps to `ColumnTypeEnum.Json`; `_jsonb` (OID 3807) maps to `ColumnTypeEnum.JsonArray`; `int4[]` (OID 1007) maps to `ColumnTypeEnum.Int32Array`. Prisma uses this to apply the correct deserialization path.

2. **Normalize values correctly per column** — For `jsonb` columns, the adapter can `JSON.stringify` arrays and bare strings before returning them, so Prisma's template literal coercion produces valid JSON that `JSON.parse` can consume.

3. **Resolve column identity in JOIN results** — `tableOid` identifies which table a column originates from, making it possible to disambiguate two columns with the same name but different types coming from different tables in a single query. Generated columns carry a null `tableOid` since they are not associated with a specific table.

4. **Distinguish ambiguous types at runtime** — No heuristics, no schema file parsing, no startup query against `information_schema.columns`. The type identity comes directly from the query response, just as it does in the standard `pg` Node.js driver via `field.dataTypeID` and `field.tableID`.

This brings the Encore adapter to parity with `@prisma/adapter-pg`, which has relied on field OIDs for correct JSON and array handling since its initial release.

---

## Why This Is a Compatibility Gap, Not a Bug

Encore's automatic JSONB deserialization is the right default for application code that uses `rawQueryAll` directly — receiving a plain JS object is more ergonomic than receiving a JSON string. The gap is specifically in the adapter layer, which sits between Encore and a library (Prisma) that has its own expectations about how values and type metadata arrive. Exposing column OIDs on the result closes that gap without changing any existing behavior.
