### PR TITLE
Remove the migrator role

### DIFF
--- a/cli/daemon/sqldb/cluster.go
+++ b/cli/daemon/sqldb/cluster.go
@@ -143,7 +143,7 @@ func (c *Cluster) setupRoles(ctx context.Context, st *ClusterStatus) (EncoreRole
 
 		// Add cluster-level permissions.
 		switch role.Type {
-		case RoleAdmin, RoleMigrator:
+		case RoleAdmin:
 			// Grant admins the ability to create databases.
 			_, err := conn.Exec(ctx, `
 				ALTER USER `+sanitizedUsername+` CREATEDB CREATEROLE
@@ -186,7 +186,6 @@ func (c *Cluster) determineRoles(ctx context.Context, st *ClusterStatus, conn *p
 		// Otherwise if we support predefined roles, add more roles to use.
 		roles = append(roles,
 			Role{RoleServices, "encore_services", "services"},
-			Role{RoleMigrator, "encore-migrator", "migrator"},
 			Role{RoleAdmin, "encore-admin", "admin"},
 			Role{RoleService, "encore-service", "service"},
 			Role{RoleWrite, "encore-write", "write"},
@@ -402,7 +401,6 @@ func (s *ClusterStatus) ConnURI(database string, r Role) string {
 // to the cluster as an Encore user.
 type EncoreRoles []Role
 
-func (roles EncoreRoles) Migrator() (Role, bool)  { return roles.find(RoleMigrator) }
 func (roles EncoreRoles) Superuser() (Role, bool) { return roles.find(RoleSuperuser) }
 func (roles EncoreRoles) Admin() (Role, bool)     { return roles.find(RoleAdmin) }
 func (roles EncoreRoles) Write() (Role, bool)     { return roles.find(RoleWrite) }
@@ -432,7 +430,6 @@ func (r RoleType) String() string { return string(r) }
 
 const (
 	RoleSuperuser RoleType = "superuser"
-	RoleMigrator  RoleType = "migrator"
 	RoleAdmin     RoleType = "admin"
 	RoleServices  RoleType = "services"
 	RoleService   RoleType = "service"

--- a/cli/daemon/sqldb/db.go
+++ b/cli/daemon/sqldb/db.go
@@ -17,21 +17,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
-	"encr.dev/cli/daemon/internal/debugflags"
 	"encr.dev/pkg/fns"
 	"encr.dev/pkg/option"
 	meta "encr.dev/proto/encore/parser/meta/v1"
 )
-
-// migratorRoles returns the role precedence to use when running migrations
-// or creating databases. ENCOREDEBUG=sqldbrole=legacy reverts to the
-// pre-migrator-role behavior of running migrations as the admin role.
-func migratorRoles() []RoleType {
-	if debugflags.Get("sqldbrole") == debugflags.SQLDBRoleLegacy {
-		return []RoleType{RoleAdmin, RoleSuperuser}
-	}
-	return []RoleType{RoleMigrator, RoleAdmin, RoleSuperuser}
-}
 
 // DB represents a single database instance within a cluster.
 type DB struct {
@@ -164,7 +153,7 @@ func (db *DB) doCreate(ctx context.Context, cloudName string, template option.Op
 	// Does it already exist?
 	var dummy int
 	err = adm.QueryRow(ctx, "SELECT 1 FROM pg_database WHERE datname = $1", cloudName).Scan(&dummy)
-	owner, ok := db.Cluster.Roles.First(migratorRoles()...)
+	owner, ok := db.Cluster.Roles.First(RoleAdmin, RoleSuperuser)
 	if !ok {
 		return errors.New("unable to find admin or superuser roles")
 	}
@@ -232,19 +221,11 @@ func (db *DB) ensureRoles(ctx context.Context, cloudName string, roles ...Role) 
 				safeDBName, safeRoleName)
 		case RoleService:
 			stmt = fmt.Sprintf(`GRANT encore_services TO %s;`, safeRoleName)
-		case RoleMigrator:
-			stmt = fmt.Sprintf(`
-				GRANT ALL ON DATABASE %[1]s TO %[2]s;
-				GRANT pg_read_all_data TO %[2]s;
-				GRANT pg_write_all_data TO %[2]s;
-				GRANT encore_services TO %[2]s;`,
-				safeDBName, safeRoleName)
 		case RoleAdmin:
 			stmt = fmt.Sprintf(`
 				GRANT ALL ON DATABASE %[1]s TO %[2]s;
 				GRANT pg_read_all_data TO %[2]s;
 				GRANT pg_write_all_data TO %[2]s;
-				GRANT "encore-migrator" TO %[2]s;
 				GRANT encore_services TO %[2]s;`,
 				safeDBName, safeRoleName)
 		case RoleWrite:
@@ -313,7 +294,7 @@ func (db *DB) doMigrate(ctx context.Context, cloudName, appRoot string, dbMeta *
 		return errors.New("cluster not running")
 	}
 
-	admin, ok := info.Encore.First(migratorRoles()...)
+	admin, ok := info.Encore.First(RoleAdmin, RoleSuperuser)
 	if !ok {
 		return errors.New("unable to find superuser or admin roles")
 	}


### PR DESCRIPTION
The migrator role is not compatible with existing local databases as ownership of old objects would belong to encore-admin
