### PR TITLE
Add local encore_services role

### DIFF
--- a/cli/daemon/internal/debugflags/debugflags.go
+++ b/cli/daemon/internal/debugflags/debugflags.go
@@ -1,0 +1,40 @@
+// Package debugflags parses the ENCOREDEBUG environment variable, a
+// comma-separated list of key=value pairs used to toggle non-default daemon
+// behavior. Example: ENCOREDEBUG=sqldbrole=legacy,foo=bar.
+package debugflags
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// SQLDBRoleLegacy is the value of the "sqldbrole" flag that selects the
+// pre-encore_services SQL role behavior.
+const SQLDBRoleLegacy = "legacy"
+
+// Get returns the value of the named debug flag, or "" if it is not set.
+func Get(name string) string {
+	flagsOnce.Do(func() {
+		flags = parse(os.Getenv("ENCOREDEBUG"))
+	})
+	return flags[name]
+}
+
+var (
+	flagsOnce sync.Once
+	flags     map[string]string
+)
+
+func parse(s string) map[string]string {
+	out := make(map[string]string)
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, _ := strings.Cut(part, "=")
+		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return out
+}

--- a/cli/daemon/run/infra/infra.go
+++ b/cli/daemon/run/infra/infra.go
@@ -13,6 +13,7 @@ import (
 
 	"encore.dev/appruntime/exported/config"
 	"encr.dev/cli/daemon/apps"
+	"encr.dev/cli/daemon/internal/debugflags"
 	"encr.dev/cli/daemon/namespace"
 	"encr.dev/cli/daemon/objects"
 	"encr.dev/cli/daemon/pubsub"
@@ -392,10 +393,14 @@ func (rm *ResourceManager) SQLDatabaseConfig(db *meta.SQLDatabase) (config.SQLDa
 		return config.SQLDatabase{}, errors.New("no SQL cluster found")
 	}
 
+	user := "encore-service"
+	if debugflags.Get("sqldbrole") == debugflags.SQLDBRoleLegacy {
+		user = "encore"
+	}
 	dbCfg := config.SQLDatabase{
 		EncoreName:   db.Name,
 		DatabaseName: db.Name,
-		User:         "encore-service",
+		User:         user,
 		Password:     cluster.Password,
 	}
 

--- a/cli/daemon/run/infra/infra.go
+++ b/cli/daemon/run/infra/infra.go
@@ -395,7 +395,7 @@ func (rm *ResourceManager) SQLDatabaseConfig(db *meta.SQLDatabase) (config.SQLDa
 	dbCfg := config.SQLDatabase{
 		EncoreName:   db.Name,
 		DatabaseName: db.Name,
-		User:         "encore",
+		User:         "encore-service",
 		Password:     cluster.Password,
 	}
 

--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -143,7 +143,7 @@ func (c *Cluster) setupRoles(ctx context.Context, st *ClusterStatus) (EncoreRole
 
 		// Add cluster-level permissions.
 		switch role.Type {
-		case RoleAdmin:
+		case RoleAdmin, RoleMigrator:
 			// Grant admins the ability to create databases.
 			_, err := conn.Exec(ctx, `
 				ALTER USER `+sanitizedUsername+` CREATEDB CREATEROLE
@@ -185,7 +185,10 @@ func (c *Cluster) determineRoles(ctx context.Context, st *ClusterStatus, conn *p
 	if supportsPredefinedRoles {
 		// Otherwise if we support predefined roles, add more roles to use.
 		roles = append(roles,
+			Role{RoleServices, "encore_services", "services"},
+			Role{RoleMigrator, "encore-migrator", "migrator"},
 			Role{RoleAdmin, "encore-admin", "admin"},
+			Role{RoleService, "encore-service", "service"},
 			Role{RoleWrite, "encore-write", "write"},
 			Role{RoleRead, "encore-read", "read"},
 		)
@@ -399,6 +402,7 @@ func (s *ClusterStatus) ConnURI(database string, r Role) string {
 // to the cluster as an Encore user.
 type EncoreRoles []Role
 
+func (roles EncoreRoles) Migrator() (Role, bool)  { return roles.find(RoleMigrator) }
 func (roles EncoreRoles) Superuser() (Role, bool) { return roles.find(RoleSuperuser) }
 func (roles EncoreRoles) Admin() (Role, bool)     { return roles.find(RoleAdmin) }
 func (roles EncoreRoles) Write() (Role, bool)     { return roles.find(RoleWrite) }
@@ -428,7 +432,10 @@ func (r RoleType) String() string { return string(r) }
 
 const (
 	RoleSuperuser RoleType = "superuser"
+	RoleMigrator  RoleType = "migrator"
 	RoleAdmin     RoleType = "admin"
+	RoleServices  RoleType = "services"
+	RoleService   RoleType = "service"
 	RoleWrite     RoleType = "write"
 	RoleRead      RoleType = "read"
 )

--- a/cli/daemon/sqldb/db.go
+++ b/cli/daemon/sqldb/db.go
@@ -153,7 +153,7 @@ func (db *DB) doCreate(ctx context.Context, cloudName string, template option.Op
 	// Does it already exist?
 	var dummy int
 	err = adm.QueryRow(ctx, "SELECT 1 FROM pg_database WHERE datname = $1", cloudName).Scan(&dummy)
-	owner, ok := db.Cluster.Roles.First(RoleAdmin, RoleSuperuser)
+	owner, ok := db.Cluster.Roles.First(RoleMigrator, RoleAdmin, RoleSuperuser)
 	if !ok {
 		return errors.New("unable to find admin or superuser roles")
 	}
@@ -213,8 +213,29 @@ func (db *DB) ensureRoles(ctx context.Context, cloudName string, roles ...Role) 
 		case RoleSuperuser:
 			// Already granted; nothing to do
 			continue
+		case RoleServices:
+			stmt = fmt.Sprintf(`
+				GRANT ALL ON DATABASE %[1]s TO %[2]s;
+				GRANT pg_read_all_data TO %[2]s;
+				GRANT pg_write_all_data TO %[2]s;`,
+				safeDBName, safeRoleName)
+		case RoleService:
+			stmt = fmt.Sprintf(`GRANT encore_services TO %s;`, safeRoleName)
+		case RoleMigrator:
+			stmt = fmt.Sprintf(`
+				GRANT ALL ON DATABASE %[1]s TO %[2]s;
+				GRANT pg_read_all_data TO %[2]s;
+				GRANT pg_write_all_data TO %[2]s;
+				GRANT encore_services TO %[2]s;`,
+				safeDBName, safeRoleName)
 		case RoleAdmin:
-			stmt = fmt.Sprintf("GRANT ALL ON DATABASE %s TO %s;", safeDBName, safeRoleName)
+			stmt = fmt.Sprintf(`
+				GRANT ALL ON DATABASE %[1]s TO %[2]s;
+				GRANT pg_read_all_data TO %[2]s;
+				GRANT pg_write_all_data TO %[2]s;
+				GRANT "encore-migrator" TO %[2]s;
+				GRANT encore_services TO %[2]s;`,
+				safeDBName, safeRoleName)
 		case RoleWrite:
 			stmt = fmt.Sprintf(`
 				GRANT TEMP, CONNECT ON DATABASE %s TO %s;
@@ -281,7 +302,7 @@ func (db *DB) doMigrate(ctx context.Context, cloudName, appRoot string, dbMeta *
 		return errors.New("cluster not running")
 	}
 
-	admin, ok := info.Encore.First(RoleAdmin, RoleSuperuser)
+	admin, ok := info.Encore.First(RoleMigrator, RoleAdmin, RoleSuperuser)
 	if !ok {
 		return errors.New("unable to find superuser or admin roles")
 	}

--- a/cli/daemon/sqldb/db.go
+++ b/cli/daemon/sqldb/db.go
@@ -17,10 +17,21 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
+	"encr.dev/cli/daemon/internal/debugflags"
 	"encr.dev/pkg/fns"
 	"encr.dev/pkg/option"
 	meta "encr.dev/proto/encore/parser/meta/v1"
 )
+
+// migratorRoles returns the role precedence to use when running migrations
+// or creating databases. ENCOREDEBUG=sqldbrole=legacy reverts to the
+// pre-migrator-role behavior of running migrations as the admin role.
+func migratorRoles() []RoleType {
+	if debugflags.Get("sqldbrole") == debugflags.SQLDBRoleLegacy {
+		return []RoleType{RoleAdmin, RoleSuperuser}
+	}
+	return []RoleType{RoleMigrator, RoleAdmin, RoleSuperuser}
+}
 
 // DB represents a single database instance within a cluster.
 type DB struct {
@@ -153,7 +164,7 @@ func (db *DB) doCreate(ctx context.Context, cloudName string, template option.Op
 	// Does it already exist?
 	var dummy int
 	err = adm.QueryRow(ctx, "SELECT 1 FROM pg_database WHERE datname = $1", cloudName).Scan(&dummy)
-	owner, ok := db.Cluster.Roles.First(RoleMigrator, RoleAdmin, RoleSuperuser)
+	owner, ok := db.Cluster.Roles.First(migratorRoles()...)
 	if !ok {
 		return errors.New("unable to find admin or superuser roles")
 	}
@@ -302,7 +313,7 @@ func (db *DB) doMigrate(ctx context.Context, cloudName, appRoot string, dbMeta *
 		return errors.New("cluster not running")
 	}
 
-	admin, ok := info.Encore.First(RoleMigrator, RoleAdmin, RoleSuperuser)
+	admin, ok := info.Encore.First(migratorRoles()...)
 	if !ok {
 		return errors.New("unable to find superuser or admin roles")
 	}

--- a/cli/daemon/sqldb/proxy.go
+++ b/cli/daemon/sqldb/proxy.go
@@ -70,7 +70,7 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 	// If the username is "encore" we're connecting to a database cluster
 	// which may not be local
 	var cluster *Cluster
-	if startup.Username == "encore" {
+	if startup.Username == "encore" || startup.Username == "encore-service" {
 		password := startup.Password
 		found, ok := cm.LookupPassword(password)
 		if !ok {
@@ -220,9 +220,14 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 	defer fns.CloseIgnore(server)
 
 	// Send a modified startup message to the backend
-	admin, _ := info.Encore.First(RoleAdmin, RoleSuperuser)
-	startup.Username = admin.Username
-	startup.Password = admin.Password
+	var role Role
+	if startup.Username == "encore-service" {
+		role, _ = info.Encore.First(RoleService, RoleAdmin, RoleSuperuser)
+	} else {
+		role, _ = info.Encore.First(RoleAdmin, RoleSuperuser)
+	}
+	startup.Username = role.Username
+	startup.Password = role.Password
 	if db == nil {
 		// We don't know about this database, we'll use the requested name
 		// in case it does actually exist within the cluster.

--- a/cli/daemon/sqldb/proxy.go
+++ b/cli/daemon/sqldb/proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgproto3/v2"
 	"github.com/rs/zerolog/log"
 
+	"encr.dev/cli/daemon/internal/debugflags"
 	"encr.dev/cli/daemon/namespace"
 	"encr.dev/pkg/fns"
 	"encr.dev/pkg/pgproxy"
@@ -221,7 +222,7 @@ func (cm *ClusterManager) ProxyConn(client net.Conn, waitForSetup bool) error {
 
 	// Send a modified startup message to the backend
 	var role Role
-	if startup.Username == "encore-service" {
+	if startup.Username == "encore-service" && debugflags.Get("sqldbrole") != debugflags.SQLDBRoleLegacy {
 		role, _ = info.Encore.First(RoleService, RoleAdmin, RoleSuperuser)
 	} else {
 		role, _ = info.Encore.First(RoleAdmin, RoleSuperuser)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -117,6 +117,16 @@ func EncoreObjectStorageListAddr() option.Option[string] {
 	return option.None[string]()
 }
 
+// EncoreDebug reports the value of the ENCOREDEBUG environment variable,
+// a comma-separated list of key=value pairs that toggle non-default daemon
+// behavior (e.g. ENCOREDEBUG=sqldbrole=legacy).
+func EncoreDebug() option.Option[string] {
+	if p := os.Getenv("ENCOREDEBUG"); p != "" {
+		return option.Some(p)
+	}
+	return option.None[string]()
+}
+
 func encoreGoRoot() string {
 	if p := os.Getenv("ENCORE_GOROOT"); p != "" {
 		return p

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -44,6 +44,7 @@ func ConfigHash() (string, error) {
 	fmt.Fprintf(h, "EncoreDevDashListenAddr=%s\n", env.EncoreDevDashListenAddr().GetOrElse(""))
 	fmt.Fprintf(h, "EncoreMCPSSEListenAddr=%s\n", env.EncoreMCPSSEListenAddr().GetOrElse(""))
 	fmt.Fprintf(h, "EncoreObjectStorageListAddr=%s\n", env.EncoreObjectStorageListAddr().GetOrElse(""))
+	fmt.Fprintf(h, "EncoreDebug=%s\n", env.EncoreDebug().GetOrElse(""))
 
 	digest := h.Sum(nil)
 	return base64.RawURLEncoding.EncodeToString(digest), nil


### PR DESCRIPTION
This PR will split the SQL database role running migrations and the role used by the services during `encore run`. It will also introduce a role group (encore_services) which the role used by the services is granted. 