### PR TITLE
Add Managing Infrastructure docs page

### DIFF
--- a/docs/go/primitives/databases.md
+++ b/docs/go/primitives/databases.md
@@ -185,6 +185,8 @@ It's often useful to be able to connect to the database from outside the backend
 
 Currently Encore does not expose user credentials for databases in the local environment or for environments on Encore Cloud. You can use a connection string to connect instead, see below.
 
+If you need to connect external tools like data pipelines or BI platforms, see [Connecting external tools to databases](/docs/platform/infrastructure/managing-infrastructure#connecting-external-tools-to-databases) for guidance on SSL certificates and network access.
+
 ### Using the Encore CLI
 
 Encore's CLI comes with built-in support for connecting to databases:

--- a/docs/menu.cue
+++ b/docs/menu.cue
@@ -1201,6 +1201,11 @@
 				text: "Infrastructure Configuration"
 				path: "/platform/infrastructure/configuration"
 				file: "platform/infrastructure/configuration"
+			}, {
+				kind: "basic"
+				text: "Managing Infrastructure"
+				path: "/platform/infrastructure/managing-infrastructure"
+				file: "platform/infrastructure/managing-infrastructure"
 			},
 			{
 				kind: "accordion"

--- a/docs/platform/deploy/security.md
+++ b/docs/platform/deploy/security.md
@@ -27,3 +27,4 @@ When Encore Cloud deploys your application and infrastructure, it takes care of 
 - **Cloud security**: Automatic provisioning with security best practices specific to each cloud provider
   - Learn more about [Google Cloud Platform (GCP)](/docs/platform/infrastructure/gcp)
   - Learn more about [Amazon Web Services (AWS)](/docs/platform/infrastructure/aws)
+- **Infrastructure safety**: Deletion protection, admin-only environment management, and full audit trails for infrastructure changes. Learn more in [Managing Infrastructure](/docs/platform/infrastructure/managing-infrastructure).

--- a/docs/platform/deploy/security.md
+++ b/docs/platform/deploy/security.md
@@ -24,6 +24,7 @@ When Encore Cloud deploys your application and infrastructure, it takes care of 
 
 - **Strong encryption**: All communication uses mutual TLSv1.3
 - **Secure databases**: Database access is encrypted with certificate validation and strong security credentials
+- **Isolated database credentials**: Each database instance has unique credentials, and each container connecting to a database uses its own credential. Credentials can be [rotated via the dashboard](/docs/platform/infrastructure/manage-db-users).
 - **Cloud security**: Automatic provisioning with security best practices specific to each cloud provider
   - Learn more about [Google Cloud Platform (GCP)](/docs/platform/infrastructure/gcp)
   - Learn more about [Amazon Web Services (AWS)](/docs/platform/infrastructure/aws)

--- a/docs/platform/infrastructure/configuration.md
+++ b/docs/platform/infrastructure/configuration.md
@@ -56,6 +56,8 @@ Therefore it only makes the minimum necessary modifications to infrastructure wh
 
 - **Avoid full syncs:** Unlike Terraform, Encore Cloud updates only the specific resources necessary to accomplish an infrastructure change rather than performing a complete infrastructure refresh.
 
+- **Drift-aware updates:** Before making any changes to a resource, Encore Cloud pulls the current resource properties. If drift is detected (e.g. a setting was changed directly in the cloud console), Encore updates its internal representation to match the current state, unless there is a pending, unapplied change request in the Encore Cloud dashboard.
+
 These behaviors ensure an efficient and predictable workflow, minimizing unintended changes and reducing deployment times, and means that you can safely use your cloud provider's console to modify the provisioned resources.
 
 This behavior also makes Encore Cloud well-suited for environments where infrastructure is partially managed outside of Encore Cloud, enabling you to deploy Encore applications alongside existing infrastructure (more on this below).

--- a/docs/platform/infrastructure/infra.md
+++ b/docs/platform/infrastructure/infra.md
@@ -106,3 +106,5 @@ Encore Cloud provisions production infrastructure resources using best-practice 
 With Encore you do not define any cloud service specifics in the application code. This means that after deploying, you can safely use your cloud provider's console to modify the provisioned resources, or use the built-in configuration UI in the Encore Cloud dashboard.
 
 Learn more in the [Infrastructure Configuration](/docs/platform/infrastructure/configuration) documentation.
+
+For information on infrastructure safety, upgrades, disaster recovery, and shared responsibilities, see [Managing Infrastructure](/docs/platform/infrastructure/managing-infrastructure).

--- a/docs/platform/infrastructure/manage-db-users.md
+++ b/docs/platform/infrastructure/manage-db-users.md
@@ -23,7 +23,7 @@ To connect to an Encore Cloud-hosted database, use [`encore db shell`](/docs/ts/
 Encore Cloud provisions unique credentials at multiple levels to ensure proper security isolation:
 
 - Each database instance has its own unique credentials.
-- Each container connecting to a database uses a unique credential, so no credentials are shared across services or instances.
+- Each container connecting to a database uses a unique credential.
 
 ## Credential rotation
 

--- a/docs/platform/infrastructure/manage-db-users.md
+++ b/docs/platform/infrastructure/manage-db-users.md
@@ -18,6 +18,17 @@ To connect to an Encore Cloud-hosted database, use [`encore db shell`](/docs/ts/
 
 <img src="/assets/docs/db-user.png" title="View Database User Credentials"/>
 
+## Credential isolation
+
+Encore Cloud provisions unique credentials at multiple levels to ensure proper security isolation:
+
+- Each database instance has its own unique credentials.
+- Each container connecting to a database uses a unique credential, so no credentials are shared across services or instances.
+
+## Credential rotation
+
+To rotate database credentials, open the [Encore Cloud dashboard](https://app.encore.cloud) and navigate to the **Infrastructure** page for the relevant environment. In the database cluster section, use the rotation controls to generate new credentials. Existing connections will be updated automatically on the next deployment.
+
 <Callout type="important">
 
 Do not change or remove the database users created by Encore, as this will prevent Encore Cloud from maintaining and handling connections to the databases in your application.

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -105,6 +105,21 @@ CREATE TABLE myapp.todo_item (
 
 This is purely a migration-level decision and does not require any changes to Encore's configuration.
 
+### Database availability
+
+Encore Cloud provisions databases with regional (multi-AZ) availability by default, distributing replicas across multiple availability zones for higher resilience. This means your database remains available even if an individual zone experiences an outage.
+
+You can change the availability configuration on the **Infrastructure** page in the Encore Cloud dashboard:
+
+- **Regional (multi-AZ):** Default. Provides higher availability and automatic failover across zones. Recommended for production workloads.
+- **Zonal (single-AZ):** Runs the database in a single availability zone. Lower cost, but no automatic failover if the zone goes down. Suitable for development environments or workloads where cost is a higher priority than availability.
+
+<Callout type="important">
+
+Switching between regional and zonal availability causes downtime while the change is applied. Plan accordingly and consider making this change during a maintenance window.
+
+</Callout>
+
 ### Credential management
 
 Encore Cloud automatically manages database credentials with built-in isolation:

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -148,8 +148,22 @@ To download the CA certificate and create a client certificate for your database
 6. If your tool requires a client certificate, under **Manage client certificates**, click **Create Client Certificate** and follow the prompts.
 
 *AWS (RDS):*
-1. Download the RDS CA certificate bundle from the [AWS RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html).
-2. Configure your tool to use the appropriate regional or global CA certificate.
+1. Download the RDS CA certificate bundle. You can use the global bundle (covers all regions) or a region-specific one:
+   ```shell
+   # Global bundle (recommended)
+   $ wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+
+   # Or region-specific, e.g. us-east-1
+   $ wget https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
+   ```
+2. Configure your tool to trust the downloaded certificate. For example, with `psql`:
+   ```shell
+   $ psql "host=your-instance.rds.amazonaws.com dbname=yourdb user=youruser sslmode=verify-full sslrootcert=global-bundle.pem"
+   ```
+3. For application connection strings, append the SSL parameters:
+   ```
+   postgresql://user:password@your-instance.rds.amazonaws.com:5432/dbname?sslmode=verify-full&sslrootcert=/path/to/global-bundle.pem
+   ```
 
 Configure your external tool to trust the downloaded CA certificate, and provide the client certificate if required. The exact configuration depends on the tool you are using.
 

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -17,7 +17,7 @@ Encore Cloud implements multiple layers of protection against accidental or mali
 - **Admin-only environment deletion:** Only users with the Admin role can destroy or delete environments. [Learn more about roles](/docs/platform/management/permissions).
 - **Confirmation required:** Destroying an environment requires the admin to manually type a confirmation message.
 - **Stateful resource protection:** Stateful resources (databases, buckets, queues) are never deleted unless they are unused by the application and a user has manually confirmed deletion. Encore tracks which resources are in use through its [Application Model](/docs/ts/concepts/application-model).
-- **Cloud provider safeguards:** For GCP deployments, SQL databases have deletion protection enabled at the cloud provider level, which must be manually disabled in the GCP console before the resource can be removed.
+- **Cloud provider safeguards:** For deployments to your own cloud, SQL databases have deletion protection enabled at the cloud provider level, which must be manually disabled in the cloud provider console before the resource can be removed.
 
 ### Drift detection
 
@@ -74,7 +74,7 @@ Encore runtime versions are automatically included as part of each build in the 
 Encore Cloud automatically applies schema migrations as part of each deployment. However, PostgreSQL major version upgrades (e.g. PostgreSQL 15 to 16) are handled differently:
 
 - **Major version upgrades** must be manually initiated. They involve downtime and should be planned accordingly. Expect 10 to 20 minutes of downtime depending on database size, controlled by the cloud provider.
-- **Migration tooling:** Standard cloud provider tools (e.g. `pg_dump`/`pg_restore` for GCP) are supported for migrating data between database versions or environments.
+- **Migration tooling:** Standard cloud provider tools and PostgreSQL utilities like `pg_dump`/`pg_restore` are supported for migrating data between database versions or environments.
 - **Testing:** Always test major upgrades in a staging environment before rolling out to production. Major PostgreSQL version upgrades may introduce backward compatibility issues at the SQL level.
 
 ### Infrastructure component upgrades
@@ -85,20 +85,20 @@ Upgrades to the underlying cloud services (Cloud Run, Pub/Sub, IAM, VPC, etc.) a
 
 ### Built-in protections
 
-For GCP deployments, Encore Cloud provisions databases with the following protections by default:
+When deploying to your own cloud account, Encore Cloud provisions databases with the following protections by default:
 
 - **Automated daily backups** retained for 7 days
 - **Point-in-time recovery (PITR)** capabilities
 - **Private subnet placement** for network isolation
 
-Learn more about the default database configuration in the [GCP Infrastructure](/docs/platform/infrastructure/gcp) docs.
+Learn more about the default database configuration in the [GCP Infrastructure](/docs/platform/infrastructure/gcp) and [AWS Infrastructure](/docs/platform/infrastructure/aws) docs.
 
 ### Configuring DR
 
 Disaster recovery settings for stateful resources can be configured in two ways:
 
 1. **Encore Cloud dashboard:** Use the infrastructure configuration UI to adjust backup schedules, retention periods, and other DR-related settings.
-2. **Cloud provider console:** Since Encore Cloud deploys infrastructure directly into your cloud account, you can configure DR settings (high availability, multi-zone, cross-region replication, etc.) directly in the GCP or AWS console.
+2. **Cloud provider console:** Since Encore Cloud deploys infrastructure directly into your cloud account, you can configure DR settings (high availability, multi-zone, cross-region replication, etc.) directly in your cloud provider's console.
 
 Learn more about manual configuration in the [Infrastructure Configuration](/docs/platform/infrastructure/configuration) docs.
 

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -2,7 +2,7 @@
 seotitle: Managing Infrastructure – Safety, Upgrades & Disaster Recovery
 seodesc: Learn how Encore Cloud protects your infrastructure with deletion safeguards, handles upgrades, and supports disaster recovery for production environments.
 title: Managing Infrastructure
-subtitle: Safety, upgrades, database management, and disaster recovery
+subtitle: Day 2 operations for production infrastructure
 lang: platform
 ---
 

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -135,12 +135,25 @@ For cloud environments on AWS/GCP, you can retrieve database credentials from th
 
 **SSL/TLS certificates**
 
-Encore Cloud provisions databases with TLS encryption enabled. When connecting external tools, you may need to configure SSL certificates:
+Encore Cloud provisions databases with TLS encryption enabled. When connecting external tools (data pipelines, replication services, database management utilities, etc.), you will need to configure SSL certificates for the connection.
 
-- **Download the CA certificate** from your cloud provider's console (e.g. the Cloud SQL instance page in GCP, or the RDS instance page in AWS) and configure your tool to trust it.
-- **Disable TLS verification** if your tool connects over a trusted internal network (e.g. within the same VPC via a private IP or a secured proxy). This is only appropriate when the connection path is already encrypted or isolated at the network level.
+To download the CA certificate and create a client certificate for your database instance:
 
-The right approach depends on your network topology and security requirements. Tools connecting over the public internet should always use TLS with proper certificate validation.
+*GCP (Cloud SQL):*
+1. Go to the Cloud SQL Instances page in the GCP console.
+2. Click on your PostgreSQL instance name.
+3. Select **Connections** from the left-hand menu.
+4. Click the **Security** tab.
+5. Under **Manage certificates**, click **Download CA certificate**. This downloads the `server-ca.pem` file.
+6. If your tool requires a client certificate, under **Manage client certificates**, click **Create Client Certificate** and follow the prompts.
+
+*AWS (RDS):*
+1. Download the RDS CA certificate bundle from the [AWS RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html).
+2. Configure your tool to use the appropriate regional or global CA certificate.
+
+Configure your external tool to trust the downloaded CA certificate, and provide the client certificate if required. The exact configuration depends on the tool you are using.
+
+If your tool connects over a trusted internal network (e.g. within the same VPC via a private IP or a secured proxy), you may be able to disable TLS verification. This is only appropriate when the connection path is already encrypted or isolated at the network level. Tools connecting over the public internet should always use TLS with proper certificate validation.
 
 ## Disaster Recovery
 

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -112,19 +112,23 @@ For production environments with specific RTO/RPO targets, consider:
 - Testing recovery procedures regularly in non-production environments
 - Documenting your recovery runbooks
 
-## Shared Responsibility Model
+## What Encore Cloud Automates vs. What You Control
 
-Encore Cloud and your team share responsibility for operating production infrastructure:
+Encore Cloud automates the heavy lifting of infrastructure management, while giving you full control over customization and decisions that are specific to your application.
 
-| Area | Encore Cloud | Customer |
-| --- | --- | --- |
-| **Infrastructure provisioning** | Automatically provisions and manages cloud resources based on your application code | Defines infrastructure requirements through application code |
-| **Deployments** | Builds, tests, and deploys automatically via CI/CD | Pushes code changes; optionally reviews and approves deployments |
-| **Schema migrations** | Automatically applies database migrations on deploy | Writes and tests migration files |
-| **Runtime upgrades** | Includes latest runtime in each build | Optionally pins specific versions; tests in staging |
-| **PostgreSQL major upgrades** | N/A (must be manually initiated) | Plans and executes major version upgrades; tests in staging first |
-| **Infrastructure configuration** | Provides defaults following best practices | Customizes settings via dashboard or cloud console as needed |
-| **Disaster recovery** | Provides default backups and PITR for databases | Configures DR settings to meet specific RTO/RPO requirements |
-| **Security & IAM** | Automatically manages IAM with least-privilege; encrypts data in transit and at rest | Reviews permissions; manages application-level auth |
-| **Monitoring & alerting** | Provides built-in observability (tracing, metrics, logs) | Sets up custom alerts and monitors for application-specific needs |
-| **Cloud provider updates** | Manages GCP/AWS deprecations as they arise | Stays informed of cloud provider deprecation notices |
+### Automated by Encore Cloud
+- **Infrastructure provisioning:** Cloud resources are automatically created and managed based on your application code. No Terraform, no YAML.
+- **Deployments and CI/CD:** Every git push triggers a build, test, and deploy pipeline. No manual steps required.
+- **Schema migrations:** Database migrations are automatically applied on each deploy.
+- **Runtime upgrades:** Each build includes the latest Encore runtime. Backward compatibility is maintained across releases.
+- **Security and IAM:** IAM policies are automatically managed using the principle of least privilege. All data is encrypted in transit and at rest.
+- **Monitoring and observability:** Built-in distributed tracing, metrics, and logging are available out of the box.
+- **Cloud provider updates:** Encore Cloud handles changes to underlying cloud services as part of normal deployments.
+
+### Under your control
+- **Infrastructure customization:** Override defaults via the Encore Cloud dashboard or directly in your cloud provider's console.
+- **Deploy approval:** Optionally require admin approval for deployments that include infrastructure changes.
+- **Runtime pinning:** Pin specific runtime or base image versions when you need to.
+- **PostgreSQL major upgrades:** Major version upgrades are a manual decision, giving you control over timing and testing.
+- **Disaster recovery tuning:** Encore provides default backups and PITR. You can adjust retention, replication, and HA settings to meet your specific RTO/RPO targets.
+- **Application-level concerns:** Authentication logic, custom alerting, and domain-specific monitoring are yours to configure as needed.

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -115,6 +115,33 @@ Encore Cloud automatically manages database credentials with built-in isolation:
 
 Learn more about viewing and managing database credentials in the [Managing database users](/docs/platform/infrastructure/manage-db-users) docs.
 
+### Connecting external tools to databases
+
+When deploying to your own cloud account, Encore Cloud provisions databases in private subnets that are not directly accessible from the public internet. If you need to connect external tools (data pipelines, BI platforms, database management utilities, etc.) to your databases, there are a few approaches:
+
+**Using the Encore CLI proxy**
+
+The simplest way to connect external tools is through the Encore CLI's built-in database proxy:
+
+```shell
+$ encore db proxy --env=<environment-name>
+```
+
+This sets up a local proxy that forwards connections to your databases. External tools can then connect to the local proxy endpoint. Learn more in the [database CLI docs](/docs/ts/primitives/databases#connecting-to-databases).
+
+**Using database credentials directly**
+
+For cloud environments on AWS/GCP, you can retrieve database credentials from the Encore Cloud dashboard and use them with your cloud provider's connectivity options (e.g. VPC peering, private service access, or a proxy). See the [Managing database users](/docs/platform/infrastructure/manage-db-users) docs for how to access credentials.
+
+**SSL/TLS certificates**
+
+Encore Cloud provisions databases with TLS encryption enabled. When connecting external tools, you may need to configure SSL certificates:
+
+- **Download the CA certificate** from your cloud provider's console (e.g. the Cloud SQL instance page in GCP, or the RDS instance page in AWS) and configure your tool to trust it.
+- **Disable TLS verification** if your tool connects over a trusted internal network (e.g. within the same VPC via a private IP or a secured proxy). This is only appropriate when the connection path is already encrypted or isolated at the network level.
+
+The right approach depends on your network topology and security requirements. Tools connecting over the public internet should always use TLS with proper certificate validation.
+
 ## Disaster Recovery
 
 ### Built-in protections

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -81,6 +81,40 @@ Encore Cloud automatically applies schema migrations as part of each deployment.
 
 Upgrades to the underlying cloud services (Cloud Run, Pub/Sub, IAM, VPC, etc.) are handled as part of the normal [deployment phases](#deployment-phases). By default, these upgrades are applied automatically during deployment. You can require admin approval for deployments that include infrastructure changes through the [deploy approval](#deploy-approval) settings.
 
+## Database Management
+
+### Instance naming
+
+Encore Cloud assigns names to database instances automatically when provisioning. Cloud providers (e.g. GCP Cloud SQL, AWS RDS) do not support renaming instances after creation. If you need a different naming convention (for example, to include environment or service identifiers), the process involves:
+
+1. Cloning the database to a new instance with the desired name.
+2. Contacting Encore support to reconfigure the environment to point to the new instance.
+3. Planning for downtime while the instance is being replaced.
+
+### Database schemas
+
+Encore does not enforce a specific PostgreSQL schema for your tables. Table creation is controlled entirely by your [migration files](/docs/ts/primitives/databases#database-migrations), so you have full control over which schema tables are created in. If your organization requires tables to be in a dedicated schema rather than `public`, update your migration files accordingly. For example:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS myapp;
+CREATE TABLE myapp.todo_item (
+    id BIGSERIAL PRIMARY KEY,
+    title TEXT NOT NULL
+);
+```
+
+This is purely a migration-level decision and does not require any changes to Encore's configuration.
+
+### Credential management
+
+Encore Cloud automatically manages database credentials with built-in isolation:
+
+- **Per-instance credentials:** Each database instance has its own unique credentials.
+- **Per-container credentials:** Each container connecting to a database instance uses a unique credential.
+- **Credential rotation:** Credentials can be rotated through the Encore Cloud dashboard. Navigate to the **Infrastructure** page for the relevant environment and use the rotation controls in the database cluster section.
+
+Learn more about viewing and managing database credentials in the [Managing database users](/docs/platform/infrastructure/manage-db-users) docs.
+
 ## Disaster Recovery
 
 ### Built-in protections

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -2,7 +2,7 @@
 seotitle: Managing Infrastructure – Safety, Upgrades & Disaster Recovery
 seodesc: Learn how Encore Cloud protects your infrastructure with deletion safeguards, handles upgrades, and supports disaster recovery for production environments.
 title: Managing Infrastructure
-subtitle: Deletion protection, upgrades, disaster recovery, and shared responsibilities
+subtitle: Safety, upgrades, database management, and disaster recovery
 lang: platform
 ---
 

--- a/docs/platform/infrastructure/managing-infrastructure.md
+++ b/docs/platform/infrastructure/managing-infrastructure.md
@@ -1,0 +1,130 @@
+---
+seotitle: Managing Infrastructure – Safety, Upgrades & Disaster Recovery
+seodesc: Learn how Encore Cloud protects your infrastructure with deletion safeguards, handles upgrades, and supports disaster recovery for production environments.
+title: Managing Infrastructure
+subtitle: Deletion protection, upgrades, disaster recovery, and shared responsibilities
+lang: platform
+---
+
+Encore Cloud provides built-in safeguards to protect your production infrastructure, manages upgrades across the stack, and gives you the tools to implement disaster recovery. This page covers the operational aspects of running production infrastructure with Encore Cloud.
+
+## Infrastructure Safety
+
+### Deletion protection
+
+Encore Cloud implements multiple layers of protection against accidental or malicious deletion of production resources:
+
+- **Admin-only environment deletion:** Only users with the Admin role can destroy or delete environments. [Learn more about roles](/docs/platform/management/permissions).
+- **Confirmation required:** Destroying an environment requires the admin to manually type a confirmation message.
+- **Stateful resource protection:** Stateful resources (databases, buckets, queues) are never deleted unless they are unused by the application and a user has manually confirmed deletion. Encore tracks which resources are in use through its [Application Model](/docs/ts/concepts/application-model).
+- **Cloud provider safeguards:** For GCP deployments, SQL databases have deletion protection enabled at the cloud provider level, which must be manually disabled in the GCP console before the resource can be removed.
+
+### Drift detection
+
+Encore Cloud is designed to coexist with manual changes made in your cloud provider's console. When deploying, Encore pulls the current resource properties before making any changes. If drift is detected (i.e. the resource was modified outside of Encore), Encore updates its internal representation to match the current state, unless there is a pending, manually requested property change in the Encore Cloud dashboard that hasn't been applied yet.
+
+This means you can safely make changes directly in your cloud provider's console without worrying about Encore overwriting them. Learn more in the [Infrastructure Configuration](/docs/platform/infrastructure/configuration) docs.
+
+### Audit trail
+
+Encore Cloud maintains a versioned infrastructure graph where each node and edge is an immutable, versioned entity. Changes are applied by adding a new version, creating a complete audit trail:
+
+- Each infrastructure graph version is linked to the deployment that applied it.
+- Each deployment is connected to a specific git commit and any manually requested infrastructure changes.
+- Each infrastructure change request is linked to the user who requested it.
+- If a deployment was triggered manually (rather than via git push), the triggering user is also recorded.
+
+This gives you full traceability from any infrastructure state back to the code change, change request, and user responsible.
+
+## Deployment Phases
+
+When Encore Cloud deploys your application, it follows a three-phase process:
+
+1. **Infrastructure provisioning:** Encore sets up any new infrastructure required by your code changes, such as databases, IAM policies, Pub/Sub topics, and other resources.
+2. **Deployment:** Encore deploys the new container images to your compute platform (Cloud Run, Fargate, Kubernetes, etc.).
+3. **Cleanup:** Encore removes any unused stateless resources. Stateful resources are only removed if they are unused and deletion has been explicitly confirmed by a user.
+
+### Deploy approval
+
+For production environments, you can require admin approval before any deployment that includes infrastructure changes. When enabled, an Admin must manually review and approve the changes before the deployment proceeds. This includes IAM changes.
+
+To configure this, go to **Encore Cloud dashboard > (Select your environment) > Settings > Infrastructure Approval**. Learn more in the [Environments](/docs/platform/deploy/environments) docs.
+
+## Control Plane Separation
+
+Encore Cloud separates the control plane from the runtime of your services. Your application runs independently in your own cloud environment, so if Encore Cloud's control plane is unavailable, your production services continue to operate normally.
+
+The main impact of a control plane outage would be on control plane features like deployments, observability, and the Encore Cloud dashboard. Your running services, databases, and other infrastructure remain unaffected.
+
+For recovery independently of Encore's service, you retain full ownership of your infrastructure and code. You can use the [open source tools](/docs/ts/self-host/build) to build images and deploy using any alternative CI/CD tooling.
+
+## Upgrades
+
+### Runtime and SDK upgrades
+
+Encore runtime versions are automatically included as part of each build in the CI/CD pipeline. When you deploy, Encore builds your application with the latest runtime.
+
+- **Backward compatibility:** The Encore SDK maintains backward compatibility. Breaking changes have never been introduced, and if one were necessary, it would be communicated ahead of time through release notes and directly to all customers on paid plans.
+- **Custom runtime versions:** You can customize the Docker base image used for deployments through the `build.docker.base_image` setting in your `encore.app` file. This lets you pin a specific runtime version if needed. Learn more in the [Deploying](/docs/platform/deploy/deploying) docs.
+- **Rollback:** To roll back a runtime version, update the configuration to specify the desired version and re-deploy.
+- **Testing upgrades:** While generally no action is required due to backward compatibility, you can verify behavior by deploying to a staging/development environment first.
+
+### Database upgrades (PostgreSQL)
+
+Encore Cloud automatically applies schema migrations as part of each deployment. However, PostgreSQL major version upgrades (e.g. PostgreSQL 15 to 16) are handled differently:
+
+- **Major version upgrades** must be manually initiated. They involve downtime and should be planned accordingly. Expect 10 to 20 minutes of downtime depending on database size, controlled by the cloud provider.
+- **Migration tooling:** Standard cloud provider tools (e.g. `pg_dump`/`pg_restore` for GCP) are supported for migrating data between database versions or environments.
+- **Testing:** Always test major upgrades in a staging environment before rolling out to production. Major PostgreSQL version upgrades may introduce backward compatibility issues at the SQL level.
+
+### Infrastructure component upgrades
+
+Upgrades to the underlying cloud services (Cloud Run, Pub/Sub, IAM, VPC, etc.) are handled as part of the normal [deployment phases](#deployment-phases). By default, these upgrades are applied automatically during deployment. You can require admin approval for deployments that include infrastructure changes through the [deploy approval](#deploy-approval) settings.
+
+## Disaster Recovery
+
+### Built-in protections
+
+For GCP deployments, Encore Cloud provisions databases with the following protections by default:
+
+- **Automated daily backups** retained for 7 days
+- **Point-in-time recovery (PITR)** capabilities
+- **Private subnet placement** for network isolation
+
+Learn more about the default database configuration in the [GCP Infrastructure](/docs/platform/infrastructure/gcp) docs.
+
+### Configuring DR
+
+Disaster recovery settings for stateful resources can be configured in two ways:
+
+1. **Encore Cloud dashboard:** Use the infrastructure configuration UI to adjust backup schedules, retention periods, and other DR-related settings.
+2. **Cloud provider console:** Since Encore Cloud deploys infrastructure directly into your cloud account, you can configure DR settings (high availability, multi-zone, cross-region replication, etc.) directly in the GCP or AWS console.
+
+Learn more about manual configuration in the [Infrastructure Configuration](/docs/platform/infrastructure/configuration) docs.
+
+### Recommended practices
+
+For production environments with specific RTO/RPO targets, consider:
+
+- Configuring automated backups with appropriate retention periods
+- Enabling point-in-time recovery for databases
+- Setting up high-availability and multi-zone configurations
+- Testing recovery procedures regularly in non-production environments
+- Documenting your recovery runbooks
+
+## Shared Responsibility Model
+
+Encore Cloud and your team share responsibility for operating production infrastructure:
+
+| Area | Encore Cloud | Customer |
+| --- | --- | --- |
+| **Infrastructure provisioning** | Automatically provisions and manages cloud resources based on your application code | Defines infrastructure requirements through application code |
+| **Deployments** | Builds, tests, and deploys automatically via CI/CD | Pushes code changes; optionally reviews and approves deployments |
+| **Schema migrations** | Automatically applies database migrations on deploy | Writes and tests migration files |
+| **Runtime upgrades** | Includes latest runtime in each build | Optionally pins specific versions; tests in staging |
+| **PostgreSQL major upgrades** | N/A (must be manually initiated) | Plans and executes major version upgrades; tests in staging first |
+| **Infrastructure configuration** | Provides defaults following best practices | Customizes settings via dashboard or cloud console as needed |
+| **Disaster recovery** | Provides default backups and PITR for databases | Configures DR settings to meet specific RTO/RPO requirements |
+| **Security & IAM** | Automatically manages IAM with least-privilege; encrypts data in transit and at rest | Reviews permissions; manages application-level auth |
+| **Monitoring & alerting** | Provides built-in observability (tracing, metrics, logs) | Sets up custom alerts and monitors for application-specific needs |
+| **Cloud provider updates** | Manages GCP/AWS deprecations as they arise | Stays informed of cloud provider deprecation notices |

--- a/docs/ts/primitives/databases.md
+++ b/docs/ts/primitives/databases.md
@@ -202,6 +202,8 @@ It's often useful to be able to connect to the database from outside the backend
 
 Currently Encore does not expose user credentials for databases in the local environment or for environments on Encore Cloud. You can use a connection string to connect instead, see below.
 
+If you need to connect external tools like data pipelines or BI platforms, see [Connecting external tools to databases](/docs/platform/infrastructure/managing-infrastructure#connecting-external-tools-to-databases) for guidance on SSL certificates and network access.
+
 ### Using the Encore CLI
 
 Encore's CLI comes with built-in support for connecting to databases:


### PR DESCRIPTION
## Summary
- Adds a new **Managing Infrastructure** docs page (`docs/platform/infrastructure/managing-infrastructure.md`) covering infrastructure safety, upgrades, disaster recovery, and shared responsibilities
- Updates existing docs (security, infra config, infra overview) with cross-references to the new page
- Adds drift detection detail to the infrastructure configuration page

### New page covers:
- **Infrastructure Safety**: deletion protection, drift detection, audit trails
- **Deployment Phases**: the 3-phase deploy process (provision, deploy, cleanup) and deploy approval
- **Control Plane Separation**: services run independently from Encore Cloud's control plane
- **Upgrades**: runtime/SDK upgrades, PostgreSQL major upgrades, infrastructure component upgrades
- **Disaster Recovery**: built-in protections, configuring DR, recommended practices
- **Shared Responsibility Model**: table of Encore Cloud vs customer responsibilities