### PR TITLE
Docs: document cloud permissions scoping and self-hosted preview environments

### DIFF
--- a/docs/platform/deploy/own-cloud.md
+++ b/docs/platform/deploy/own-cloud.md
@@ -23,7 +23,13 @@ within Encore, you need to explicitly approve the deletion of the infrastructure
 
 ## Google Cloud Platform (GCP)
 
-Encore Cloud provides a GCP Service Account for each Encore Cloud application, letting you grant Encore Cloud access to provision all the necessary infrastructure directly in your own GCP Organization account.
+Encore Cloud provides a GCP Service Account for each Encore Cloud application, letting you grant Encore Cloud access to provision all the necessary infrastructure directly in your own GCP account.
+
+### Permissions scoping
+
+GCP's permissions system is well-suited for scoping down Encore Cloud's access. While the simplest setup grants access at the organization level, permissions can also be scoped down to a single GCP project. This is useful when you want to isolate Encore Cloud's access to a specific project within your organization, for example a sandboxed prototyping environment. [Contact us](https://encore.dev/book) to discuss the best setup for your needs.
+
+### Setup
 
 To find your app's Service Account email and configure GCP deployments, head over to the Connect Cloud page by going to the **[Encore Cloud dashboard](https://app.encore.cloud/) > (Select your app) > App Settings > Integrations > Connect Cloud**.
 
@@ -56,6 +62,15 @@ If you're using several GCP accounts, make sure you're logged in with the correc
 Still having issues? Drop us an email at [support@encore.dev](mailto:support@encore.dev) or chat with us in the [Encore Discord](https://encore.dev/discord.
 
 ## Amazon Web Services (AWS)
+
+### Permissions scoping
+
+For a seamless experience, the default setup uses an IAM Role that gives Encore Cloud the permissions needed to provision and manage infrastructure in your AWS account. The simplest way to scope this is to use a dedicated AWS sub-organization for Encore Cloud, which provides clear isolation.
+
+It's also possible to configure a more narrowly scoped IAM policy. The required permissions depend dynamically on the structure of your applications and the infrastructure resources they use. We're actively working on providing more solutions for scoping down permissions further. [Contact us](https://encore.dev/book) to discuss the best setup for your needs.
+
+### Setup
+
 To configure your Encore Cloud app to deploy to your AWS account, head over to the Connect Cloud page by going to the
 **[Encore Cloud dashboard](https://app.encore.cloud/) > (Select your app) > App Settings > Integrations > Connect Cloud**.
 

--- a/docs/platform/deploy/preview-environments.md
+++ b/docs/platform/deploy/preview-environments.md
@@ -10,6 +10,12 @@ When using [Encore Cloud Pro](https://encore.cloud/pricing), you automatically g
 
 Preview Environments are free, fully-managed development environments that run on Encore Cloud. They let you test changes without managing infrastructure or incurring cost.
 
+### Self-hosted Preview Environments (Enterprise)
+
+On the Enterprise tier, Preview Environments can also be hosted on your own cloud infrastructure. This is useful when your Preview Environments need network access to private resources, such as shared databases or internal APIs.
+
+For example, on GCP you can isolate all Preview Environments to a single GCP project, so you only need to set up networking and VPC access to your other private resources once and all Preview Environments will automatically have access. [Contact us](https://encore.dev/book) to discuss your requirements.
+
 See the [infra docs](/docs/platform/infrastructure/infra#preview-environments) if you're curious about exactly how Preview Environments are provisioned.
 
 ## Using Preview Environments

--- a/docs/platform/infrastructure/infra.md
+++ b/docs/platform/infrastructure/infra.md
@@ -69,8 +69,10 @@ The application code itself is compiled and run natively on your machine (withou
 
 When you've [connected your application to GitHub](/docs/platform/integrations/github), Encore Cloud automatically provisions a temporary [Preview Environment](/docs/platform/deploy/preview-environments) for each Pull Request.
 
-Preview Environments are created in Encore Cloud Hosting, and are optimized for provisioning speed and cost-effectiveness.
+Preview Environments are created in Encore Cloud Hosting by default, and are optimized for provisioning speed and cost-effectiveness.
 The Preview Environment is automatically destroyed when the Pull Request is merged or closed.
+
+On the Enterprise tier, Preview Environments can also be hosted on your own cloud infrastructure. See the [Preview Environments docs](/docs/platform/deploy/preview-environments#self-hosted-preview-environments-enterprise) for more information.
 
 Preview Environments are named after the pull request, so PR #72 will create an environment named `pr:72`.
 


### PR DESCRIPTION
## Summary
- Added permissions scoping sections for both GCP and AWS in the cloud connection docs, documenting that GCP permissions can be scoped to a single project and AWS supports sub-organizations and narrower IAM policies
- Added self-hosted preview environments section (Enterprise tier) to preview environments docs, with GCP single-project isolation as an example
- Updated infra overview to reference the self-hosted preview environments option