### PR TITLE
clientgen: add optional CallParameters to generated TypeScript endpoint methods

### DIFF
--- a/pkg/clientgen/testdata/goapp/expected_baseauth_typescript.ts
+++ b/pkg/clientgen/testdata/goapp/expected_baseauth_typescript.ts
@@ -120,15 +120,15 @@ export namespace svc {
         /**
          * DummyAPI is a dummy endpoint.
          */
-        public async DummyAPI(params: Request): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
+        public async DummyAPI(params: Request, options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params), options)
         }
 
         /**
          * Private is a basic auth endpoint.
          */
-        public async Private(params: Request): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/svc.Private`, JSON.stringify(params))
+        public async Private(params: Request, options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/svc.Private`, JSON.stringify(params), options)
         }
     }
 }

--- a/pkg/clientgen/testdata/goapp/expected_httpstatus_typescript.ts
+++ b/pkg/clientgen/testdata/goapp/expected_httpstatus_typescript.ts
@@ -94,9 +94,9 @@ export namespace svc {
         /**
          * DummyAPI is a dummy endpoint.
          */
-        public async DummyAPI(): Promise<Response> {
+        public async DummyAPI(options?: CallParameters): Promise<Response> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, undefined, options)
             return await resp.json() as Response
         }
     }

--- a/pkg/clientgen/testdata/goapp/expected_noauth_typescript.ts
+++ b/pkg/clientgen/testdata/goapp/expected_noauth_typescript.ts
@@ -94,8 +94,8 @@ export namespace svc {
         /**
          * DummyAPI is a dummy endpoint.
          */
-        public async DummyAPI(params: Request): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params))
+        public async DummyAPI(params: Request, options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(params), options)
         }
     }
 }

--- a/pkg/clientgen/testdata/goapp/expected_typescript.ts
+++ b/pkg/clientgen/testdata/goapp/expected_typescript.ts
@@ -132,8 +132,8 @@ export namespace authentication {
             this.Docs = this.Docs.bind(this)
         }
 
-        public async Docs(params: FooType): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/authentication.Docs`, JSON.stringify(params))
+        public async Docs(params: FooType, options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/authentication.Docs`, JSON.stringify(params), options)
         }
     }
 }
@@ -174,7 +174,7 @@ export namespace products {
             this.List = this.List.bind(this)
         }
 
-        public async Create(params: CreateProductRequest): Promise<Product> {
+        public async Create(params: CreateProductRequest, options?: CallParameters): Promise<Product> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "idempotency-key": params.IdempotencyKey,
@@ -187,13 +187,13 @@ export namespace products {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/products.Create`, JSON.stringify(body), {headers})
+            const resp = await this.baseClient.callTypedAPI("POST", `/products.Create`, JSON.stringify(body), {...options, headers})
             return await resp.json() as Product
         }
 
-        public async List(): Promise<ProductListing> {
+        public async List(options?: CallParameters): Promise<ProductListing> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("GET", `/products.List`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/products.List`, undefined, options)
             return await resp.json() as ProductListing
         }
     }
@@ -370,16 +370,16 @@ export namespace svc {
             this.Webhook2 = this.Webhook2.bind(this)
         }
 
-        public async CreateDocumentedOrder(params: DocumentedOrder): Promise<DocumentedOrder> {
+        public async CreateDocumentedOrder(params: DocumentedOrder, options?: CallParameters): Promise<DocumentedOrder> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.CreateDocumentedOrder`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.CreateDocumentedOrder`, JSON.stringify(params), options)
             return await resp.json() as DocumentedOrder
         }
 
         /**
          * DummyAPI is a dummy endpoint.
          */
-        public async DummyAPI(params: Request): Promise<void> {
+        public async DummyAPI(params: Request, options?: CallParameters): Promise<void> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 baz:   params.HeaderBaz,
@@ -399,23 +399,23 @@ export namespace svc {
                 boo: params.boo,
             }
 
-            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {headers, query})
+            await this.baseClient.callTypedAPI("POST", `/svc.DummyAPI`, JSON.stringify(body), {...options, headers, query})
         }
 
-        public async FallbackPath(a: string, b: string[]): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+        public async FallbackPath(a: string, b: string[], options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/fallbackPath/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, undefined, options)
         }
 
-        public async Get(params: GetRequest): Promise<void> {
+        public async Get(params: GetRequest, options?: CallParameters): Promise<void> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
                 boo: String(params.Baz),
             })
 
