### PR TITLE
cli/cmd/encore: new 'encore check' command

### DIFF
--- a/cli/cmd/encore/check.go
+++ b/cli/cmd/encore/check.go
@@ -1,60 +1,295 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
-	"encr.dev/cli/cmd/encore/cmdutil"
 	daemonpb "encr.dev/proto/encore/daemon"
 )
 
-var (
-	codegenDebug    bool
-	checkParseTests bool
-)
-
-var checkCmd = &cobra.Command{
-	Use:   "check",
-	Short: "Checks your application for compile-time errors using Encore's compiler.",
-
-	DisableFlagsInUseLine: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		appRoot, relPath := determineAppRoot()
-		runChecks(appRoot, relPath)
-	},
-}
+var checkTimeout time.Duration
 
 func init() {
+	checkCmd := &cobra.Command{
+		Use:   "check [spec]",
+		Short: "Runs a list of HTTP requests against a fresh app instance",
+		Long: `Compiles the application, starts up required infrastructure resources,
+and waits for the application to start. Then runs each command from the spec
+against the app and writes the results to stdout. Shuts down the application afterwards.
+
+The spec is taken from the positional argument (if given), or from stdin (if
+piped/redirected), or empty otherwise. An empty spec just verifies that the
+app successsfully starts up. Pass a file with shell redirection,
+e.g. 'encore check < spec.txt'.
+
+Spec format: one command per line. Multiple commands on a single line can be
+separated by ';'. Blank lines and lines starting with '#' are ignored.
+
+  curl <path> [args...]    # path must start with '/'.
+                           # remaining tokens are passed verbatim to curl.
+
+Examples:
+  encore check
+  encore check 'curl /ping'
+  encore check 'curl /ping; curl /hello/world -i'
+  encore check < spec.txt
+
+Output: each command result is printed to stdout framed by '=== [i/N] ... ===' lines.
+Daemon and app log output goes to stderr. Exit code is 0 when every command
+exited 0; if the app failed to start or any command failed, the exit code is 1.
+`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var (
+				spec   io.Reader
+				source string
+			)
+			switch {
+			case len(args) == 1:
+				spec = strings.NewReader(args[0])
+				source = "<spec>"
+			case !term.IsTerminal(int(os.Stdin.Fd())):
+				spec = os.Stdin
+				source = "<stdin>"
+			default:
+				spec = strings.NewReader("")
+				source = "<spec>"
+			}
+			runCheck(spec, source)
+		},
+	}
 	rootCmd.AddCommand(checkCmd)
-	checkCmd.Flags().BoolVar(&codegenDebug, "codegen-debug", false, "Dump generated code (for debugging Encore's code generation)")
-	checkCmd.Flags().BoolVar(&checkParseTests, "tests", false, "Parse tests as well")
+	checkCmd.Flags().DurationVar(&checkTimeout, "timeout", 60*time.Second, "How long to wait for /__encore/healthz before giving up")
 }
 
-func runChecks(appRoot, relPath string) {
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
+func runCheck(spec io.Reader, source string) {
+	cmds, err := parseSpec(spec, source)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-interrupt
-		cancel()
-	}()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
 
+	appRoot, wd := determineAppRoot()
 	daemon := setupDaemon(ctx)
-	stream, err := daemon.Check(ctx, &daemonpb.CheckRequest{
-		AppRoot:      appRoot,
-		WorkingDir:   relPath,
-		CodegenDebug: codegenDebug,
-		ParseTests:   checkParseTests,
-		Environ:      os.Environ(),
+
+	stream, err := daemon.RunSpec(ctx, &daemonpb.RunSpecRequest{
+		AppRoot:             appRoot,
+		WorkingDir:          wd,
+		Environ:             os.Environ(),
+		Commands:            cmds,
+		ReadyTimeoutSeconds: int32(checkTimeout.Seconds()),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "fatal: ", err)
-		os.Exit(1)
+		fatal(err)
 	}
-	os.Exit(cmdutil.StreamCommandOutput(stream, nil))
+
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			fmt.Fprintln(os.Stderr, "check: stream closed unexpectedly without a completion message")
+			os.Exit(1)
+		} else if err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				os.Exit(130)
+			}
+			fmt.Fprintf(os.Stderr, "check: %v\n", err)
+			os.Exit(1)
+		}
+		switch m := msg.Msg.(type) {
+		case *daemonpb.RunSpecMessage_Output:
+			if len(m.Output.Stderr) > 0 {
+				_, _ = os.Stderr.Write(m.Output.Stderr)
+			}
+			if len(m.Output.Stdout) > 0 {
+				// Daemon log noise routes to *our* stderr — stdout is for results only.
+				_, _ = os.Stderr.Write(m.Output.Stdout)
+			}
+		case *daemonpb.RunSpecMessage_Result:
+			renderResult(m.Result)
+		case *daemonpb.RunSpecMessage_Complete:
+			renderComplete(m.Complete)
+			if m.Complete.Error != "" || m.Complete.Succeeded != m.Complete.Total {
+				os.Exit(1)
+			}
+			os.Exit(0)
+		}
+	}
+}
+
+func renderResult(r *daemonpb.SpecCommandResult) {
+	fmt.Fprintf(os.Stdout, "=== [%d/%d] %s ===\n", r.Index, r.Total, r.Display)
+	if len(r.Stdout) > 0 {
+		_, _ = os.Stdout.Write(r.Stdout)
+		if r.Stdout[len(r.Stdout)-1] != '\n' {
+			fmt.Fprintln(os.Stdout)
+		}
+	}
+	if len(r.Stderr) > 0 {
+		fmt.Fprintln(os.Stdout, "--- stderr ---")
+		_, _ = os.Stdout.Write(r.Stderr)
+		if r.Stderr[len(r.Stderr)-1] != '\n' {
+			fmt.Fprintln(os.Stdout)
+		}
+	}
+	fmt.Fprintf(os.Stdout, "--- exit: %d ---\n", r.ExitCode)
+}
+
+func renderComplete(c *daemonpb.SpecComplete) {
+	if c.Error != "" {
+		fmt.Fprintf(os.Stderr, "check: %s\n", c.Error)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "check: %d/%d commands succeeded\n", c.Succeeded, c.Total)
+}
+
+// parseSpec parses a spec from r. source is used in error messages.
+// Lines may contain multiple commands separated by ';'. Blank lines and
+// lines starting with '#' are ignored. Currently only `curl <path> [args...]`
+// is supported.
+func parseSpec(r io.Reader, source string) ([]*daemonpb.SpecCommand, error) {
+	var cmds []*daemonpb.SpecCommand
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024) // allow long lines (e.g. JSON bodies)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+		segments, err := tokenize(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s:%d: %v", source, lineNo, err)
+		}
+		for _, tokens := range segments {
+			if len(tokens) == 0 {
+				continue
+			}
+			switch tokens[0] {
+			case "curl":
+				if len(tokens) < 2 {
+					return nil, fmt.Errorf("%s:%d: curl requires a path argument", source, lineNo)
+				}
+				pathArg := tokens[1]
+				if !strings.HasPrefix(pathArg, "/") {
+					return nil, fmt.Errorf("%s:%d: curl path %q must be relative (start with '/')", source, lineNo, pathArg)
+				}
+				cmds = append(cmds, &daemonpb.SpecCommand{
+					Cmd: &daemonpb.SpecCommand_Curl{Curl: &daemonpb.CurlCommand{
+						Path: pathArg,
+						Args: tokens[2:],
+					}},
+				})
+			default:
+				return nil, fmt.Errorf("%s:%d: unsupported command %q (only 'curl' is supported)", source, lineNo, tokens[0])
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("check: read %s: %v", source, err)
+	}
+	return cmds, nil
+}
+
+// tokenize splits a spec line into one or more command segments, each a list
+// of shell-style tokens. A top-level ';' (outside any quotes) ends a segment.
+// Handles single quotes (literal), double quotes (with backslash escapes for
+// \" and \\), and backslash escapes outside quotes. This is a small subset of
+// POSIX shell tokenization sufficient for curl-style argument lists.
+func tokenize(line string) ([][]string, error) {
+	var (
+		segments [][]string
+		tokens   []string
+		cur      strings.Builder
+		inTok    bool
+	)
+	const (
+		none = iota
+		single
+		double
+	)
+	quote := none
+	flushTok := func() {
+		if inTok {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+			inTok = false
+		}
+	}
+	flushSeg := func() {
+		flushTok()
+		if len(tokens) > 0 {
+			segments = append(segments, tokens)
+			tokens = nil
+		}
+	}
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		switch quote {
+		case single:
+			if r == '\'' {
+				quote = none
+				continue
+			}
+			cur.WriteRune(r)
+			inTok = true
+		case double:
+			if r == '\\' && i+1 < len(runes) {
+				next := runes[i+1]
+				if next == '"' || next == '\\' {
+					cur.WriteRune(next)
+					inTok = true
+					i++
+					continue
+				}
+			}
+			if r == '"' {
+				quote = none
+				continue
+			}
+			cur.WriteRune(r)
+			inTok = true
+		default:
+			switch r {
+			case ' ', '\t':
+				flushTok()
+			case ';':
+				flushSeg()
+			case '\'':
+				quote = single
+				inTok = true
+			case '"':
+				quote = double
+				inTok = true
+			case '\\':
+				if i+1 < len(runes) {
+					i++
+					cur.WriteRune(runes[i])
+					inTok = true
+				}
+			default:
+				cur.WriteRune(r)
+				inTok = true
+			}
+		}
+	}
+	if quote != none {
+		return nil, errors.New("unterminated quote")
+	}
+	flushSeg()
+	return segments, nil
 }

--- a/cli/cmd/encore/debug.go
+++ b/cli/cmd/encore/debug.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 
@@ -11,12 +12,29 @@ import (
 	daemonpb "encr.dev/proto/encore/daemon"
 )
 
