### PR TITLE
Fix DummySocket for latest Node socket types

### DIFF
--- a/runtimes/js/encore.dev/internal/api/node_http.ts
+++ b/runtimes/js/encore.dev/internal/api/node_http.ts
@@ -324,6 +324,8 @@ class DummySocket extends stream.Duplex {
   setTimeout(_timeout: number, _callback?: () => void): this { return this; }
   setNoDelay(_noDelay?: boolean): this { return this; }
   setKeepAlive(_enable?: boolean, _initialDelay?: number): this { return this; }
+  getTypeOfService(): number { return 0; }
+  setTypeOfService(_tos: number): this { return this; }
   address(): AddressInfo | {} { return {}; }
   unref(): this { return this; }
   ref(): this { return this; }


### PR DESCRIPTION
Add getTypeOfService and setTypeOfService to DummySocket.

These methods were added to net.Socket in the latest Node type definitions. Without them, the DummySocket cast to Socket fails during type checking.

The implementations are no-ops, matching the rest of DummySocket.