-            await this.baseClient.callTypedAPI("GET", `/svc.Get`, undefined, {query})
+            await this.baseClient.callTypedAPI("GET", `/svc.Get`, undefined, {...options, query})
         }
 
-        public async GetRequestWithAllInputTypes(params: AllInputTypes<number>): Promise<HeaderOnlyStruct> {
+        public async GetRequestWithAllInputTypes(params: AllInputTypes<number>, options?: CallParameters): Promise<HeaderOnlyStruct> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "x-alice": String(params.A),
@@ -429,7 +429,7 @@ export namespace svc {
             })
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {headers, query})
+            const resp = await this.baseClient.callTypedAPI("GET", `/svc.GetRequestWithAllInputTypes`, undefined, {...options, headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as HeaderOnlyStruct
@@ -446,7 +446,7 @@ export namespace svc {
             return rtn
         }
 
-        public async HeaderOnlyRequest(params: HeaderOnlyStruct): Promise<void> {
+        public async HeaderOnlyRequest(params: HeaderOnlyStruct, options?: CallParameters): Promise<void> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "x-boolean":  String(params.Boolean),
@@ -461,26 +461,26 @@ export namespace svc {
                 "x-uuid":     String(params.UUID),
             })
 
-            await this.baseClient.callTypedAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {headers})
+            await this.baseClient.callTypedAPI("GET", `/svc.HeaderOnlyRequest`, undefined, {...options, headers})
         }
 
-        public async Nested(params: WithNested): Promise<WithNested> {
+        public async Nested(params: WithNested, options?: CallParameters): Promise<WithNested> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.Nested`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.Nested`, JSON.stringify(params), options)
             return await resp.json() as WithNested
         }
 
-        public async RESTPath(a: string, b: number): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`)
+        public async RESTPath(a: string, b: number, options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/path/${encodeURIComponent(a)}/${encodeURIComponent(b)}`, undefined, options)
         }
 
-        public async Rec(params: Recursive): Promise<Recursive> {
+        public async Rec(params: Recursive, options?: CallParameters): Promise<Recursive> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.Rec`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.Rec`, JSON.stringify(params), options)
             return await resp.json() as Recursive
         }
 