+var (
+	debugBuildCodegenDebug bool
+	debugBuildParseTests   bool
+)
+
 func init() {
 	debugCmd := &cobra.Command{
 		Use:    "debug",
 		Short:  "debug is a collection of debug commands",
 		Hidden: true,
 	}
+
+	buildCmd := &cobra.Command{
+		Use:                   "build",
+		Short:                 "Checks your application for compile-time errors using Encore's compiler.",
+		DisableFlagsInUseLine: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			appRoot, relPath := determineAppRoot()
+			runDebugBuild(appRoot, relPath)
+		},
+	}
+	buildCmd.Flags().BoolVar(&debugBuildCodegenDebug, "codegen-debug", false, "Dump generated code (for debugging Encore's code generation)")
+	buildCmd.Flags().BoolVar(&debugBuildParseTests, "tests", false, "Parse tests as well")
 
 	format := cmdutil.Oneof{
 		Value:     "proto",
@@ -53,7 +71,27 @@ func init() {
 	format.AddFlag(dumpMeta)
 	dumpMeta.Flags().BoolVar(&p.ParseTests, "tests", false, "Parse tests as well")
 	rootCmd.AddCommand(debugCmd)
+	debugCmd.AddCommand(buildCmd)
 	debugCmd.AddCommand(dumpMeta)
+}
+
+func runDebugBuild(appRoot, relPath string) {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	daemon := setupDaemon(ctx)
+	stream, err := daemon.Check(ctx, &daemonpb.CheckRequest{
+		AppRoot:      appRoot,
+		WorkingDir:   relPath,
+		CodegenDebug: debugBuildCodegenDebug,
+		ParseTests:   debugBuildParseTests,
+		Environ:      os.Environ(),
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "fatal: ", err)
+		os.Exit(1)
+	}
+	os.Exit(cmdutil.StreamCommandOutput(stream, nil))
 }
 
 type dumpMetaParams struct {

--- a/cli/daemon/daemon.go
+++ b/cli/daemon/daemon.go
@@ -49,7 +49,7 @@ type Server struct {
 	mcp  *mcp.Manager
 
 	mu      sync.Mutex
-	streams map[string]*streamLog // run id -> stream
+	streams map[string]runStreamSink // run id -> stream
 
 	availableVerInit sync.Once
 	availableVer     atomic.Value // string
@@ -69,7 +69,7 @@ func New(appsMgr *apps.Manager, mgr *run.Manager, cm *sqldb.ClusterManager, sm *
 		sm:      sm,
 		ns:      ns,
 		mcp:     mcp,
-		streams: make(map[string]*streamLog),
+		streams: make(map[string]runStreamSink),
 
 		appDebouncers: make(map[*apps.Instance]*regenerateCodeDebouncer),
 	}
@@ -261,6 +261,15 @@ var errNotLinked = (func() error {
 
 type commandStream interface {
 	Send(msg *daemonpb.CommandMessage) error
+}
+
+// runStreamSink is the subset of *streamLog used by the run.EventListener
+// implementation on Server. Different RPC handlers can plug in their own
+// sink as long as they can render stdout/stderr bytes and errlist errors.
+type runStreamSink interface {
+	Stdout(buffer bool) io.Writer
+	Stderr(buffer bool) io.Writer
+	Error(err *errlist.List)
 }
 
 func newStreamLogger(slog *streamLog) zerolog.Logger {

--- a/cli/daemon/run_spec.go
+++ b/cli/daemon/run_spec.go
@@ -1,0 +1,282 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	"encr.dev/cli/daemon/run"
+	"encr.dev/internal/optracker"
+	"encr.dev/pkg/errlist"
+	"encr.dev/pkg/fns"
+	daemonpb "encr.dev/proto/encore/daemon"
+)
+
+// RunSpec boots the application on a random local port, waits for
+// /__encore/healthz, then runs each spec command against it and streams the
+// results. Designed for non-interactive agents.
+func (s *Server) RunSpec(req *daemonpb.RunSpecRequest, stream daemonpb.Daemon_RunSpecServer) error {
+	ctx := stream.Context()
+	sink := newRunSpecSink(stream)
+	stderr := sink.Stderr(false)
+
+	total := int32(len(req.Commands))
+	sendComplete := func(succeeded int32, errMsg string) {
+		_ = stream.Send(&daemonpb.RunSpecMessage{Msg: &daemonpb.RunSpecMessage_Complete{
+			Complete: &daemonpb.SpecComplete{
+				Succeeded: succeeded,
+				Total:     total,
+				Error:     errMsg,
+			},
+		}})
+	}
+
+	// Validate up front so callers get a fast error before we spend time
+	// compiling the app. The CLI also validates, but the daemon is the
+	// authoritative boundary. An empty command list is allowed — it makes
+	// `encore check` with no spec a useful "does this app boot?" smoke test.
+	for i, c := range req.Commands {
+		curl := c.GetCurl()
+		if curl == nil {
+			sendComplete(0, fmt.Sprintf("command %d: unsupported command (only curl is supported)", i+1))
+			return nil
+		}
+		if !strings.HasPrefix(curl.Path, "/") {
+			sendComplete(0, fmt.Sprintf("command %d: path %q must be relative (start with '/')", i+1, curl.Path))
+			return nil
+		}
+	}
+
+	app, err := s.apps.Track(req.AppRoot)
+	if err != nil {
+		sendComplete(0, fmt.Sprintf("failed to resolve app: %v", err))
+		return nil
+	}
+
+	ns, err := s.namespaceOrActive(ctx, app, req.Namespace)
+	if err != nil {
+		sendComplete(0, fmt.Sprintf("failed to resolve namespace: %v", err))
+		return nil
+	}
+
+	// Pre-bind a free local port and pass the listener to the manager so
+	// there is no race window between picking a port and the app binding to it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		sendComplete(0, fmt.Sprintf("failed to allocate local port: %v", err))
+		return nil
+	}
+	// On the happy path mgr.Start takes ownership of ln and closes it on
+	// teardown. If Start returns an error we close it ourselves below.
+	listenerOwnedByMgr := false
+	defer func() {
+		if !listenerOwnedByMgr {
+			fns.CloseIgnore(ln)
+		}
+	}()
+	listenAddr := ln.Addr().String()
+
+	// Use a line-mode op tracker so the compile/start phases emit one progress
+	// line each to the client's stderr. No ANSI, no spinner — safe for agents.
+	ops := optracker.NewLineMode(stderr)
+	defer ops.AllDone()
+
+	runInstance, err := s.mgr.Start(ctx, run.StartParams{
+		App:        app,
+		NS:         ns,
+		WorkingDir: req.WorkingDir,
+		Listener:   ln,
+		ListenAddr: listenAddr,
+		Watch:      false,
+		Environ:    req.Environ,
+		OpsTracker: ops,
+		Browser:    run.BrowserModeNever,
+	})
+	if err != nil {
+		// Forward errlist details (compile errors, parse errors) as plain text
+		// to stderr so the client can render them.
+		if errList := run.AsErrorList(err); errList != nil {
+			_, _ = io.WriteString(stderr, errList.Error())
+			if !strings.HasSuffix(errList.Error(), "\n") {
+				_, _ = io.WriteString(stderr, "\n")
+			}
+			sendComplete(0, "failed to start app (see stderr for details)")
+		} else {
+			sendComplete(0, fmt.Sprintf("failed to start app: %v", err))
+		}
+		return nil
+	}
+	listenerOwnedByMgr = true
+	defer func() {
+		runInstance.Close()
+		fmt.Fprintln(stderr, "encore: app shut down")
+	}()
+
+	// Register the sink so OnStdout/OnStderr from run.EventListener forward
+	// the app's log output to our stream as CommandOutput messages.
+	s.mu.Lock()
+	s.streams[runInstance.ID] = sink
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.streams, runInstance.ID)
+		s.mu.Unlock()
+	}()
+
+	timeout := time.Duration(req.ReadyTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	healthzURL := "http://" + runInstance.ListenAddr + "/__encore/healthz"
+	fmt.Fprintf(stderr, "encore: waiting for app to start (timeout %s)...\n", timeout)
+	if err := waitForHealthz(ctx, healthzURL, timeout); err != nil {
+		sendComplete(0, fmt.Sprintf("timed out waiting for /__encore/healthz: %v", err))
+		return nil
+	}
+	fmt.Fprintln(stderr, "encore: app is ready")
+
+	var succeeded int32
+	for i, c := range req.Commands {
+		// Stream cancellation (client disconnect) should stop further commands.
+		if err := ctx.Err(); err != nil {
+			sendComplete(succeeded, fmt.Sprintf("interrupted: %v", err))
+			return nil
+		}
+		curl := c.GetCurl()
+		display := formatCurlDisplay(curl)
+		stdoutBytes, stderrBytes, exitCode := runCurl(ctx, runInstance.ListenAddr, curl)
+		if exitCode == 0 {
+			succeeded++
+		}
+		_ = stream.Send(&daemonpb.RunSpecMessage{Msg: &daemonpb.RunSpecMessage_Result{
+			Result: &daemonpb.SpecCommandResult{
+				Index:    int32(i + 1),
+				Total:    total,
+				Display:  display,
+				Stdout:   stdoutBytes,
+				Stderr:   stderrBytes,
+				ExitCode: exitCode,
+			},
+		}})
+	}
+
+	sendComplete(succeeded, "")
+	return nil
+}
+
+// runCurl executes a single curl command against the app and returns its
+// stdout, stderr, and exit code. The URL is appended after user-supplied args
+// so callers can't accidentally override it via a positional URL.
+func runCurl(ctx context.Context, listenAddr string, c *daemonpb.CurlCommand) (stdout, stderr []byte, exitCode int32) {
+	argv := append([]string{"-s"}, c.Args...)
+	argv = append(argv, "http://"+listenAddr+c.Path)
+
+	cmd := exec.CommandContext(ctx, "curl", argv...)
+	var sout, serr bytes.Buffer
+	cmd.Stdout = &sout
+	cmd.Stderr = &serr
+	err := cmd.Run()
+	if err == nil {
+		return sout.Bytes(), serr.Bytes(), 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return sout.Bytes(), serr.Bytes(), int32(exitErr.ExitCode())
+	}
+	// curl could not be exec'd at all (e.g. not on PATH).
+	if serr.Len() > 0 {
+		serr.WriteByte('\n')
+	}
+	serr.WriteString(err.Error())
+	return sout.Bytes(), serr.Bytes(), -1
+}
+
+func formatCurlDisplay(c *daemonpb.CurlCommand) string {
+	parts := append([]string{"curl", c.Path}, c.Args...)
+	return strings.Join(parts, " ")
+}
+
+// waitForHealthz polls /__encore/healthz with exponential backoff until it
+// returns 200, the context is canceled, or the timeout elapses.
+func waitForHealthz(ctx context.Context, url string, timeout time.Duration) error {
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 50 * time.Millisecond
+	b.MaxInterval = 250 * time.Millisecond
+	b.MaxElapsedTime = timeout
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	op := func() error {
+		req, err := http.NewRequestWithContext(pollCtx, "GET", url, nil)
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		fns.CloseIgnore(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("status %d", resp.StatusCode)
+		}
+		return nil
+	}
+	return backoff.Retry(op, backoff.WithContext(b, pollCtx))
+}
+
+// runSpecSink adapts a Daemon_RunSpecServer to the runStreamSink interface so
+// the daemon's run.EventListener can forward the app's stdout/stderr output to
+// the gRPC client as CommandOutput messages.
+type runSpecSink struct {
+	stream daemonpb.Daemon_RunSpecServer
+	mu     sync.Mutex
+}
+
+func newRunSpecSink(stream daemonpb.Daemon_RunSpecServer) *runSpecSink {
+	return &runSpecSink{stream: stream}
+}
+
+func (s *runSpecSink) Stdout(_ bool) io.Writer { return runSpecWriter{sink: s, stderr: false} }
+func (s *runSpecSink) Stderr(_ bool) io.Writer { return runSpecWriter{sink: s, stderr: true} }
+
+func (s *runSpecSink) Error(err *errlist.List) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err == nil || len(err.List) == 0 {
+		return
+	}
+	out := &daemonpb.CommandOutput{Stderr: []byte(err.Error() + "\n")}
+	_ = s.stream.Send(&daemonpb.RunSpecMessage{Msg: &daemonpb.RunSpecMessage_Output{Output: out}})
+}
+
+type runSpecWriter struct {
+	sink   *runSpecSink
+	stderr bool
+}
+
+func (w runSpecWriter) Write(b []byte) (int, error) {
+	w.sink.mu.Lock()
+	defer w.sink.mu.Unlock()
+	out := &daemonpb.CommandOutput{}
+	if w.stderr {
+		out.Stderr = b
+	} else {
+		out.Stdout = b
+	}
+	if err := w.sink.stream.Send(&daemonpb.RunSpecMessage{Msg: &daemonpb.RunSpecMessage_Output{Output: out}}); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}

--- a/internal/optracker/optracker.go
+++ b/internal/optracker/optracker.go
@@ -27,6 +27,14 @@ func New(w io.Writer, stream OutputStream) *OpTracker {
 	}
 }
 
+// NewLineMode creates a tracker that emits one plain-text line per state
+// change instead of redrawing a spinner display. Suited for non-interactive
+// agents (no ANSI, no spinner). The stream is unused — this constructor exists
+// so callers don't need to plumb a CommandMessage stream they don't have.
+func NewLineMode(w io.Writer) *OpTracker {
+	return &OpTracker{w: w, lineMode: true}
+}
+
 type OpTracker struct {
 	mu          sync.Mutex
 	ops         []*slowOp
@@ -35,6 +43,7 @@ type OpTracker struct {
 	quit        bool // quit indicates that the tracker has been stopped (this should only be set by AllDone)
 	savedCursor sync.Once
 	stream      OutputStream
+	lineMode    bool // when true, emit one line per state change instead of redrawing
 }
 
 type OperationID int
@@ -66,6 +75,11 @@ func (t *OpTracker) AllDone() {
 		}
 	}
 	t.quit = true
+	if t.lineMode {
+		// State transitions were already emitted as they happened; nothing
+		// further to render.
+		return
+	}
 	t.refresh()
 }
 
@@ -88,6 +102,12 @@ func (t *OpTracker) Add(msg string, minStart time.Time) OperationID {
 	}
 	op := &slowOp{msg: msg, start: start}
 	t.ops = append(t.ops, op)
+
+	if t.lineMode {
+		fmt.Fprintf(t.w, "encore: %s...\n", msg)
+		return id
+	}
+
 	t.refresh()
 
 	if !t.started {
@@ -115,6 +135,11 @@ func (t *OpTracker) Done(id OperationID, minDuration time.Duration) {
 		done = a
 	}
 	o.done = done
+
+	if t.lineMode {
+		fmt.Fprintf(t.w, "encore: %s done (%s)\n", o.msg, done.Sub(o.start).Round(time.Millisecond))
+		return
+	}
 	t.refresh()
 }
 
@@ -135,6 +160,16 @@ func (t *OpTracker) Fail(id OperationID, err error) {
 	}
 	t.ops[id].err = err
 	t.ops[id].done = time.Now()
+
+	if t.lineMode {
+		o := t.ops[id]
+		if errors.Is(err, ErrCanceled) {
+			fmt.Fprintf(t.w, "encore: %s canceled\n", o.msg)
+		} else {
+			fmt.Fprintf(t.w, "encore: %s failed: %v\n", o.msg, err)
+		}
+		return
+	}
 	t.refresh()
 }
 

--- a/proto/encore/daemon/daemon.pb.go
+++ b/proto/encore/daemon/daemon.pb.go
@@ -273,7 +273,7 @@ func (x DumpMetaRequest_Format) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DumpMetaRequest_Format.Descriptor instead.
 func (DumpMetaRequest_Format) EnumDescriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{35, 0}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{41, 0}
 }
 
 type CommandMessage struct {
@@ -760,6 +760,469 @@ func (x *RunRequest) GetScrubSensitiveData() bool {
 	return false
 }
 
+type RunSpecRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// app_root is the absolute filesystem path to the Encore app root.
+	AppRoot string `protobuf:"bytes,1,opt,name=app_root,json=appRoot,proto3" json:"app_root,omitempty"`
+	// working_dir is the working directory relative to the app_root,
+	// for formatting relative paths in error messages.
+	WorkingDir string `protobuf:"bytes,2,opt,name=working_dir,json=workingDir,proto3" json:"working_dir,omitempty"`
+	// environ is the environment to set for the running app,
+	// each entry in "KEY=VALUE" format.
+	Environ []string `protobuf:"bytes,3,rep,name=environ,proto3" json:"environ,omitempty"`
+	// commands is the ordered list of spec commands to execute against the app.
+	Commands []*SpecCommand `protobuf:"bytes,4,rep,name=commands,proto3" json:"commands,omitempty"`
+	// ready_timeout_seconds is the budget for waiting on /__encore/healthz.
+	// If <= 0, the daemon picks a sensible default.
+	ReadyTimeoutSeconds int32 `protobuf:"varint,5,opt,name=ready_timeout_seconds,json=readyTimeoutSeconds,proto3" json:"ready_timeout_seconds,omitempty"`
+	// namespace is the infrastructure namespace to use.
+	// If empty the active namespace is used.
+	Namespace     *string `protobuf:"bytes,6,opt,name=namespace,proto3,oneof" json:"namespace,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunSpecRequest) Reset() {
+	*x = RunSpecRequest{}
+	mi := &file_encore_daemon_daemon_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunSpecRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunSpecRequest) ProtoMessage() {}
+
+func (x *RunSpecRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_encore_daemon_daemon_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunSpecRequest.ProtoReflect.Descriptor instead.
+func (*RunSpecRequest) Descriptor() ([]byte, []int) {
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RunSpecRequest) GetAppRoot() string {
+	if x != nil {
+		return x.AppRoot
+	}
+	return ""
+}
+
+func (x *RunSpecRequest) GetWorkingDir() string {
+	if x != nil {
+		return x.WorkingDir
+	}
+	return ""
+}
+
+func (x *RunSpecRequest) GetEnviron() []string {
+	if x != nil {
+		return x.Environ
+	}
+	return nil
+}
+
+func (x *RunSpecRequest) GetCommands() []*SpecCommand {
+	if x != nil {
+		return x.Commands
+	}
+	return nil
+}
+
+func (x *RunSpecRequest) GetReadyTimeoutSeconds() int32 {
+	if x != nil {
+		return x.ReadyTimeoutSeconds
+	}
+	return 0
+}
+
+func (x *RunSpecRequest) GetNamespace() string {
+	if x != nil && x.Namespace != nil {
+		return *x.Namespace
+	}
+	return ""
+}
+
+type SpecCommand struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Cmd:
+	//
+	//	*SpecCommand_Curl
+	Cmd           isSpecCommand_Cmd `protobuf_oneof:"cmd"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpecCommand) Reset() {
+	*x = SpecCommand{}
+	mi := &file_encore_daemon_daemon_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpecCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpecCommand) ProtoMessage() {}
+
+func (x *SpecCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_encore_daemon_daemon_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpecCommand.ProtoReflect.Descriptor instead.
+func (*SpecCommand) Descriptor() ([]byte, []int) {
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SpecCommand) GetCmd() isSpecCommand_Cmd {
+	if x != nil {
+		return x.Cmd
+	}
+	return nil
+}
+
+func (x *SpecCommand) GetCurl() *CurlCommand {
+	if x != nil {
+		if x, ok := x.Cmd.(*SpecCommand_Curl); ok {
+			return x.Curl
+		}
+	}
+	return nil
+}
+
+type isSpecCommand_Cmd interface {
+	isSpecCommand_Cmd()
+}
+
+type SpecCommand_Curl struct {
+	Curl *CurlCommand `protobuf:"bytes,1,opt,name=curl,proto3,oneof"`
+}
+
+func (*SpecCommand_Curl) isSpecCommand_Cmd() {}
+
+type CurlCommand struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// path must start with "/" and is appended to http://<bound-addr> by the daemon.
+	Path string `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	// args are extra flags passed verbatim to the curl subprocess.
+	Args          []string `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CurlCommand) Reset() {
+	*x = CurlCommand{}
+	mi := &file_encore_daemon_daemon_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CurlCommand) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CurlCommand) ProtoMessage() {}
+
+func (x *CurlCommand) ProtoReflect() protoreflect.Message {
+	mi := &file_encore_daemon_daemon_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CurlCommand.ProtoReflect.Descriptor instead.
+func (*CurlCommand) Descriptor() ([]byte, []int) {
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *CurlCommand) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *CurlCommand) GetArgs() []string {
+	if x != nil {
+		return x.Args
+	}
+	return nil
+}
+
+type RunSpecMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Msg:
+	//
+	//	*RunSpecMessage_Output
+	//	*RunSpecMessage_Result
+	//	*RunSpecMessage_Complete
+	Msg           isRunSpecMessage_Msg `protobuf_oneof:"msg"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunSpecMessage) Reset() {
+	*x = RunSpecMessage{}
+	mi := &file_encore_daemon_daemon_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunSpecMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunSpecMessage) ProtoMessage() {}
+
+func (x *RunSpecMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_encore_daemon_daemon_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunSpecMessage.ProtoReflect.Descriptor instead.
+func (*RunSpecMessage) Descriptor() ([]byte, []int) {
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *RunSpecMessage) GetMsg() isRunSpecMessage_Msg {
+	if x != nil {
+		return x.Msg
+	}
+	return nil
+}
+
+func (x *RunSpecMessage) GetOutput() *CommandOutput {
+	if x != nil {
+		if x, ok := x.Msg.(*RunSpecMessage_Output); ok {
+			return x.Output
+		}
+	}
+	return nil
+}
+
+func (x *RunSpecMessage) GetResult() *SpecCommandResult {
+	if x != nil {
+		if x, ok := x.Msg.(*RunSpecMessage_Result); ok {
+			return x.Result
+		}
+	}
+	return nil
+}
+
+func (x *RunSpecMessage) GetComplete() *SpecComplete {
+	if x != nil {
+		if x, ok := x.Msg.(*RunSpecMessage_Complete); ok {
+			return x.Complete
+		}
+	}
+	return nil
+}
+
+type isRunSpecMessage_Msg interface {
+	isRunSpecMessage_Msg()
+}
+
+type RunSpecMessage_Output struct {
+	// output forwards stdout/stderr from the app or daemon (compile noise,
+	// runtime logs). Clients should render this on stderr.
+	Output *CommandOutput `protobuf:"bytes,1,opt,name=output,proto3,oneof"`
+}
+
+type RunSpecMessage_Result struct {
+	// result is one finished spec command.
+	Result *SpecCommandResult `protobuf:"bytes,2,opt,name=result,proto3,oneof"`
+}
+
+type RunSpecMessage_Complete struct {
+	// complete is the terminal message for the stream.
+	Complete *SpecComplete `protobuf:"bytes,3,opt,name=complete,proto3,oneof"`
+}
+
+func (*RunSpecMessage_Output) isRunSpecMessage_Msg() {}
+
+func (*RunSpecMessage_Result) isRunSpecMessage_Msg() {}
+
+func (*RunSpecMessage_Complete) isRunSpecMessage_Msg() {}
+
+type SpecCommandResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Index         int32                  `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"` // 1-based
+	Total         int32                  `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty"`
+	Display       string                 `protobuf:"bytes,3,opt,name=display,proto3" json:"display,omitempty"` // human-readable, e.g. "curl /api/foo -i"
+	Stdout        []byte                 `protobuf:"bytes,4,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr        []byte                 `protobuf:"bytes,5,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	ExitCode      int32                  `protobuf:"varint,6,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpecCommandResult) Reset() {
+	*x = SpecCommandResult{}
+	mi := &file_encore_daemon_daemon_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpecCommandResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpecCommandResult) ProtoMessage() {}
+
+func (x *SpecCommandResult) ProtoReflect() protoreflect.Message {
+	mi := &file_encore_daemon_daemon_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpecCommandResult.ProtoReflect.Descriptor instead.
+func (*SpecCommandResult) Descriptor() ([]byte, []int) {
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SpecCommandResult) GetIndex() int32 {
+	if x != nil {
+		return x.Index
+	}
+	return 0
+}
+
+func (x *SpecCommandResult) GetTotal() int32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+func (x *SpecCommandResult) GetDisplay() string {
+	if x != nil {
+		return x.Display
+	}
+	return ""
+}
+
+func (x *SpecCommandResult) GetStdout() []byte {
+	if x != nil {
+		return x.Stdout
+	}
+	return nil
+}
+
+func (x *SpecCommandResult) GetStderr() []byte {
+	if x != nil {
+		return x.Stderr
+	}
+	return nil
+}
+
+func (x *SpecCommandResult) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+type SpecComplete struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Succeeded int32                  `protobuf:"varint,1,opt,name=succeeded,proto3" json:"succeeded,omitempty"`
+	Total     int32                  `protobuf:"varint,2,opt,name=total,proto3" json:"total,omitempty"`
+	// error, if non-empty, indicates the run never reached the command-running
+	// phase (compile failure, healthz timeout, etc.). When set, succeeded/total
+	// reflect commands that did execute (typically zero).
+	Error         string `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpecComplete) Reset() {
+	*x = SpecComplete{}
+	mi := &file_encore_daemon_daemon_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpecComplete) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpecComplete) ProtoMessage() {}
+
+func (x *SpecComplete) ProtoReflect() protoreflect.Message {
+	mi := &file_encore_daemon_daemon_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpecComplete.ProtoReflect.Descriptor instead.
+func (*SpecComplete) Descriptor() ([]byte, []int) {
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *SpecComplete) GetSucceeded() int32 {
+	if x != nil {
+		return x.Succeeded
+	}
+	return 0
+}
+
+func (x *SpecComplete) GetTotal() int32 {
+	if x != nil {
+		return x.Total
+	}
+	return 0
+}
+
+func (x *SpecComplete) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 type TestRequest struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	AppRoot    string                 `protobuf:"bytes,1,opt,name=app_root,json=appRoot,proto3" json:"app_root,omitempty"`
@@ -782,7 +1245,7 @@ type TestRequest struct {
 
 func (x *TestRequest) Reset() {
 	*x = TestRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[7]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -794,7 +1257,7 @@ func (x *TestRequest) String() string {
 func (*TestRequest) ProtoMessage() {}
 
 func (x *TestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[7]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -807,7 +1270,7 @@ func (x *TestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TestRequest.ProtoReflect.Descriptor instead.
 func (*TestRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{7}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *TestRequest) GetAppRoot() string {
@@ -876,7 +1339,7 @@ type TestSpecRequest struct {
 
 func (x *TestSpecRequest) Reset() {
 	*x = TestSpecRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[8]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -888,7 +1351,7 @@ func (x *TestSpecRequest) String() string {
 func (*TestSpecRequest) ProtoMessage() {}
 
 func (x *TestSpecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[8]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -901,7 +1364,7 @@ func (x *TestSpecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TestSpecRequest.ProtoReflect.Descriptor instead.
 func (*TestSpecRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{8}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TestSpecRequest) GetAppRoot() string {
@@ -950,7 +1413,7 @@ type TestSpecResponse struct {
 
 func (x *TestSpecResponse) Reset() {
 	*x = TestSpecResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[9]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -962,7 +1425,7 @@ func (x *TestSpecResponse) String() string {
 func (*TestSpecResponse) ProtoMessage() {}
 
 func (x *TestSpecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[9]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -975,7 +1438,7 @@ func (x *TestSpecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TestSpecResponse.ProtoReflect.Descriptor instead.
 func (*TestSpecResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{9}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TestSpecResponse) GetCommand() string {
@@ -1019,7 +1482,7 @@ type ExecScriptRequest struct {
 
 func (x *ExecScriptRequest) Reset() {
 	*x = ExecScriptRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[10]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1031,7 +1494,7 @@ func (x *ExecScriptRequest) String() string {
 func (*ExecScriptRequest) ProtoMessage() {}
 
 func (x *ExecScriptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[10]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1044,7 +1507,7 @@ func (x *ExecScriptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecScriptRequest.ProtoReflect.Descriptor instead.
 func (*ExecScriptRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{10}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ExecScriptRequest) GetAppRoot() string {
@@ -1109,7 +1572,7 @@ type ExecSpecRequest struct {
 
 func (x *ExecSpecRequest) Reset() {
 	*x = ExecSpecRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[11]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1121,7 +1584,7 @@ func (x *ExecSpecRequest) String() string {
 func (*ExecSpecRequest) ProtoMessage() {}
 
 func (x *ExecSpecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[11]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1134,7 +1597,7 @@ func (x *ExecSpecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSpecRequest.ProtoReflect.Descriptor instead.
 func (*ExecSpecRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{11}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ExecSpecRequest) GetAppRoot() string {
@@ -1192,7 +1655,7 @@ type ExecSpecMessage struct {
 
 func (x *ExecSpecMessage) Reset() {
 	*x = ExecSpecMessage{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[12]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1204,7 +1667,7 @@ func (x *ExecSpecMessage) String() string {
 func (*ExecSpecMessage) ProtoMessage() {}
 
 func (x *ExecSpecMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[12]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1217,7 +1680,7 @@ func (x *ExecSpecMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSpecMessage.ProtoReflect.Descriptor instead.
 func (*ExecSpecMessage) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{12}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ExecSpecMessage) GetMsg() isExecSpecMessage_Msg {
@@ -1272,7 +1735,7 @@ type ExecSpecResponse struct {
 
 func (x *ExecSpecResponse) Reset() {
 	*x = ExecSpecResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[13]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1284,7 +1747,7 @@ func (x *ExecSpecResponse) String() string {
 func (*ExecSpecResponse) ProtoMessage() {}
 
 func (x *ExecSpecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[13]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,7 +1760,7 @@ func (x *ExecSpecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecSpecResponse.ProtoReflect.Descriptor instead.
 func (*ExecSpecResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{13}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ExecSpecResponse) GetCommand() string {
@@ -1338,7 +1801,7 @@ type CheckRequest struct {
 
 func (x *CheckRequest) Reset() {
 	*x = CheckRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[14]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1350,7 +1813,7 @@ func (x *CheckRequest) String() string {
 func (*CheckRequest) ProtoMessage() {}
 
 func (x *CheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[14]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1363,7 +1826,7 @@ func (x *CheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CheckRequest.ProtoReflect.Descriptor instead.
 func (*CheckRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{14}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *CheckRequest) GetAppRoot() string {
@@ -1431,7 +1894,7 @@ type ExportRequest struct {
 
 func (x *ExportRequest) Reset() {
 	*x = ExportRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[15]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1443,7 +1906,7 @@ func (x *ExportRequest) String() string {
 func (*ExportRequest) ProtoMessage() {}
 
 func (x *ExportRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[15]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1456,7 +1919,7 @@ func (x *ExportRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportRequest.ProtoReflect.Descriptor instead.
 func (*ExportRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{15}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ExportRequest) GetAppRoot() string {
@@ -1574,7 +2037,7 @@ type DockerExportParams struct {
 
 func (x *DockerExportParams) Reset() {
 	*x = DockerExportParams{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[16]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1586,7 +2049,7 @@ func (x *DockerExportParams) String() string {
 func (*DockerExportParams) ProtoMessage() {}
 
 func (x *DockerExportParams) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[16]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1599,7 +2062,7 @@ func (x *DockerExportParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DockerExportParams.ProtoReflect.Descriptor instead.
 func (*DockerExportParams) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{16}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *DockerExportParams) GetLocalDaemonTag() string {
@@ -1639,7 +2102,7 @@ type DBConnectRequest struct {
 
 func (x *DBConnectRequest) Reset() {
 	*x = DBConnectRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[17]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1651,7 +2114,7 @@ func (x *DBConnectRequest) String() string {
 func (*DBConnectRequest) ProtoMessage() {}
 
 func (x *DBConnectRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[17]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1664,7 +2127,7 @@ func (x *DBConnectRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DBConnectRequest.ProtoReflect.Descriptor instead.
 func (*DBConnectRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{17}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *DBConnectRequest) GetAppRoot() string {
@@ -1718,7 +2181,7 @@ type DBConnectResponse struct {
 
 func (x *DBConnectResponse) Reset() {
 	*x = DBConnectResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[18]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1730,7 +2193,7 @@ func (x *DBConnectResponse) String() string {
 func (*DBConnectResponse) ProtoMessage() {}
 
 func (x *DBConnectResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[18]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1743,7 +2206,7 @@ func (x *DBConnectResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DBConnectResponse.ProtoReflect.Descriptor instead.
 func (*DBConnectResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{18}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *DBConnectResponse) GetDsn() string {
@@ -1769,7 +2232,7 @@ type DBProxyRequest struct {
 
 func (x *DBProxyRequest) Reset() {
 	*x = DBProxyRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[19]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1781,7 +2244,7 @@ func (x *DBProxyRequest) String() string {
 func (*DBProxyRequest) ProtoMessage() {}
 
 func (x *DBProxyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[19]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1794,7 +2257,7 @@ func (x *DBProxyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DBProxyRequest.ProtoReflect.Descriptor instead.
 func (*DBProxyRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{19}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DBProxyRequest) GetAppRoot() string {
@@ -1853,7 +2316,7 @@ type DBResetRequest struct {
 
 func (x *DBResetRequest) Reset() {
 	*x = DBResetRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[20]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1865,7 +2328,7 @@ func (x *DBResetRequest) String() string {
 func (*DBResetRequest) ProtoMessage() {}
 
 func (x *DBResetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[20]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1878,7 +2341,7 @@ func (x *DBResetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DBResetRequest.ProtoReflect.Descriptor instead.
 func (*DBResetRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{20}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DBResetRequest) GetAppRoot() string {
@@ -1949,7 +2412,7 @@ type GenClientRequest struct {
 
 func (x *GenClientRequest) Reset() {
 	*x = GenClientRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[21]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1961,7 +2424,7 @@ func (x *GenClientRequest) String() string {
 func (*GenClientRequest) ProtoMessage() {}
 
 func (x *GenClientRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[21]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1974,7 +2437,7 @@ func (x *GenClientRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenClientRequest.ProtoReflect.Descriptor instead.
 func (*GenClientRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{21}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GenClientRequest) GetAppId() string {
@@ -2070,7 +2533,7 @@ type GenClientResponse struct {
 
 func (x *GenClientResponse) Reset() {
 	*x = GenClientResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[22]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2082,7 +2545,7 @@ func (x *GenClientResponse) String() string {
 func (*GenClientResponse) ProtoMessage() {}
 
 func (x *GenClientResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[22]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2095,7 +2558,7 @@ func (x *GenClientResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenClientResponse.ProtoReflect.Descriptor instead.
 func (*GenClientResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{22}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GenClientResponse) GetCode() []byte {
@@ -2114,7 +2577,7 @@ type GenWrappersRequest struct {
 
 func (x *GenWrappersRequest) Reset() {
 	*x = GenWrappersRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[23]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2126,7 +2589,7 @@ func (x *GenWrappersRequest) String() string {
 func (*GenWrappersRequest) ProtoMessage() {}
 
 func (x *GenWrappersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[23]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2139,7 +2602,7 @@ func (x *GenWrappersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenWrappersRequest.ProtoReflect.Descriptor instead.
 func (*GenWrappersRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{23}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GenWrappersRequest) GetAppRoot() string {
@@ -2157,7 +2620,7 @@ type GenWrappersResponse struct {
 
 func (x *GenWrappersResponse) Reset() {
 	*x = GenWrappersResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[24]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2169,7 +2632,7 @@ func (x *GenWrappersResponse) String() string {
 func (*GenWrappersResponse) ProtoMessage() {}
 
 func (x *GenWrappersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[24]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2182,7 +2645,7 @@ func (x *GenWrappersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenWrappersResponse.ProtoReflect.Descriptor instead.
 func (*GenWrappersResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{24}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{30}
 }
 
 type SecretsRefreshRequest struct {
@@ -2196,7 +2659,7 @@ type SecretsRefreshRequest struct {
 
 func (x *SecretsRefreshRequest) Reset() {
 	*x = SecretsRefreshRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[25]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2208,7 +2671,7 @@ func (x *SecretsRefreshRequest) String() string {
 func (*SecretsRefreshRequest) ProtoMessage() {}
 
 func (x *SecretsRefreshRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[25]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2221,7 +2684,7 @@ func (x *SecretsRefreshRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretsRefreshRequest.ProtoReflect.Descriptor instead.
 func (*SecretsRefreshRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{25}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *SecretsRefreshRequest) GetAppRoot() string {
@@ -2253,7 +2716,7 @@ type SecretsRefreshResponse struct {
 
 func (x *SecretsRefreshResponse) Reset() {
 	*x = SecretsRefreshResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[26]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2265,7 +2728,7 @@ func (x *SecretsRefreshResponse) String() string {
 func (*SecretsRefreshResponse) ProtoMessage() {}
 
 func (x *SecretsRefreshResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[26]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2278,7 +2741,7 @@ func (x *SecretsRefreshResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecretsRefreshResponse.ProtoReflect.Descriptor instead.
 func (*SecretsRefreshResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{26}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{32}
 }
 
 type VersionResponse struct {
@@ -2291,7 +2754,7 @@ type VersionResponse struct {
 
 func (x *VersionResponse) Reset() {
 	*x = VersionResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[27]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2303,7 +2766,7 @@ func (x *VersionResponse) String() string {
 func (*VersionResponse) ProtoMessage() {}
 
 func (x *VersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[27]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2316,7 +2779,7 @@ func (x *VersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VersionResponse.ProtoReflect.Descriptor instead.
 func (*VersionResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{27}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *VersionResponse) GetVersion() string {
@@ -2346,7 +2809,7 @@ type Namespace struct {
 
 func (x *Namespace) Reset() {
 	*x = Namespace{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[28]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2358,7 +2821,7 @@ func (x *Namespace) String() string {
 func (*Namespace) ProtoMessage() {}
 
 func (x *Namespace) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[28]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2371,7 +2834,7 @@ func (x *Namespace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Namespace.ProtoReflect.Descriptor instead.
 func (*Namespace) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{28}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Namespace) GetId() string {
@@ -2419,7 +2882,7 @@ type CreateNamespaceRequest struct {
 
 func (x *CreateNamespaceRequest) Reset() {
 	*x = CreateNamespaceRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[29]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2431,7 +2894,7 @@ func (x *CreateNamespaceRequest) String() string {
 func (*CreateNamespaceRequest) ProtoMessage() {}
 
 func (x *CreateNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[29]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2444,7 +2907,7 @@ func (x *CreateNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*CreateNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{29}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *CreateNamespaceRequest) GetAppRoot() string {
@@ -2472,7 +2935,7 @@ type SwitchNamespaceRequest struct {
 
 func (x *SwitchNamespaceRequest) Reset() {
 	*x = SwitchNamespaceRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[30]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2484,7 +2947,7 @@ func (x *SwitchNamespaceRequest) String() string {
 func (*SwitchNamespaceRequest) ProtoMessage() {}
 
 func (x *SwitchNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[30]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2497,7 +2960,7 @@ func (x *SwitchNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SwitchNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*SwitchNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{30}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *SwitchNamespaceRequest) GetAppRoot() string {
@@ -2530,7 +2993,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[31]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2542,7 +3005,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[31]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2555,7 +3018,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{31}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ListNamespacesRequest) GetAppRoot() string {
@@ -2575,7 +3038,7 @@ type DeleteNamespaceRequest struct {
 
 func (x *DeleteNamespaceRequest) Reset() {
 	*x = DeleteNamespaceRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[32]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2587,7 +3050,7 @@ func (x *DeleteNamespaceRequest) String() string {
 func (*DeleteNamespaceRequest) ProtoMessage() {}
 
 func (x *DeleteNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[32]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2600,7 +3063,7 @@ func (x *DeleteNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{32}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *DeleteNamespaceRequest) GetAppRoot() string {
@@ -2626,7 +3089,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[33]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2638,7 +3101,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[33]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2651,7 +3114,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{33}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []*Namespace {
@@ -2672,7 +3135,7 @@ type TelemetryConfig struct {
 
 func (x *TelemetryConfig) Reset() {
 	*x = TelemetryConfig{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[34]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2684,7 +3147,7 @@ func (x *TelemetryConfig) String() string {
 func (*TelemetryConfig) ProtoMessage() {}
 
 func (x *TelemetryConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[34]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2697,7 +3160,7 @@ func (x *TelemetryConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TelemetryConfig.ProtoReflect.Descriptor instead.
 func (*TelemetryConfig) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{34}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *TelemetryConfig) GetAnonId() string {
@@ -2737,7 +3200,7 @@ type DumpMetaRequest struct {
 
 func (x *DumpMetaRequest) Reset() {
 	*x = DumpMetaRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[35]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2749,7 +3212,7 @@ func (x *DumpMetaRequest) String() string {
 func (*DumpMetaRequest) ProtoMessage() {}
 
 func (x *DumpMetaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[35]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2762,7 +3225,7 @@ func (x *DumpMetaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DumpMetaRequest.ProtoReflect.Descriptor instead.
 func (*DumpMetaRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{35}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *DumpMetaRequest) GetAppRoot() string {
@@ -2809,7 +3272,7 @@ type DumpMetaResponse struct {
 
 func (x *DumpMetaResponse) Reset() {
 	*x = DumpMetaResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[36]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2821,7 +3284,7 @@ func (x *DumpMetaResponse) String() string {
 func (*DumpMetaResponse) ProtoMessage() {}
 
 func (x *DumpMetaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[36]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2834,7 +3297,7 @@ func (x *DumpMetaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DumpMetaResponse.ProtoReflect.Descriptor instead.
 func (*DumpMetaResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{36}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *DumpMetaResponse) GetMeta() []byte {
@@ -2853,7 +3316,7 @@ type SQLCPlugin struct {
 
 func (x *SQLCPlugin) Reset() {
 	*x = SQLCPlugin{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[37]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2865,7 +3328,7 @@ func (x *SQLCPlugin) String() string {
 func (*SQLCPlugin) ProtoMessage() {}
 
 func (x *SQLCPlugin) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[37]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2878,7 +3341,7 @@ func (x *SQLCPlugin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43}
 }
 
 type SQLCPlugin_File struct {
@@ -2891,7 +3354,7 @@ type SQLCPlugin_File struct {
 
 func (x *SQLCPlugin_File) Reset() {
 	*x = SQLCPlugin_File{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[38]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2903,7 +3366,7 @@ func (x *SQLCPlugin_File) String() string {
 func (*SQLCPlugin_File) ProtoMessage() {}
 
 func (x *SQLCPlugin_File) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[38]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2916,7 +3379,7 @@ func (x *SQLCPlugin_File) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_File.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_File) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 0}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 0}
 }
 
 func (x *SQLCPlugin_File) GetName() string {
@@ -2946,7 +3409,7 @@ type SQLCPlugin_Settings struct {
 
 func (x *SQLCPlugin_Settings) Reset() {
 	*x = SQLCPlugin_Settings{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[39]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2958,7 +3421,7 @@ func (x *SQLCPlugin_Settings) String() string {
 func (*SQLCPlugin_Settings) ProtoMessage() {}
 
 func (x *SQLCPlugin_Settings) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[39]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2971,7 +3434,7 @@ func (x *SQLCPlugin_Settings) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Settings.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Settings) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 1}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 1}
 }
 
 func (x *SQLCPlugin_Settings) GetVersion() string {
@@ -3023,7 +3486,7 @@ type SQLCPlugin_Codegen struct {
 
 func (x *SQLCPlugin_Codegen) Reset() {
 	*x = SQLCPlugin_Codegen{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[40]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3035,7 +3498,7 @@ func (x *SQLCPlugin_Codegen) String() string {
 func (*SQLCPlugin_Codegen) ProtoMessage() {}
 
 func (x *SQLCPlugin_Codegen) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[40]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3048,7 +3511,7 @@ func (x *SQLCPlugin_Codegen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Codegen.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Codegen) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 2}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 2}
 }
 
 func (x *SQLCPlugin_Codegen) GetOut() string {
@@ -3105,7 +3568,7 @@ type SQLCPlugin_Catalog struct {
 
 func (x *SQLCPlugin_Catalog) Reset() {
 	*x = SQLCPlugin_Catalog{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[41]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3117,7 +3580,7 @@ func (x *SQLCPlugin_Catalog) String() string {
 func (*SQLCPlugin_Catalog) ProtoMessage() {}
 
 func (x *SQLCPlugin_Catalog) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[41]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3130,7 +3593,7 @@ func (x *SQLCPlugin_Catalog) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Catalog.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Catalog) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 3}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 3}
 }
 
 func (x *SQLCPlugin_Catalog) GetComment() string {
@@ -3174,7 +3637,7 @@ type SQLCPlugin_Schema struct {
 
 func (x *SQLCPlugin_Schema) Reset() {
 	*x = SQLCPlugin_Schema{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[42]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3186,7 +3649,7 @@ func (x *SQLCPlugin_Schema) String() string {
 func (*SQLCPlugin_Schema) ProtoMessage() {}
 
 func (x *SQLCPlugin_Schema) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[42]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3199,7 +3662,7 @@ func (x *SQLCPlugin_Schema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Schema.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Schema) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 4}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 4}
 }
 
 func (x *SQLCPlugin_Schema) GetComment() string {
@@ -3247,7 +3710,7 @@ type SQLCPlugin_CompositeType struct {
 
 func (x *SQLCPlugin_CompositeType) Reset() {
 	*x = SQLCPlugin_CompositeType{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[43]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3259,7 +3722,7 @@ func (x *SQLCPlugin_CompositeType) String() string {
 func (*SQLCPlugin_CompositeType) ProtoMessage() {}
 
 func (x *SQLCPlugin_CompositeType) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[43]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3272,7 +3735,7 @@ func (x *SQLCPlugin_CompositeType) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_CompositeType.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_CompositeType) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 5}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 5}
 }
 
 func (x *SQLCPlugin_CompositeType) GetName() string {
@@ -3300,7 +3763,7 @@ type SQLCPlugin_Enum struct {
 
 func (x *SQLCPlugin_Enum) Reset() {
 	*x = SQLCPlugin_Enum{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[44]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3312,7 +3775,7 @@ func (x *SQLCPlugin_Enum) String() string {
 func (*SQLCPlugin_Enum) ProtoMessage() {}
 
 func (x *SQLCPlugin_Enum) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[44]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3325,7 +3788,7 @@ func (x *SQLCPlugin_Enum) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Enum.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Enum) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 6}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 6}
 }
 
 func (x *SQLCPlugin_Enum) GetName() string {
@@ -3360,7 +3823,7 @@ type SQLCPlugin_Table struct {
 
 func (x *SQLCPlugin_Table) Reset() {
 	*x = SQLCPlugin_Table{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[45]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3372,7 +3835,7 @@ func (x *SQLCPlugin_Table) String() string {
 func (*SQLCPlugin_Table) ProtoMessage() {}
 
 func (x *SQLCPlugin_Table) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[45]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3385,7 +3848,7 @@ func (x *SQLCPlugin_Table) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Table.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Table) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 7}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 7}
 }
 
 func (x *SQLCPlugin_Table) GetRel() *SQLCPlugin_Identifier {
@@ -3420,7 +3883,7 @@ type SQLCPlugin_Identifier struct {
 
 func (x *SQLCPlugin_Identifier) Reset() {
 	*x = SQLCPlugin_Identifier{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[46]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3432,7 +3895,7 @@ func (x *SQLCPlugin_Identifier) String() string {
 func (*SQLCPlugin_Identifier) ProtoMessage() {}
 
 func (x *SQLCPlugin_Identifier) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[46]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3445,7 +3908,7 @@ func (x *SQLCPlugin_Identifier) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Identifier.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Identifier) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 8}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 8}
 }
 
 func (x *SQLCPlugin_Identifier) GetCatalog() string {
@@ -3494,7 +3957,7 @@ type SQLCPlugin_Column struct {
 
 func (x *SQLCPlugin_Column) Reset() {
 	*x = SQLCPlugin_Column{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[47]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3506,7 +3969,7 @@ func (x *SQLCPlugin_Column) String() string {
 func (*SQLCPlugin_Column) ProtoMessage() {}
 
 func (x *SQLCPlugin_Column) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[47]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3519,7 +3982,7 @@ func (x *SQLCPlugin_Column) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Column.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Column) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 9}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 9}
 }
 
 func (x *SQLCPlugin_Column) GetName() string {
@@ -3650,7 +4113,7 @@ type SQLCPlugin_Query struct {
 
 func (x *SQLCPlugin_Query) Reset() {
 	*x = SQLCPlugin_Query{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[48]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3662,7 +4125,7 @@ func (x *SQLCPlugin_Query) String() string {
 func (*SQLCPlugin_Query) ProtoMessage() {}
 
 func (x *SQLCPlugin_Query) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[48]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3675,7 +4138,7 @@ func (x *SQLCPlugin_Query) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Query.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Query) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 10}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 10}
 }
 
 func (x *SQLCPlugin_Query) GetText() string {
@@ -3744,7 +4207,7 @@ type SQLCPlugin_Parameter struct {
 
 func (x *SQLCPlugin_Parameter) Reset() {
 	*x = SQLCPlugin_Parameter{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[49]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3756,7 +4219,7 @@ func (x *SQLCPlugin_Parameter) String() string {
 func (*SQLCPlugin_Parameter) ProtoMessage() {}
 
 func (x *SQLCPlugin_Parameter) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[49]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3769,7 +4232,7 @@ func (x *SQLCPlugin_Parameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Parameter.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Parameter) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 11}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 11}
 }
 
 func (x *SQLCPlugin_Parameter) GetNumber() int32 {
@@ -3800,7 +4263,7 @@ type SQLCPlugin_GenerateRequest struct {
 
 func (x *SQLCPlugin_GenerateRequest) Reset() {
 	*x = SQLCPlugin_GenerateRequest{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[50]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3812,7 +4275,7 @@ func (x *SQLCPlugin_GenerateRequest) String() string {
 func (*SQLCPlugin_GenerateRequest) ProtoMessage() {}
 
 func (x *SQLCPlugin_GenerateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[50]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3825,7 +4288,7 @@ func (x *SQLCPlugin_GenerateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_GenerateRequest.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_GenerateRequest) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 12}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 12}
 }
 
 func (x *SQLCPlugin_GenerateRequest) GetSettings() *SQLCPlugin_Settings {
@@ -3879,7 +4342,7 @@ type SQLCPlugin_GenerateResponse struct {
 
 func (x *SQLCPlugin_GenerateResponse) Reset() {
 	*x = SQLCPlugin_GenerateResponse{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[51]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3891,7 +4354,7 @@ func (x *SQLCPlugin_GenerateResponse) String() string {
 func (*SQLCPlugin_GenerateResponse) ProtoMessage() {}
 
 func (x *SQLCPlugin_GenerateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[51]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3904,7 +4367,7 @@ func (x *SQLCPlugin_GenerateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_GenerateResponse.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_GenerateResponse) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 13}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 13}
 }
 
 func (x *SQLCPlugin_GenerateResponse) GetFiles() []*SQLCPlugin_File {
@@ -3923,7 +4386,7 @@ type SQLCPlugin_Codegen_Process struct {
 
 func (x *SQLCPlugin_Codegen_Process) Reset() {
 	*x = SQLCPlugin_Codegen_Process{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[52]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3935,7 +4398,7 @@ func (x *SQLCPlugin_Codegen_Process) String() string {
 func (*SQLCPlugin_Codegen_Process) ProtoMessage() {}
 
 func (x *SQLCPlugin_Codegen_Process) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[52]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3948,7 +4411,7 @@ func (x *SQLCPlugin_Codegen_Process) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Codegen_Process.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Codegen_Process) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 2, 0}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 2, 0}
 }
 
 func (x *SQLCPlugin_Codegen_Process) GetCmd() string {
@@ -3968,7 +4431,7 @@ type SQLCPlugin_Codegen_WASM struct {
 
 func (x *SQLCPlugin_Codegen_WASM) Reset() {
 	*x = SQLCPlugin_Codegen_WASM{}
-	mi := &file_encore_daemon_daemon_proto_msgTypes[53]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3980,7 +4443,7 @@ func (x *SQLCPlugin_Codegen_WASM) String() string {
 func (*SQLCPlugin_Codegen_WASM) ProtoMessage() {}
 
 func (x *SQLCPlugin_Codegen_WASM) ProtoReflect() protoreflect.Message {
-	mi := &file_encore_daemon_daemon_proto_msgTypes[53]
+	mi := &file_encore_daemon_daemon_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3993,7 +4456,7 @@ func (x *SQLCPlugin_Codegen_WASM) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SQLCPlugin_Codegen_WASM.ProtoReflect.Descriptor instead.
 func (*SQLCPlugin_Codegen_WASM) Descriptor() ([]byte, []int) {
-	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{37, 2, 1}
+	return file_encore_daemon_daemon_proto_rawDescGZIP(), []int{43, 2, 1}
 }
 
 func (x *SQLCPlugin_Codegen_WASM) GetUrl() string {
@@ -4063,7 +4526,39 @@ const file_encore_daemon_daemon_proto_rawDesc = "" +
 	"\n" +
 	"_namespaceB\f\n" +
 	"\n" +
-	"_log_level\"\xf0\x01\n" +
+	"_log_level\"\x83\x02\n" +
+	"\x0eRunSpecRequest\x12\x19\n" +
+	"\bapp_root\x18\x01 \x01(\tR\aappRoot\x12\x1f\n" +
+	"\vworking_dir\x18\x02 \x01(\tR\n" +
+	"workingDir\x12\x18\n" +
+	"\aenviron\x18\x03 \x03(\tR\aenviron\x126\n" +
+	"\bcommands\x18\x04 \x03(\v2\x1a.encore.daemon.SpecCommandR\bcommands\x122\n" +
+	"\x15ready_timeout_seconds\x18\x05 \x01(\x05R\x13readyTimeoutSeconds\x12!\n" +
+	"\tnamespace\x18\x06 \x01(\tH\x00R\tnamespace\x88\x01\x01B\f\n" +
+	"\n" +
+	"_namespace\"F\n" +
+	"\vSpecCommand\x120\n" +
+	"\x04curl\x18\x01 \x01(\v2\x1a.encore.daemon.CurlCommandH\x00R\x04curlB\x05\n" +
+	"\x03cmd\"5\n" +
+	"\vCurlCommand\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
+	"\x04args\x18\x02 \x03(\tR\x04args\"\xc6\x01\n" +
+	"\x0eRunSpecMessage\x126\n" +
+	"\x06output\x18\x01 \x01(\v2\x1c.encore.daemon.CommandOutputH\x00R\x06output\x12:\n" +
+	"\x06result\x18\x02 \x01(\v2 .encore.daemon.SpecCommandResultH\x00R\x06result\x129\n" +
+	"\bcomplete\x18\x03 \x01(\v2\x1b.encore.daemon.SpecCompleteH\x00R\bcompleteB\x05\n" +
+	"\x03msg\"\xa6\x01\n" +
+	"\x11SpecCommandResult\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\x05R\x05index\x12\x14\n" +
+	"\x05total\x18\x02 \x01(\x05R\x05total\x12\x18\n" +
+	"\adisplay\x18\x03 \x01(\tR\adisplay\x12\x16\n" +
+	"\x06stdout\x18\x04 \x01(\fR\x06stdout\x12\x16\n" +
+	"\x06stderr\x18\x05 \x01(\fR\x06stderr\x12\x1b\n" +
+	"\texit_code\x18\x06 \x01(\x05R\bexitCode\"X\n" +
+	"\fSpecComplete\x12\x1c\n" +
+	"\tsucceeded\x18\x01 \x01(\x05R\tsucceeded\x12\x14\n" +
+	"\x05total\x18\x02 \x01(\x05R\x05total\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"\xf0\x01\n" +
 	"\vTestRequest\x12\x19\n" +
 	"\bapp_root\x18\x01 \x01(\tR\aappRoot\x12\x1f\n" +
 	"\vworking_dir\x18\x02 \x01(\tR\n" +
@@ -4351,9 +4846,10 @@ const file_encore_daemon_daemon_proto_rawDesc = "" +
 	"\x1bDB_CLUSTER_TYPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13DB_CLUSTER_TYPE_RUN\x10\x01\x12\x18\n" +
 	"\x14DB_CLUSTER_TYPE_TEST\x10\x02\x12\x1a\n" +
-	"\x16DB_CLUSTER_TYPE_SHADOW\x10\x032\xf5\f\n" +
+	"\x16DB_CLUSTER_TYPE_SHADOW\x10\x032\xc0\r\n" +
 	"\x06Daemon\x12A\n" +
-	"\x03Run\x12\x19.encore.daemon.RunRequest\x1a\x1d.encore.daemon.CommandMessage0\x01\x12C\n" +
+	"\x03Run\x12\x19.encore.daemon.RunRequest\x1a\x1d.encore.daemon.CommandMessage0\x01\x12I\n" +
+	"\aRunSpec\x12\x1d.encore.daemon.RunSpecRequest\x1a\x1d.encore.daemon.RunSpecMessage0\x01\x12C\n" +
 	"\x04Test\x12\x1a.encore.daemon.TestRequest\x1a\x1d.encore.daemon.CommandMessage0\x01\x12K\n" +
 	"\bTestSpec\x12\x1e.encore.daemon.TestSpecRequest\x1a\x1f.encore.daemon.TestSpecResponse\x12O\n" +
 	"\n" +
@@ -4389,7 +4885,7 @@ func file_encore_daemon_daemon_proto_rawDescGZIP() []byte {
 }
 
 var file_encore_daemon_daemon_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_encore_daemon_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
+var file_encore_daemon_daemon_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_encore_daemon_daemon_proto_goTypes = []any{
 	(DBRole)(0),                         // 0: encore.daemon.DBRole
 	(DBClusterType)(0),                  // 1: encore.daemon.DBClusterType
@@ -4403,54 +4899,60 @@ var file_encore_daemon_daemon_proto_goTypes = []any{
 	(*CreateAppRequest)(nil),            // 9: encore.daemon.CreateAppRequest
 	(*CreateAppResponse)(nil),           // 10: encore.daemon.CreateAppResponse
 	(*RunRequest)(nil),                  // 11: encore.daemon.RunRequest
-	(*TestRequest)(nil),                 // 12: encore.daemon.TestRequest
-	(*TestSpecRequest)(nil),             // 13: encore.daemon.TestSpecRequest
-	(*TestSpecResponse)(nil),            // 14: encore.daemon.TestSpecResponse
-	(*ExecScriptRequest)(nil),           // 15: encore.daemon.ExecScriptRequest
-	(*ExecSpecRequest)(nil),             // 16: encore.daemon.ExecSpecRequest
-	(*ExecSpecMessage)(nil),             // 17: encore.daemon.ExecSpecMessage
-	(*ExecSpecResponse)(nil),            // 18: encore.daemon.ExecSpecResponse
-	(*CheckRequest)(nil),                // 19: encore.daemon.CheckRequest
-	(*ExportRequest)(nil),               // 20: encore.daemon.ExportRequest
-	(*DockerExportParams)(nil),          // 21: encore.daemon.DockerExportParams
-	(*DBConnectRequest)(nil),            // 22: encore.daemon.DBConnectRequest
-	(*DBConnectResponse)(nil),           // 23: encore.daemon.DBConnectResponse
-	(*DBProxyRequest)(nil),              // 24: encore.daemon.DBProxyRequest
-	(*DBResetRequest)(nil),              // 25: encore.daemon.DBResetRequest
-	(*GenClientRequest)(nil),            // 26: encore.daemon.GenClientRequest
-	(*GenClientResponse)(nil),           // 27: encore.daemon.GenClientResponse
-	(*GenWrappersRequest)(nil),          // 28: encore.daemon.GenWrappersRequest
-	(*GenWrappersResponse)(nil),         // 29: encore.daemon.GenWrappersResponse
-	(*SecretsRefreshRequest)(nil),       // 30: encore.daemon.SecretsRefreshRequest
-	(*SecretsRefreshResponse)(nil),      // 31: encore.daemon.SecretsRefreshResponse
-	(*VersionResponse)(nil),             // 32: encore.daemon.VersionResponse
-	(*Namespace)(nil),                   // 33: encore.daemon.Namespace
-	(*CreateNamespaceRequest)(nil),      // 34: encore.daemon.CreateNamespaceRequest
-	(*SwitchNamespaceRequest)(nil),      // 35: encore.daemon.SwitchNamespaceRequest
-	(*ListNamespacesRequest)(nil),       // 36: encore.daemon.ListNamespacesRequest
-	(*DeleteNamespaceRequest)(nil),      // 37: encore.daemon.DeleteNamespaceRequest
-	(*ListNamespacesResponse)(nil),      // 38: encore.daemon.ListNamespacesResponse
-	(*TelemetryConfig)(nil),             // 39: encore.daemon.TelemetryConfig
-	(*DumpMetaRequest)(nil),             // 40: encore.daemon.DumpMetaRequest
-	(*DumpMetaResponse)(nil),            // 41: encore.daemon.DumpMetaResponse
-	(*SQLCPlugin)(nil),                  // 42: encore.daemon.SQLCPlugin
-	(*SQLCPlugin_File)(nil),             // 43: encore.daemon.SQLCPlugin.File
-	(*SQLCPlugin_Settings)(nil),         // 44: encore.daemon.SQLCPlugin.Settings
-	(*SQLCPlugin_Codegen)(nil),          // 45: encore.daemon.SQLCPlugin.Codegen
-	(*SQLCPlugin_Catalog)(nil),          // 46: encore.daemon.SQLCPlugin.Catalog
-	(*SQLCPlugin_Schema)(nil),           // 47: encore.daemon.SQLCPlugin.Schema
-	(*SQLCPlugin_CompositeType)(nil),    // 48: encore.daemon.SQLCPlugin.CompositeType
-	(*SQLCPlugin_Enum)(nil),             // 49: encore.daemon.SQLCPlugin.Enum
-	(*SQLCPlugin_Table)(nil),            // 50: encore.daemon.SQLCPlugin.Table
-	(*SQLCPlugin_Identifier)(nil),       // 51: encore.daemon.SQLCPlugin.Identifier
-	(*SQLCPlugin_Column)(nil),           // 52: encore.daemon.SQLCPlugin.Column
-	(*SQLCPlugin_Query)(nil),            // 53: encore.daemon.SQLCPlugin.Query
-	(*SQLCPlugin_Parameter)(nil),        // 54: encore.daemon.SQLCPlugin.Parameter
-	(*SQLCPlugin_GenerateRequest)(nil),  // 55: encore.daemon.SQLCPlugin.GenerateRequest
-	(*SQLCPlugin_GenerateResponse)(nil), // 56: encore.daemon.SQLCPlugin.GenerateResponse
-	(*SQLCPlugin_Codegen_Process)(nil),  // 57: encore.daemon.SQLCPlugin.Codegen.Process
-	(*SQLCPlugin_Codegen_WASM)(nil),     // 58: encore.daemon.SQLCPlugin.Codegen.WASM
-	(*emptypb.Empty)(nil),               // 59: google.protobuf.Empty
+	(*RunSpecRequest)(nil),              // 12: encore.daemon.RunSpecRequest
+	(*SpecCommand)(nil),                 // 13: encore.daemon.SpecCommand
+	(*CurlCommand)(nil),                 // 14: encore.daemon.CurlCommand
+	(*RunSpecMessage)(nil),              // 15: encore.daemon.RunSpecMessage
+	(*SpecCommandResult)(nil),           // 16: encore.daemon.SpecCommandResult
+	(*SpecComplete)(nil),                // 17: encore.daemon.SpecComplete
+	(*TestRequest)(nil),                 // 18: encore.daemon.TestRequest
+	(*TestSpecRequest)(nil),             // 19: encore.daemon.TestSpecRequest
+	(*TestSpecResponse)(nil),            // 20: encore.daemon.TestSpecResponse
+	(*ExecScriptRequest)(nil),           // 21: encore.daemon.ExecScriptRequest
+	(*ExecSpecRequest)(nil),             // 22: encore.daemon.ExecSpecRequest
+	(*ExecSpecMessage)(nil),             // 23: encore.daemon.ExecSpecMessage
+	(*ExecSpecResponse)(nil),            // 24: encore.daemon.ExecSpecResponse
+	(*CheckRequest)(nil),                // 25: encore.daemon.CheckRequest
+	(*ExportRequest)(nil),               // 26: encore.daemon.ExportRequest
+	(*DockerExportParams)(nil),          // 27: encore.daemon.DockerExportParams
+	(*DBConnectRequest)(nil),            // 28: encore.daemon.DBConnectRequest
+	(*DBConnectResponse)(nil),           // 29: encore.daemon.DBConnectResponse
+	(*DBProxyRequest)(nil),              // 30: encore.daemon.DBProxyRequest
+	(*DBResetRequest)(nil),              // 31: encore.daemon.DBResetRequest
+	(*GenClientRequest)(nil),            // 32: encore.daemon.GenClientRequest
+	(*GenClientResponse)(nil),           // 33: encore.daemon.GenClientResponse
+	(*GenWrappersRequest)(nil),          // 34: encore.daemon.GenWrappersRequest
+	(*GenWrappersResponse)(nil),         // 35: encore.daemon.GenWrappersResponse
+	(*SecretsRefreshRequest)(nil),       // 36: encore.daemon.SecretsRefreshRequest
+	(*SecretsRefreshResponse)(nil),      // 37: encore.daemon.SecretsRefreshResponse
+	(*VersionResponse)(nil),             // 38: encore.daemon.VersionResponse
+	(*Namespace)(nil),                   // 39: encore.daemon.Namespace
+	(*CreateNamespaceRequest)(nil),      // 40: encore.daemon.CreateNamespaceRequest
+	(*SwitchNamespaceRequest)(nil),      // 41: encore.daemon.SwitchNamespaceRequest
+	(*ListNamespacesRequest)(nil),       // 42: encore.daemon.ListNamespacesRequest
+	(*DeleteNamespaceRequest)(nil),      // 43: encore.daemon.DeleteNamespaceRequest
+	(*ListNamespacesResponse)(nil),      // 44: encore.daemon.ListNamespacesResponse
+	(*TelemetryConfig)(nil),             // 45: encore.daemon.TelemetryConfig
+	(*DumpMetaRequest)(nil),             // 46: encore.daemon.DumpMetaRequest
+	(*DumpMetaResponse)(nil),            // 47: encore.daemon.DumpMetaResponse
+	(*SQLCPlugin)(nil),                  // 48: encore.daemon.SQLCPlugin
+	(*SQLCPlugin_File)(nil),             // 49: encore.daemon.SQLCPlugin.File
+	(*SQLCPlugin_Settings)(nil),         // 50: encore.daemon.SQLCPlugin.Settings
+	(*SQLCPlugin_Codegen)(nil),          // 51: encore.daemon.SQLCPlugin.Codegen
+	(*SQLCPlugin_Catalog)(nil),          // 52: encore.daemon.SQLCPlugin.Catalog
+	(*SQLCPlugin_Schema)(nil),           // 53: encore.daemon.SQLCPlugin.Schema
+	(*SQLCPlugin_CompositeType)(nil),    // 54: encore.daemon.SQLCPlugin.CompositeType
+	(*SQLCPlugin_Enum)(nil),             // 55: encore.daemon.SQLCPlugin.Enum
+	(*SQLCPlugin_Table)(nil),            // 56: encore.daemon.SQLCPlugin.Table
+	(*SQLCPlugin_Identifier)(nil),       // 57: encore.daemon.SQLCPlugin.Identifier
+	(*SQLCPlugin_Column)(nil),           // 58: encore.daemon.SQLCPlugin.Column
+	(*SQLCPlugin_Query)(nil),            // 59: encore.daemon.SQLCPlugin.Query
+	(*SQLCPlugin_Parameter)(nil),        // 60: encore.daemon.SQLCPlugin.Parameter
+	(*SQLCPlugin_GenerateRequest)(nil),  // 61: encore.daemon.SQLCPlugin.GenerateRequest
+	(*SQLCPlugin_GenerateResponse)(nil), // 62: encore.daemon.SQLCPlugin.GenerateResponse
+	(*SQLCPlugin_Codegen_Process)(nil),  // 63: encore.daemon.SQLCPlugin.Codegen.Process
+	(*SQLCPlugin_Codegen_WASM)(nil),     // 64: encore.daemon.SQLCPlugin.Codegen.WASM
+	(*emptypb.Empty)(nil),               // 65: google.protobuf.Empty
 }
 var file_encore_daemon_daemon_proto_depIdxs = []int32{
 	6,  // 0: encore.daemon.CommandMessage.output:type_name -> encore.daemon.CommandOutput
@@ -4458,83 +4960,90 @@ var file_encore_daemon_daemon_proto_depIdxs = []int32{
 	8,  // 2: encore.daemon.CommandMessage.errors:type_name -> encore.daemon.CommandDisplayErrors
 	2,  // 3: encore.daemon.RunRequest.browser:type_name -> encore.daemon.RunRequest.BrowserMode
 	3,  // 4: encore.daemon.RunRequest.debug_mode:type_name -> encore.daemon.RunRequest.DebugMode
-	6,  // 5: encore.daemon.ExecSpecMessage.output:type_name -> encore.daemon.CommandOutput
-	18, // 6: encore.daemon.ExecSpecMessage.spec:type_name -> encore.daemon.ExecSpecResponse
-	21, // 7: encore.daemon.ExportRequest.docker:type_name -> encore.daemon.DockerExportParams
-	1,  // 8: encore.daemon.DBConnectRequest.cluster_type:type_name -> encore.daemon.DBClusterType
-	0,  // 9: encore.daemon.DBConnectRequest.role:type_name -> encore.daemon.DBRole
-	1,  // 10: encore.daemon.DBProxyRequest.cluster_type:type_name -> encore.daemon.DBClusterType
-	0,  // 11: encore.daemon.DBProxyRequest.role:type_name -> encore.daemon.DBRole
-	1,  // 12: encore.daemon.DBResetRequest.cluster_type:type_name -> encore.daemon.DBClusterType
-	33, // 13: encore.daemon.ListNamespacesResponse.namespaces:type_name -> encore.daemon.Namespace
-	4,  // 14: encore.daemon.DumpMetaRequest.format:type_name -> encore.daemon.DumpMetaRequest.Format
-	45, // 15: encore.daemon.SQLCPlugin.Settings.codegen:type_name -> encore.daemon.SQLCPlugin.Codegen
-	57, // 16: encore.daemon.SQLCPlugin.Codegen.process:type_name -> encore.daemon.SQLCPlugin.Codegen.Process
-	58, // 17: encore.daemon.SQLCPlugin.Codegen.wasm:type_name -> encore.daemon.SQLCPlugin.Codegen.WASM
-	47, // 18: encore.daemon.SQLCPlugin.Catalog.schemas:type_name -> encore.daemon.SQLCPlugin.Schema
-	50, // 19: encore.daemon.SQLCPlugin.Schema.tables:type_name -> encore.daemon.SQLCPlugin.Table
-	49, // 20: encore.daemon.SQLCPlugin.Schema.enums:type_name -> encore.daemon.SQLCPlugin.Enum
-	48, // 21: encore.daemon.SQLCPlugin.Schema.composite_types:type_name -> encore.daemon.SQLCPlugin.CompositeType
-	51, // 22: encore.daemon.SQLCPlugin.Table.rel:type_name -> encore.daemon.SQLCPlugin.Identifier
-	52, // 23: encore.daemon.SQLCPlugin.Table.columns:type_name -> encore.daemon.SQLCPlugin.Column
-	51, // 24: encore.daemon.SQLCPlugin.Column.table:type_name -> encore.daemon.SQLCPlugin.Identifier
-	51, // 25: encore.daemon.SQLCPlugin.Column.type:type_name -> encore.daemon.SQLCPlugin.Identifier
-	51, // 26: encore.daemon.SQLCPlugin.Column.embed_table:type_name -> encore.daemon.SQLCPlugin.Identifier
-	52, // 27: encore.daemon.SQLCPlugin.Query.columns:type_name -> encore.daemon.SQLCPlugin.Column
-	54, // 28: encore.daemon.SQLCPlugin.Query.params:type_name -> encore.daemon.SQLCPlugin.Parameter
-	51, // 29: encore.daemon.SQLCPlugin.Query.insert_into_table:type_name -> encore.daemon.SQLCPlugin.Identifier
-	52, // 30: encore.daemon.SQLCPlugin.Parameter.column:type_name -> encore.daemon.SQLCPlugin.Column
-	44, // 31: encore.daemon.SQLCPlugin.GenerateRequest.settings:type_name -> encore.daemon.SQLCPlugin.Settings
-	46, // 32: encore.daemon.SQLCPlugin.GenerateRequest.catalog:type_name -> encore.daemon.SQLCPlugin.Catalog
-	53, // 33: encore.daemon.SQLCPlugin.GenerateRequest.queries:type_name -> encore.daemon.SQLCPlugin.Query
-	43, // 34: encore.daemon.SQLCPlugin.GenerateResponse.files:type_name -> encore.daemon.SQLCPlugin.File
-	11, // 35: encore.daemon.Daemon.Run:input_type -> encore.daemon.RunRequest
-	12, // 36: encore.daemon.Daemon.Test:input_type -> encore.daemon.TestRequest
-	13, // 37: encore.daemon.Daemon.TestSpec:input_type -> encore.daemon.TestSpecRequest
-	15, // 38: encore.daemon.Daemon.ExecScript:input_type -> encore.daemon.ExecScriptRequest
-	16, // 39: encore.daemon.Daemon.ExecSpec:input_type -> encore.daemon.ExecSpecRequest
-	19, // 40: encore.daemon.Daemon.Check:input_type -> encore.daemon.CheckRequest
-	20, // 41: encore.daemon.Daemon.Export:input_type -> encore.daemon.ExportRequest
-	22, // 42: encore.daemon.Daemon.DBConnect:input_type -> encore.daemon.DBConnectRequest
-	24, // 43: encore.daemon.Daemon.DBProxy:input_type -> encore.daemon.DBProxyRequest
-	25, // 44: encore.daemon.Daemon.DBReset:input_type -> encore.daemon.DBResetRequest
-	26, // 45: encore.daemon.Daemon.GenClient:input_type -> encore.daemon.GenClientRequest
-	28, // 46: encore.daemon.Daemon.GenWrappers:input_type -> encore.daemon.GenWrappersRequest
-	30, // 47: encore.daemon.Daemon.SecretsRefresh:input_type -> encore.daemon.SecretsRefreshRequest
-	59, // 48: encore.daemon.Daemon.Version:input_type -> google.protobuf.Empty
-	34, // 49: encore.daemon.Daemon.CreateNamespace:input_type -> encore.daemon.CreateNamespaceRequest
-	35, // 50: encore.daemon.Daemon.SwitchNamespace:input_type -> encore.daemon.SwitchNamespaceRequest
-	36, // 51: encore.daemon.Daemon.ListNamespaces:input_type -> encore.daemon.ListNamespacesRequest
-	37, // 52: encore.daemon.Daemon.DeleteNamespace:input_type -> encore.daemon.DeleteNamespaceRequest
-	40, // 53: encore.daemon.Daemon.DumpMeta:input_type -> encore.daemon.DumpMetaRequest
-	39, // 54: encore.daemon.Daemon.Telemetry:input_type -> encore.daemon.TelemetryConfig
-	9,  // 55: encore.daemon.Daemon.CreateApp:input_type -> encore.daemon.CreateAppRequest
-	5,  // 56: encore.daemon.Daemon.Run:output_type -> encore.daemon.CommandMessage
-	5,  // 57: encore.daemon.Daemon.Test:output_type -> encore.daemon.CommandMessage
-	14, // 58: encore.daemon.Daemon.TestSpec:output_type -> encore.daemon.TestSpecResponse
-	5,  // 59: encore.daemon.Daemon.ExecScript:output_type -> encore.daemon.CommandMessage
-	17, // 60: encore.daemon.Daemon.ExecSpec:output_type -> encore.daemon.ExecSpecMessage
-	5,  // 61: encore.daemon.Daemon.Check:output_type -> encore.daemon.CommandMessage
-	5,  // 62: encore.daemon.Daemon.Export:output_type -> encore.daemon.CommandMessage
-	23, // 63: encore.daemon.Daemon.DBConnect:output_type -> encore.daemon.DBConnectResponse
-	5,  // 64: encore.daemon.Daemon.DBProxy:output_type -> encore.daemon.CommandMessage
-	5,  // 65: encore.daemon.Daemon.DBReset:output_type -> encore.daemon.CommandMessage
-	27, // 66: encore.daemon.Daemon.GenClient:output_type -> encore.daemon.GenClientResponse
-	29, // 67: encore.daemon.Daemon.GenWrappers:output_type -> encore.daemon.GenWrappersResponse
-	31, // 68: encore.daemon.Daemon.SecretsRefresh:output_type -> encore.daemon.SecretsRefreshResponse
-	32, // 69: encore.daemon.Daemon.Version:output_type -> encore.daemon.VersionResponse
-	33, // 70: encore.daemon.Daemon.CreateNamespace:output_type -> encore.daemon.Namespace
-	33, // 71: encore.daemon.Daemon.SwitchNamespace:output_type -> encore.daemon.Namespace
-	38, // 72: encore.daemon.Daemon.ListNamespaces:output_type -> encore.daemon.ListNamespacesResponse
-	59, // 73: encore.daemon.Daemon.DeleteNamespace:output_type -> google.protobuf.Empty
-	41, // 74: encore.daemon.Daemon.DumpMeta:output_type -> encore.daemon.DumpMetaResponse
-	59, // 75: encore.daemon.Daemon.Telemetry:output_type -> google.protobuf.Empty
-	10, // 76: encore.daemon.Daemon.CreateApp:output_type -> encore.daemon.CreateAppResponse
-	56, // [56:77] is the sub-list for method output_type
-	35, // [35:56] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	13, // 5: encore.daemon.RunSpecRequest.commands:type_name -> encore.daemon.SpecCommand
+	14, // 6: encore.daemon.SpecCommand.curl:type_name -> encore.daemon.CurlCommand
+	6,  // 7: encore.daemon.RunSpecMessage.output:type_name -> encore.daemon.CommandOutput
+	16, // 8: encore.daemon.RunSpecMessage.result:type_name -> encore.daemon.SpecCommandResult
+	17, // 9: encore.daemon.RunSpecMessage.complete:type_name -> encore.daemon.SpecComplete
+	6,  // 10: encore.daemon.ExecSpecMessage.output:type_name -> encore.daemon.CommandOutput
+	24, // 11: encore.daemon.ExecSpecMessage.spec:type_name -> encore.daemon.ExecSpecResponse
+	27, // 12: encore.daemon.ExportRequest.docker:type_name -> encore.daemon.DockerExportParams
+	1,  // 13: encore.daemon.DBConnectRequest.cluster_type:type_name -> encore.daemon.DBClusterType
+	0,  // 14: encore.daemon.DBConnectRequest.role:type_name -> encore.daemon.DBRole
+	1,  // 15: encore.daemon.DBProxyRequest.cluster_type:type_name -> encore.daemon.DBClusterType
+	0,  // 16: encore.daemon.DBProxyRequest.role:type_name -> encore.daemon.DBRole
+	1,  // 17: encore.daemon.DBResetRequest.cluster_type:type_name -> encore.daemon.DBClusterType
+	39, // 18: encore.daemon.ListNamespacesResponse.namespaces:type_name -> encore.daemon.Namespace
+	4,  // 19: encore.daemon.DumpMetaRequest.format:type_name -> encore.daemon.DumpMetaRequest.Format
+	51, // 20: encore.daemon.SQLCPlugin.Settings.codegen:type_name -> encore.daemon.SQLCPlugin.Codegen
+	63, // 21: encore.daemon.SQLCPlugin.Codegen.process:type_name -> encore.daemon.SQLCPlugin.Codegen.Process
+	64, // 22: encore.daemon.SQLCPlugin.Codegen.wasm:type_name -> encore.daemon.SQLCPlugin.Codegen.WASM
+	53, // 23: encore.daemon.SQLCPlugin.Catalog.schemas:type_name -> encore.daemon.SQLCPlugin.Schema
+	56, // 24: encore.daemon.SQLCPlugin.Schema.tables:type_name -> encore.daemon.SQLCPlugin.Table
+	55, // 25: encore.daemon.SQLCPlugin.Schema.enums:type_name -> encore.daemon.SQLCPlugin.Enum
+	54, // 26: encore.daemon.SQLCPlugin.Schema.composite_types:type_name -> encore.daemon.SQLCPlugin.CompositeType
+	57, // 27: encore.daemon.SQLCPlugin.Table.rel:type_name -> encore.daemon.SQLCPlugin.Identifier
+	58, // 28: encore.daemon.SQLCPlugin.Table.columns:type_name -> encore.daemon.SQLCPlugin.Column
+	57, // 29: encore.daemon.SQLCPlugin.Column.table:type_name -> encore.daemon.SQLCPlugin.Identifier
+	57, // 30: encore.daemon.SQLCPlugin.Column.type:type_name -> encore.daemon.SQLCPlugin.Identifier
+	57, // 31: encore.daemon.SQLCPlugin.Column.embed_table:type_name -> encore.daemon.SQLCPlugin.Identifier
+	58, // 32: encore.daemon.SQLCPlugin.Query.columns:type_name -> encore.daemon.SQLCPlugin.Column
+	60, // 33: encore.daemon.SQLCPlugin.Query.params:type_name -> encore.daemon.SQLCPlugin.Parameter
+	57, // 34: encore.daemon.SQLCPlugin.Query.insert_into_table:type_name -> encore.daemon.SQLCPlugin.Identifier
+	58, // 35: encore.daemon.SQLCPlugin.Parameter.column:type_name -> encore.daemon.SQLCPlugin.Column
+	50, // 36: encore.daemon.SQLCPlugin.GenerateRequest.settings:type_name -> encore.daemon.SQLCPlugin.Settings
+	52, // 37: encore.daemon.SQLCPlugin.GenerateRequest.catalog:type_name -> encore.daemon.SQLCPlugin.Catalog
+	59, // 38: encore.daemon.SQLCPlugin.GenerateRequest.queries:type_name -> encore.daemon.SQLCPlugin.Query
+	49, // 39: encore.daemon.SQLCPlugin.GenerateResponse.files:type_name -> encore.daemon.SQLCPlugin.File
+	11, // 40: encore.daemon.Daemon.Run:input_type -> encore.daemon.RunRequest
+	12, // 41: encore.daemon.Daemon.RunSpec:input_type -> encore.daemon.RunSpecRequest
+	18, // 42: encore.daemon.Daemon.Test:input_type -> encore.daemon.TestRequest
+	19, // 43: encore.daemon.Daemon.TestSpec:input_type -> encore.daemon.TestSpecRequest
+	21, // 44: encore.daemon.Daemon.ExecScript:input_type -> encore.daemon.ExecScriptRequest
+	22, // 45: encore.daemon.Daemon.ExecSpec:input_type -> encore.daemon.ExecSpecRequest
+	25, // 46: encore.daemon.Daemon.Check:input_type -> encore.daemon.CheckRequest
+	26, // 47: encore.daemon.Daemon.Export:input_type -> encore.daemon.ExportRequest
+	28, // 48: encore.daemon.Daemon.DBConnect:input_type -> encore.daemon.DBConnectRequest
+	30, // 49: encore.daemon.Daemon.DBProxy:input_type -> encore.daemon.DBProxyRequest
+	31, // 50: encore.daemon.Daemon.DBReset:input_type -> encore.daemon.DBResetRequest
+	32, // 51: encore.daemon.Daemon.GenClient:input_type -> encore.daemon.GenClientRequest
+	34, // 52: encore.daemon.Daemon.GenWrappers:input_type -> encore.daemon.GenWrappersRequest
+	36, // 53: encore.daemon.Daemon.SecretsRefresh:input_type -> encore.daemon.SecretsRefreshRequest
+	65, // 54: encore.daemon.Daemon.Version:input_type -> google.protobuf.Empty
+	40, // 55: encore.daemon.Daemon.CreateNamespace:input_type -> encore.daemon.CreateNamespaceRequest
+	41, // 56: encore.daemon.Daemon.SwitchNamespace:input_type -> encore.daemon.SwitchNamespaceRequest
+	42, // 57: encore.daemon.Daemon.ListNamespaces:input_type -> encore.daemon.ListNamespacesRequest
+	43, // 58: encore.daemon.Daemon.DeleteNamespace:input_type -> encore.daemon.DeleteNamespaceRequest
+	46, // 59: encore.daemon.Daemon.DumpMeta:input_type -> encore.daemon.DumpMetaRequest
+	45, // 60: encore.daemon.Daemon.Telemetry:input_type -> encore.daemon.TelemetryConfig
+	9,  // 61: encore.daemon.Daemon.CreateApp:input_type -> encore.daemon.CreateAppRequest
+	5,  // 62: encore.daemon.Daemon.Run:output_type -> encore.daemon.CommandMessage
+	15, // 63: encore.daemon.Daemon.RunSpec:output_type -> encore.daemon.RunSpecMessage
+	5,  // 64: encore.daemon.Daemon.Test:output_type -> encore.daemon.CommandMessage
+	20, // 65: encore.daemon.Daemon.TestSpec:output_type -> encore.daemon.TestSpecResponse
+	5,  // 66: encore.daemon.Daemon.ExecScript:output_type -> encore.daemon.CommandMessage
+	23, // 67: encore.daemon.Daemon.ExecSpec:output_type -> encore.daemon.ExecSpecMessage
+	5,  // 68: encore.daemon.Daemon.Check:output_type -> encore.daemon.CommandMessage
+	5,  // 69: encore.daemon.Daemon.Export:output_type -> encore.daemon.CommandMessage
+	29, // 70: encore.daemon.Daemon.DBConnect:output_type -> encore.daemon.DBConnectResponse
+	5,  // 71: encore.daemon.Daemon.DBProxy:output_type -> encore.daemon.CommandMessage
+	5,  // 72: encore.daemon.Daemon.DBReset:output_type -> encore.daemon.CommandMessage
+	33, // 73: encore.daemon.Daemon.GenClient:output_type -> encore.daemon.GenClientResponse
+	35, // 74: encore.daemon.Daemon.GenWrappers:output_type -> encore.daemon.GenWrappersResponse
+	37, // 75: encore.daemon.Daemon.SecretsRefresh:output_type -> encore.daemon.SecretsRefreshResponse
+	38, // 76: encore.daemon.Daemon.Version:output_type -> encore.daemon.VersionResponse
+	39, // 77: encore.daemon.Daemon.CreateNamespace:output_type -> encore.daemon.Namespace
+	39, // 78: encore.daemon.Daemon.SwitchNamespace:output_type -> encore.daemon.Namespace
+	44, // 79: encore.daemon.Daemon.ListNamespaces:output_type -> encore.daemon.ListNamespacesResponse
+	65, // 80: encore.daemon.Daemon.DeleteNamespace:output_type -> google.protobuf.Empty
+	47, // 81: encore.daemon.Daemon.DumpMeta:output_type -> encore.daemon.DumpMetaResponse
+	65, // 82: encore.daemon.Daemon.Telemetry:output_type -> google.protobuf.Empty
+	10, // 83: encore.daemon.Daemon.CreateApp:output_type -> encore.daemon.CreateAppResponse
+	62, // [62:84] is the sub-list for method output_type
+	40, // [40:62] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_encore_daemon_daemon_proto_init() }
@@ -4549,27 +5058,36 @@ func file_encore_daemon_daemon_proto_init() {
 	}
 	file_encore_daemon_daemon_proto_msgTypes[6].OneofWrappers = []any{}
 	file_encore_daemon_daemon_proto_msgTypes[7].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[10].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[11].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[12].OneofWrappers = []any{
+	file_encore_daemon_daemon_proto_msgTypes[8].OneofWrappers = []any{
+		(*SpecCommand_Curl)(nil),
+	}
+	file_encore_daemon_daemon_proto_msgTypes[10].OneofWrappers = []any{
+		(*RunSpecMessage_Output)(nil),
+		(*RunSpecMessage_Result)(nil),
+		(*RunSpecMessage_Complete)(nil),
+	}
+	file_encore_daemon_daemon_proto_msgTypes[13].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[16].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[17].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[18].OneofWrappers = []any{
 		(*ExecSpecMessage_Output)(nil),
 		(*ExecSpecMessage_Spec)(nil),
 	}
-	file_encore_daemon_daemon_proto_msgTypes[15].OneofWrappers = []any{
+	file_encore_daemon_daemon_proto_msgTypes[21].OneofWrappers = []any{
 		(*ExportRequest_Docker)(nil),
 	}
-	file_encore_daemon_daemon_proto_msgTypes[17].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[19].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[20].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[21].OneofWrappers = []any{}
-	file_encore_daemon_daemon_proto_msgTypes[28].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[23].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[25].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[26].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[27].OneofWrappers = []any{}
+	file_encore_daemon_daemon_proto_msgTypes[34].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_encore_daemon_daemon_proto_rawDesc), len(file_encore_daemon_daemon_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   54,
+			NumMessages:   60,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/encore/daemon/daemon.proto
+++ b/proto/encore/daemon/daemon.proto
@@ -9,6 +9,9 @@ option go_package = "encr.dev/proto/encore/daemon";
 service Daemon {
   // Run runs the application.
   rpc Run(RunRequest) returns (stream CommandMessage);
+  // RunSpec runs a list of HTTP requests against a freshly-started app and
+  // streams the results. Designed for non-interactive agents.
+  rpc RunSpec(RunSpecRequest) returns (stream RunSpecMessage);
   // Test runs tests.
   rpc Test(TestRequest) returns (stream CommandMessage);
   // TestSpec returns the specification for how to run tests.
@@ -136,6 +139,68 @@ message RunRequest {
     DEBUG_ENABLED = 1;
     DEBUG_BREAK = 2;
   }
+}
+
+message RunSpecRequest {
+  // app_root is the absolute filesystem path to the Encore app root.
+  string app_root = 1;
+  // working_dir is the working directory relative to the app_root,
+  // for formatting relative paths in error messages.
+  string working_dir = 2;
+  // environ is the environment to set for the running app,
+  // each entry in "KEY=VALUE" format.
+  repeated string environ = 3;
+  // commands is the ordered list of spec commands to execute against the app.
+  repeated SpecCommand commands = 4;
+  // ready_timeout_seconds is the budget for waiting on /__encore/healthz.
+  // If <= 0, the daemon picks a sensible default.
+  int32 ready_timeout_seconds = 5;
+  // namespace is the infrastructure namespace to use.
+  // If empty the active namespace is used.
+  optional string namespace = 6;
+}
+
+message SpecCommand {
+  oneof cmd {
+    CurlCommand curl = 1;
+  }
+}
+
+message CurlCommand {
+  // path must start with "/" and is appended to http://<bound-addr> by the daemon.
+  string path = 1;
+  // args are extra flags passed verbatim to the curl subprocess.
+  repeated string args = 2;
+}
+
+message RunSpecMessage {
+  oneof msg {
+    // output forwards stdout/stderr from the app or daemon (compile noise,
+    // runtime logs). Clients should render this on stderr.
+    CommandOutput output = 1;
+    // result is one finished spec command.
+    SpecCommandResult result = 2;
+    // complete is the terminal message for the stream.
+    SpecComplete complete = 3;
+  }
+}
+
+message SpecCommandResult {
+  int32 index = 1;       // 1-based
+  int32 total = 2;
+  string display = 3;    // human-readable, e.g. "curl /api/foo -i"
+  bytes stdout = 4;
+  bytes stderr = 5;
+  int32 exit_code = 6;
+}
+
+message SpecComplete {
+  int32 succeeded = 1;
+  int32 total = 2;
+  // error, if non-empty, indicates the run never reached the command-running
+  // phase (compile failure, healthz timeout, etc.). When set, succeeded/total
+  // reflect commands that did execute (typically zero).
+  string error = 3;
 }
 
 message TestRequest {

--- a/proto/encore/daemon/daemon_grpc.pb.go
+++ b/proto/encore/daemon/daemon_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	Daemon_Run_FullMethodName             = "/encore.daemon.Daemon/Run"
+	Daemon_RunSpec_FullMethodName         = "/encore.daemon.Daemon/RunSpec"
 	Daemon_Test_FullMethodName            = "/encore.daemon.Daemon/Test"
 	Daemon_TestSpec_FullMethodName        = "/encore.daemon.Daemon/TestSpec"
 	Daemon_ExecScript_FullMethodName      = "/encore.daemon.Daemon/ExecScript"
@@ -49,6 +50,9 @@ const (
 type DaemonClient interface {
 	// Run runs the application.
 	Run(ctx context.Context, in *RunRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error)
+	// RunSpec runs a list of HTTP requests against a freshly-started app and
+	// streams the results. Designed for non-interactive agents.
+	RunSpec(ctx context.Context, in *RunSpecRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RunSpecMessage], error)
 	// Test runs tests.
 	Test(ctx context.Context, in *TestRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error)
 	// TestSpec returns the specification for how to run tests.
@@ -120,9 +124,28 @@ func (c *daemonClient) Run(ctx context.Context, in *RunRequest, opts ...grpc.Cal
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Daemon_RunClient = grpc.ServerStreamingClient[CommandMessage]
 
+func (c *daemonClient) RunSpec(ctx context.Context, in *RunSpecRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RunSpecMessage], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[1], Daemon_RunSpec_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[RunSpecRequest, RunSpecMessage]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Daemon_RunSpecClient = grpc.ServerStreamingClient[RunSpecMessage]
+
 func (c *daemonClient) Test(ctx context.Context, in *TestRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[1], Daemon_Test_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[2], Daemon_Test_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +174,7 @@ func (c *daemonClient) TestSpec(ctx context.Context, in *TestSpecRequest, opts .
 
 func (c *daemonClient) ExecScript(ctx context.Context, in *ExecScriptRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[2], Daemon_ExecScript_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[3], Daemon_ExecScript_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +193,7 @@ type Daemon_ExecScriptClient = grpc.ServerStreamingClient[CommandMessage]
 
 func (c *daemonClient) ExecSpec(ctx context.Context, in *ExecSpecRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ExecSpecMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[3], Daemon_ExecSpec_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[4], Daemon_ExecSpec_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +212,7 @@ type Daemon_ExecSpecClient = grpc.ServerStreamingClient[ExecSpecMessage]
 
 func (c *daemonClient) Check(ctx context.Context, in *CheckRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[4], Daemon_Check_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[5], Daemon_Check_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +231,7 @@ type Daemon_CheckClient = grpc.ServerStreamingClient[CommandMessage]
 
 func (c *daemonClient) Export(ctx context.Context, in *ExportRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[5], Daemon_Export_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[6], Daemon_Export_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +260,7 @@ func (c *daemonClient) DBConnect(ctx context.Context, in *DBConnectRequest, opts
 
 func (c *daemonClient) DBProxy(ctx context.Context, in *DBProxyRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[6], Daemon_DBProxy_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[7], Daemon_DBProxy_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +279,7 @@ type Daemon_DBProxyClient = grpc.ServerStreamingClient[CommandMessage]
 
 func (c *daemonClient) DBReset(ctx context.Context, in *DBResetRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CommandMessage], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[7], Daemon_DBReset_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &Daemon_ServiceDesc.Streams[8], Daemon_DBReset_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -389,6 +412,9 @@ func (c *daemonClient) CreateApp(ctx context.Context, in *CreateAppRequest, opts
 type DaemonServer interface {
 	// Run runs the application.
 	Run(*RunRequest, grpc.ServerStreamingServer[CommandMessage]) error
+	// RunSpec runs a list of HTTP requests against a freshly-started app and
+	// streams the results. Designed for non-interactive agents.
+	RunSpec(*RunSpecRequest, grpc.ServerStreamingServer[RunSpecMessage]) error
 	// Test runs tests.
 	Test(*TestRequest, grpc.ServerStreamingServer[CommandMessage]) error
 	// TestSpec returns the specification for how to run tests.
@@ -443,6 +469,9 @@ type UnimplementedDaemonServer struct{}
 
 func (UnimplementedDaemonServer) Run(*RunRequest, grpc.ServerStreamingServer[CommandMessage]) error {
 	return status.Errorf(codes.Unimplemented, "method Run not implemented")
+}
+func (UnimplementedDaemonServer) RunSpec(*RunSpecRequest, grpc.ServerStreamingServer[RunSpecMessage]) error {
+	return status.Errorf(codes.Unimplemented, "method RunSpec not implemented")
 }
 func (UnimplementedDaemonServer) Test(*TestRequest, grpc.ServerStreamingServer[CommandMessage]) error {
 	return status.Errorf(codes.Unimplemented, "method Test not implemented")
@@ -535,6 +564,17 @@ func _Daemon_Run_Handler(srv interface{}, stream grpc.ServerStream) error {
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Daemon_RunServer = grpc.ServerStreamingServer[CommandMessage]
+
+func _Daemon_RunSpec_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(RunSpecRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(DaemonServer).RunSpec(m, &grpc.GenericServerStream[RunSpecRequest, RunSpecMessage]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Daemon_RunSpecServer = grpc.ServerStreamingServer[RunSpecMessage]
 
 func _Daemon_Test_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(TestRequest)
@@ -911,6 +951,11 @@ var Daemon_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Run",
 			Handler:       _Daemon_Run_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "RunSpec",
+			Handler:       _Daemon_RunSpec_Handler,
 			ServerStreams: true,
 		},
 		{


### PR DESCRIPTION
This adds a new `encore check` command that starts the app and runs a list of curl commands against it.

This is useful for LLM agents to be able to test that the app works without having to deal with `encore run` in the background.