-        public async RequestWithAllInputTypes(params: AllInputTypes<string>): Promise<AllInputTypes<number>> {
+        public async RequestWithAllInputTypes(params: AllInputTypes<string>, options?: CallParameters): Promise<AllInputTypes<number>> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 "x-alice": String(params.A),
@@ -498,7 +498,7 @@ export namespace svc {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.RequestWithAllInputTypes`, JSON.stringify(body), {headers, query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.RequestWithAllInputTypes`, JSON.stringify(body), {...options, headers, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as AllInputTypes<number>
@@ -506,14 +506,14 @@ export namespace svc {
             return rtn
         }
 
-        public async SetCookie(params: GetRequest): Promise<ResponseWithSetCookie> {
+        public async SetCookie(params: GetRequest, options?: CallParameters): Promise<ResponseWithSetCookie> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
                 boo: String(params.Baz),
             })
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.SetCookie`, undefined, {query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.SetCookie`, undefined, {...options, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as ResponseWithSetCookie
@@ -524,14 +524,14 @@ export namespace svc {
             return rtn
         }
 
-        public async SingleSetCookie(params: GetRequest): Promise<ResponseWithSingleSetCookie> {
+        public async SingleSetCookie(params: GetRequest, options?: CallParameters): Promise<ResponseWithSingleSetCookie> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
                 boo: String(params.Baz),
             })
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.SingleSetCookie`, undefined, {query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.SingleSetCookie`, undefined, {...options, query})
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as ResponseWithSingleSetCookie
@@ -545,9 +545,9 @@ export namespace svc {
          * TupleInputOutput tests the usage of generics in the client generator
          * and this comment is also multiline, so multiline comments get tested as well.
          */
-        public async TupleInputOutput(params: Tuple<string, WrappedRequest>): Promise<Tuple<boolean, Foo>> {
+        public async TupleInputOutput(params: Tuple<string, WrappedRequest>, options?: CallParameters): Promise<Tuple<boolean, Foo>> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/svc.TupleInputOutput`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/svc.TupleInputOutput`, JSON.stringify(params), options)
             return await resp.json() as Tuple<boolean, Foo>
         }
 
@@ -555,8 +555,8 @@ export namespace svc {
             return this.baseClient.callAPI(method, `/webhook/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, body, options)
         }
 
-        public async Webhook2(a: string, b: string[]): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`)
+        public async Webhook2(a: string, b: string[], options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/webhook2/${encodeURIComponent(a)}/${b.map(encodeURIComponent).join("/")}`, undefined, options)
         }
     }
 }

--- a/pkg/clientgen/testdata/tsapp/expected_decimal_typescript.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_decimal_typescript.ts
@@ -96,7 +96,7 @@ export namespace svc {
             this.dummy = this.dummy.bind(this)
         }
 
-        public async dummy(params: Request): Promise<Response> {
+        public async dummy(params: Request, options?: CallParameters): Promise<Response> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
                 message: params.message,
@@ -104,7 +104,7 @@ export namespace svc {
             })
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, {query})
+            const resp = await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, {...options, query})
             return await resp.json() as Response
         }
     }

--- a/pkg/clientgen/testdata/tsapp/expected_httpstatus_typescript.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_httpstatus_typescript.ts
@@ -91,9 +91,9 @@ export namespace svc {
             this.dummy = this.dummy.bind(this)
         }
 
-        public async dummy(): Promise<Response> {
+        public async dummy(options?: CallParameters): Promise<Response> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("GET", `/dummy`)
+            const resp = await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, options)
             return await resp.json() as Response
         }
     }

--- a/pkg/clientgen/testdata/tsapp/expected_list_of_union_typescript.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_list_of_union_typescript.ts
@@ -91,13 +91,13 @@ export namespace svc {
             this.dummy = this.dummy.bind(this)
         }
 
-        public async dummy(params: Request): Promise<void> {
+        public async dummy(params: Request, options?: CallParameters): Promise<void> {
             // Convert our params into the objects we need for the request
             const query = makeRecord<string, string | string[]>({
                 listOfUnion: params.listOfUnion.map((v) => String(v)),
             })
 
-            await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, {query})
+            await this.baseClient.callTypedAPI("GET", `/dummy`, undefined, {...options, query})
         }
     }
 }

--- a/pkg/clientgen/testdata/tsapp/expected_typescript.ts
+++ b/pkg/clientgen/testdata/tsapp/expected_typescript.ts
@@ -173,7 +173,7 @@ export namespace svc {
             this.singleSetCookie = this.singleSetCookie.bind(this)
         }
 
-        public async cookieDummy(params: Request): Promise<{
+        public async cookieDummy(params: Request, options?: CallParameters): Promise<{
 }> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
@@ -194,21 +194,21 @@ export namespace svc {
             }
 
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/cookie-dummy`, JSON.stringify(body), {headers, query})
+            const resp = await this.baseClient.callTypedAPI("POST", `/cookie-dummy`, JSON.stringify(body), {...options, headers, query})
             return await resp.json() as {
 }
         }
 
         public async cookiesOnly(params: {
-}): Promise<{
+}, options?: CallParameters): Promise<{
 }> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/cookies-only`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/cookies-only`, undefined, options)
             return await resp.json() as {
 }
         }
 
-        public async dummy(params: Request): Promise<void> {
+        public async dummy(params: Request, options?: CallParameters): Promise<void> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 baz: params.headerBaz,
@@ -227,25 +227,25 @@ export namespace svc {
                 foo: params.foo,
             }
 
-            await this.baseClient.callTypedAPI("POST", `/dummy`, JSON.stringify(body), {headers, query})
+            await this.baseClient.callTypedAPI("POST", `/dummy`, JSON.stringify(body), {...options, headers, query})
         }
 
         /**
          * Imported tests the usage of imported types
          * and this comment is also multiline.
          */
-        public async imported(params: common_stuff.ImportedRequest): Promise<common_stuff.ImportedResponse> {
+        public async imported(params: common_stuff.ImportedRequest, options?: CallParameters): Promise<common_stuff.ImportedResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/imported`, JSON.stringify(params))
+            const resp = await this.baseClient.callTypedAPI("POST", `/imported`, JSON.stringify(params), options)
             return await resp.json() as common_stuff.ImportedResponse
         }
 
-        public async multiSetCookie(): Promise<{
+        public async multiSetCookie(options?: CallParameters): Promise<{
     message: string
     tokens: string[]
 }> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/multi-set-cookie`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/multi-set-cookie`, undefined, options)
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as {
@@ -258,20 +258,20 @@ export namespace svc {
             return rtn
         }
 
-        public async noTypes(): Promise<void> {
-            await this.baseClient.callTypedAPI("POST", `/type-less`)
+        public async noTypes(options?: CallParameters): Promise<void> {
+            await this.baseClient.callTypedAPI("POST", `/type-less`, undefined, options)
         }
 
-        public async onlyPathParams(pathParam: string, pathParam2: string): Promise<common_stuff.ImportedResponse> {
+        public async onlyPathParams(pathParam: string, pathParam2: string, options?: CallParameters): Promise<common_stuff.ImportedResponse> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/path/${encodeURIComponent(pathParam)}/${encodeURIComponent(pathParam2)}`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/path/${encodeURIComponent(pathParam)}/${encodeURIComponent(pathParam2)}`, undefined, options)
             return await resp.json() as common_stuff.ImportedResponse
         }
 
         /**
          * Root is a basic POST endpoint.
          */
-        public async root(params: Request): Promise<void> {
+        public async root(params: Request, options?: CallParameters): Promise<void> {
             // Convert our params into the objects we need for the request
             const headers = makeRecord<string, string>({
                 baz: params.headerBaz,
@@ -290,15 +290,15 @@ export namespace svc {
                 foo: params.foo,
             }
 
-            await this.baseClient.callTypedAPI("POST", `/`, JSON.stringify(body), {headers, query})
+            await this.baseClient.callTypedAPI("POST", `/`, JSON.stringify(body), {...options, headers, query})
         }
 
-        public async singleSetCookie(): Promise<{
+        public async singleSetCookie(options?: CallParameters): Promise<{
     message: string
     token: string
 }> {
             // Now make the actual call to the API
-            const resp = await this.baseClient.callTypedAPI("POST", `/single-set-cookie`)
+            const resp = await this.baseClient.callTypedAPI("POST", `/single-set-cookie`, undefined, options)
 
             //Populate the return object from the JSON body and received headers
             const rtn = await resp.json() as {

--- a/pkg/clientgen/typescript.go
+++ b/pkg/clientgen/typescript.go
@@ -417,6 +417,15 @@ func (ts *typescript) writeService(svc *meta.Service, p clientgentypes.ServiceSe
 			}
 		}
 
+		// Add optional CallParameters to non-raw, non-stream endpoints so callers
+		// can pass an AbortSignal or other fetch options per request.
+		if !isRaw && !isStream && !ts.sharedTypes {
+			if rpc.RequestSchema != nil || nParams > 0 {
+				ts.WriteString(", ")
+			}
+			ts.WriteString("options?: CallParameters")
+		}
+
 		var direction streamDirection
 
 		if rpc.StreamingRequest && rpc.StreamingResponse {
@@ -726,12 +735,31 @@ func (ts *typescript) rpcCallSite(ns string, w *indentWriter, rpc *meta.RPC, rpc
 		callAPI += fmt.Sprintf("\"%s\", ", rpcEncoding.DefaultMethod)
 	}
 	callAPI += fmt.Sprintf("`%s`", rpcPath)
-	if body != "" || headers != "" || query != "" || ts.sharedTypes {
+
+	if !ts.sharedTypes {
+		// Always pass body and options so callers can provide an AbortSignal
+		// or other CallParameters per request.
 		if body == "" {
 			body = "undefined"
 		}
-		if !ts.sharedTypes {
-			callAPI += ", " + body
+		callAPI += ", " + body
+
+		if headers != "" || query != "" {
+			callAPI += ", {...options, " + headers
+			if headers != "" && query != "" {
+				callAPI += ", "
+			}
+			if query != "" {
+				callAPI += query
+			}
+			callAPI += "}"
+		} else {
+			callAPI += ", options"
+		}
+	} else {
+		// sharedTypes: always pass the params object since it embeds method and body.
+		if body == "" {
+			body = "undefined"
 		}
 
 		if headers != "" || query != "" || ts.sharedTypes {


### PR DESCRIPTION
Generated TypeScript endpoint methods don't currently accept `CallParameters`, so there's no way to pass an `AbortSignal` through the generated client. Raw endpoints already support this — this brings typed endpoints to parity.

Without this, when a user navigates away from a page in a SPA, in-flight requests can't be canceled. The backend continues processing the abandoned request and logs "context canceled" errors when the response tries to write to a closed connection.

### Before / After

```typescript
// Before — no way to pass options
await client.svc.GetStatus(req)

// After — optional CallParameters as trailing argument
await client.svc.GetStatus(req, { signal: controller.signal })
```

### Changes

- `pkg/clientgen/typescript.go`: non-raw, non-stream endpoints now accept an optional trailing `options?: CallParameters`, forwarded to `callTypedAPI`. When headers/query are present, options are spread first (`{...options, headers, query}`) so endpoint-specific values take precedence.
- 8 golden test files updated to match.
- `sharedTypes`, stream, and raw code paths are unchanged.
- Fully backwards-compatible.