### PR TITLE
cli/daemon/mcp: synchronous Pub/Sub probe + retry-aware call_endpoint

### DIFF
--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -37,7 +37,51 @@ func (m *Manager) registerAPITools() {
 		mcp.WithString("auth_token", mcp.Description("Optional authentication token to include in the request. This is used for endpoints that require authentication.")),
 		mcp.WithString("auth_payload", mcp.Description("Optional authentication payload in JSON format. This is used for custom authentication schemes.")),
 		mcp.WithString("correlation_id", mcp.Description("Optional correlation ID to track the request through the system. Useful for debugging and tracing.")),
-		mcp.WithObject("retry_until", mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. Predicate forms: status (int), body_path ({path, equals}), body_jq (subset: '<path>' or '<path> | length <op> N'). Other fields: timeout_ms (int, default 10000), interval_ms (int, default 250), fail_on_timeout (bool, default false). Accepts a JSON object or a JSON-encoded string.")),
+		mcp.WithObject("retry_until",
+			mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. Accepts a JSON object or a JSON-encoded string."),
+			mcp.Properties(map[string]any{
+				"predicate": map[string]any{
+					"type":        "object",
+					"description": "Predicate the response must satisfy to stop retrying. Exactly one of status, body_path, or body_jq should be set; precedence is body_jq > body_path > status.",
+					"properties": map[string]any{
+						"status": map[string]any{
+							"type":        "integer",
+							"description": "Stop when the HTTP response status equals this code (e.g. 200).",
+						},
+						"body_path": map[string]any{
+							"type":        "object",
+							"description": "Stop when the value at the given dot-path equals the expected JSON value.",
+							"properties": map[string]any{
+								"path": map[string]any{
+									"type":        "string",
+									"description": "Dot-path into the JSON response body (e.g. '.events.0.orderID').",
+								},
+								"equals": map[string]any{
+									"description": "Expected value at the path (any JSON value).",
+								},
+							},
+							"required": []string{"path", "equals"},
+						},
+						"body_jq": map[string]any{
+							"type":        "string",
+							"description": "Minimal jq subset: '<path> | length <op> N' where op is one of > >= == != < <=, or '<path>' for a truthy check.",
+						},
+					},
+				},
+				"timeout_ms": map[string]any{
+					"type":        "integer",
+					"description": "Max total wait in milliseconds. Default 10000.",
+				},
+				"interval_ms": map[string]any{
+					"type":        "integer",
+					"description": "Delay between retries in milliseconds. Default 250.",
+				},
+				"fail_on_timeout": map[string]any{
+					"type":        "boolean",
+					"description": "If true, return an MCP error on timeout instead of the last response. Default false.",
+				},
+			}),
+		),
 	), m.callEndpoint)
 
 	// Add tool for getting all services and endpoints

--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -36,6 +37,7 @@ func (m *Manager) registerAPITools() {
 		mcp.WithString("auth_token", mcp.Description("Optional authentication token to include in the request. This is used for endpoints that require authentication.")),
 		mcp.WithString("auth_payload", mcp.Description("Optional authentication payload in JSON format. This is used for custom authentication schemes.")),
 		mcp.WithString("correlation_id", mcp.Description("Optional correlation ID to track the request through the system. Useful for debugging and tracing.")),
+		mcp.WithObject("retry_until", mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. Predicate forms: status (int), body_path ({path, equals}), body_jq (subset: '<path>' or '<path> | length <op> N'). Other fields: timeout_ms (int, default 10000), interval_ms (int, default 250), fail_on_timeout (bool, default false).")),
 	), m.callEndpoint)
 
 	// Add tool for getting all services and endpoints
@@ -130,16 +132,69 @@ func (m *Manager) callEndpoint(ctx context.Context, request mcp.CallToolRequest)
 		return nil, err
 	}
 
-	result, err := singleShotCall(ctx, m.run, inst, params)
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		return singleShotCall(ctx, m.run, inst, params)
+	}
+
+	cfg, hasRetry, err := parseRetryUntil(request.Params.Arguments["retry_until"])
 	if err != nil {
+		return nil, err
+	}
+
+	if !hasRetry {
+		result, err := doCall(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("API call failed: %w", err)
+		}
+		jsonData, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal response: %w", err)
+		}
+		return mcp.NewToolResultText(string(jsonData)), nil
+	}
+
+	startedAt := time.Now()
+	result, info, err := runRetryLoop(ctx, cfg, doCall)
+	info.TotalWaitMS = int64(time.Since(startedAt) / time.Millisecond)
+	info.Predicate = predicateAsMap(cfg.Predicate)
+
+	if err != nil {
+		var rte *retryTimeoutError
+		if errors.As(err, &rte) {
+			body, _ := json.Marshal(map[string]any{
+				"error":         rte.Message,
+				"last_response": rte.LastResponse,
+				"attempts":      rte.Attempts,
+			})
+			return mcp.NewToolResultText(string(body)), nil
+		}
 		return nil, fmt.Errorf("API call failed: %w", err)
 	}
 
+	result["retry"] = map[string]any{
+		"matched":       info.Matched,
+		"attempts":      info.Attempts,
+		"total_wait_ms": info.TotalWaitMS,
+		"predicate":     info.Predicate,
+	}
 	jsonData, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal response: %w", err)
 	}
 	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+func predicateAsMap(p predicate) map[string]any {
+	if p.Jq != "" {
+		return map[string]any{"body_jq": p.Jq}
+	}
+	if p.Path != nil {
+		return map[string]any{"body_path": map[string]any{"path": p.Path.Path, "equals": p.Path.Equals}}
+	}
+	if p.Status != 0 {
+		return map[string]any{"status": p.Status}
+	}
+	return map[string]any{}
 }
 
 // ensureAppRunning starts the app if it isn't already, and waits for the

--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -37,7 +37,7 @@ func (m *Manager) registerAPITools() {
 		mcp.WithString("auth_token", mcp.Description("Optional authentication token to include in the request. This is used for endpoints that require authentication.")),
 		mcp.WithString("auth_payload", mcp.Description("Optional authentication payload in JSON format. This is used for custom authentication schemes.")),
 		mcp.WithString("correlation_id", mcp.Description("Optional correlation ID to track the request through the system. Useful for debugging and tracing.")),
-		mcp.WithObject("retry_until", mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. Predicate forms: status (int), body_path ({path, equals}), body_jq (subset: '<path>' or '<path> | length <op> N'). Other fields: timeout_ms (int, default 10000), interval_ms (int, default 250), fail_on_timeout (bool, default false).")),
+		mcp.WithObject("retry_until", mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. Predicate forms: status (int), body_path ({path, equals}), body_jq (subset: '<path>' or '<path> | length <op> N'). Other fields: timeout_ms (int, default 10000), interval_ms (int, default 250), fail_on_timeout (bool, default false). Accepts a JSON object or a JSON-encoded string.")),
 	), m.callEndpoint)
 
 	// Add tool for getting all services and endpoints

--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -14,6 +14,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"encr.dev/cli/daemon/apps"
+	"encr.dev/cli/daemon/namespace"
 	"encr.dev/cli/daemon/run"
 	"encr.dev/pkg/builder"
 	"encr.dev/pkg/schemautil"
@@ -124,12 +126,30 @@ func (m *Manager) callEndpoint(ctx context.Context, request mcp.CallToolRequest)
 		return nil, fmt.Errorf("failed to get active namespace: %w", err)
 	}
 
-	// Get the app's run instance
+	if err := m.ensureAppRunning(ctx, inst, ns); err != nil {
+		return nil, err
+	}
+
+	result, err := singleShotCall(ctx, m.run, inst, params)
+	if err != nil {
+		return nil, fmt.Errorf("API call failed: %w", err)
+	}
+
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+// ensureAppRunning starts the app if it isn't already, and waits for the
+// health endpoint to return 200 before returning.
+func (m *Manager) ensureAppRunning(ctx context.Context, inst *apps.Instance, ns *namespace.Namespace) error {
 	appRun := m.run.FindRunByAppID(inst.PlatformOrLocalID())
 	if appRun == nil {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
-			return nil, fmt.Errorf("failed to create listener: %w", err)
+			return fmt.Errorf("failed to create listener: %w", err)
 		}
 		port := ln.Addr().(*net.TCPAddr).Port
 		appRun, err = m.run.Start(ctx, run.StartParams{
@@ -145,48 +165,49 @@ func (m *Manager) callEndpoint(ctx context.Context, request mcp.CallToolRequest)
 			Debug:      builder.DebugModeDisabled,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to start app run: %w", err)
+			return fmt.Errorf("failed to start app run: %w", err)
 		}
 	}
-
-	started := false
-	for !started {
+	for {
 		select {
 		case <-appRun.Done():
-			return nil, fmt.Errorf("app run failed to start")
+			return fmt.Errorf("app run failed to start")
 		case <-time.After(100 * time.Millisecond):
-			// Check if the app is ready by polling the health endpoint
 			resp, err := http.Get("http://" + appRun.ListenAddr + "/__encore/healthz")
 			if err != nil {
 				continue
 			}
 			resp.Body.Close()
-			started = resp.StatusCode == 200
+			if resp.StatusCode == 200 {
+				return nil
+			}
 		}
 	}
+}
 
-	// Call the API
-	result, err := run.CallAPI(ctx, appRun, params)
-
-	if err != nil {
-		return nil, fmt.Errorf("API call failed: %w", err)
+// singleShotCall performs one HTTP call against the running app and returns
+// the result map with byte-body converted to string.
+func singleShotCall(ctx context.Context, runMgr *run.Manager, inst *apps.Instance, params *run.ApiCallParams) (map[string]any, error) {
+	appRun := runMgr.FindRunByAppID(inst.PlatformOrLocalID())
+	if appRun == nil {
+		return nil, fmt.Errorf("app is not running")
 	}
+	result, err := run.CallAPI(ctx, appRun, params)
+	if err != nil {
+		return nil, err
+	}
+	return stringifyBody(result), nil
+}
 
-	// Convert body to string
+// stringifyBody mutates result in place to convert a []byte body to string.
+// The map is returned for chaining.
+func stringifyBody(result map[string]any) map[string]any {
 	if body, ok := result["body"]; ok {
-		switch v := body.(type) {
-		case []byte:
+		if v, ok := body.([]byte); ok {
 			result["body"] = string(v)
 		}
 	}
-
-	// Serialize the response
-	jsonData, err := json.Marshal(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal response: %w", err)
-	}
-
-	return mcp.NewToolResultText(string(jsonData)), nil
+	return result
 }
 
 func (m *Manager) getEndpoints(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -164,7 +164,12 @@ func (m *Manager) callEndpoint(ctx context.Context, request mcp.CallToolRequest)
 			body, _ := json.Marshal(map[string]any{
 				"error":         rte.Message,
 				"last_response": rte.LastResponse,
-				"attempts":      rte.Attempts,
+				"retry": map[string]any{
+					"matched":       false,
+					"attempts":      rte.Attempts,
+					"total_wait_ms": info.TotalWaitMS,
+					"predicate":     info.Predicate,
+				},
 			})
 			return mcp.NewToolResultText(string(body)), nil
 		}
@@ -660,9 +665,23 @@ func parseRetryUntil(raw any) (retryConfig, bool, error) {
 	if raw == nil {
 		return retryConfig{}, false, nil
 	}
-	m, ok := raw.(map[string]any)
-	if !ok {
+	var m map[string]any
+	switch v := raw.(type) {
+	case map[string]any:
+		m = v
+	case string:
+		if v == "" {
+			return retryConfig{}, false, nil
+		}
+		if err := json.Unmarshal([]byte(v), &m); err != nil {
+			return retryConfig{}, false, fmt.Errorf("invalid retry_until: %w", err)
+		}
+	default:
 		return retryConfig{}, false, fmt.Errorf("retry_until must be an object")
+	}
+	if len(m) == 0 {
+		// Empty object → no retry, matching the omitted-field behavior.
+		return retryConfig{}, false, nil
 	}
 
 	cfg := retryConfig{

--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -573,6 +573,130 @@ func (m *Manager) getMiddleware(ctx context.Context, request mcp.CallToolRequest
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
+type retryConfig struct {
+	Predicate     predicate
+	Timeout       time.Duration
+	Interval      time.Duration
+	FailOnTimeout bool
+}
+
+type retryInfo struct {
+	Matched     bool
+	Attempts    int
+	TotalWaitMS int64
+	Predicate   map[string]any // for echoing back to the agent
+}
+
+type retryTimeoutError struct {
+	Message      string
+	LastResponse map[string]any
+	Attempts     int
+}
+
+func (e *retryTimeoutError) Error() string { return e.Message }
+
+const (
+	defaultRetryTimeoutMS  = 10000
+	defaultRetryIntervalMS = 250
+)
+
+// parseRetryUntil decodes the retry_until input. Returns ok=false when retry_until is absent.
+func parseRetryUntil(raw any) (retryConfig, bool, error) {
+	if raw == nil {
+		return retryConfig{}, false, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return retryConfig{}, false, fmt.Errorf("retry_until must be an object")
+	}
+
+	cfg := retryConfig{
+		Timeout:  defaultRetryTimeoutMS * time.Millisecond,
+		Interval: defaultRetryIntervalMS * time.Millisecond,
+	}
+
+	if v, ok := m["timeout_ms"].(float64); ok {
+		cfg.Timeout = time.Duration(v) * time.Millisecond
+	}
+	if v, ok := m["interval_ms"].(float64); ok {
+		cfg.Interval = time.Duration(v) * time.Millisecond
+	}
+	if v, ok := m["fail_on_timeout"].(bool); ok {
+		cfg.FailOnTimeout = v
+	}
+
+	pm, ok := m["predicate"].(map[string]any)
+	if !ok {
+		return retryConfig{}, false, fmt.Errorf("retry_until.predicate is required")
+	}
+	// Order of preference: jq > body_path > status (per spec).
+	if jq, ok := pm["body_jq"].(string); ok && jq != "" {
+		cfg.Predicate = predicate{Jq: jq}
+	} else if pp, ok := pm["body_path"].(map[string]any); ok {
+		path, _ := pp["path"].(string)
+		cfg.Predicate = predicate{Path: &pathPredicate{Path: path, Equals: pp["equals"]}}
+	} else if status, ok := pm["status"].(float64); ok {
+		cfg.Predicate = predicate{Status: int(status)}
+	} else {
+		return retryConfig{}, false, fmt.Errorf("retry_until.predicate must specify status, body_path, or body_jq")
+	}
+	return cfg, true, nil
+}
+
+// runRetryLoop calls doCall repeatedly until the predicate matches, the timeout
+// elapses, or ctx is canceled.
+func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.Context) (map[string]any, error)) (map[string]any, retryInfo, error) {
+	deadline := time.Now().Add(cfg.Timeout)
+	var (
+		lastResp map[string]any
+		attempts int
+	)
+	info := retryInfo{}
+
+	for {
+		attempts++
+		resp, err := doCall(ctx)
+		if err != nil {
+			return nil, info, err
+		}
+		lastResp = resp
+
+		status, _ := resp["status"].(float64)
+		body, _ := resp["body"].(string)
+
+		matched, evalErr := cfg.Predicate.evaluate(int(status), []byte(body))
+		if evalErr != nil {
+			return nil, info, fmt.Errorf("predicate evaluation failed: %w", evalErr)
+		}
+		if matched {
+			info.Matched = true
+			info.Attempts = attempts
+			info.TotalWaitMS = int64(time.Since(deadline.Add(-cfg.Timeout)) / time.Millisecond)
+			return resp, info, nil
+		}
+
+		if time.Now().After(deadline) {
+			info.Matched = false
+			info.Attempts = attempts
+			info.TotalWaitMS = cfg.Timeout.Milliseconds()
+			if cfg.FailOnTimeout {
+				return nil, info, &retryTimeoutError{
+					Message:      fmt.Sprintf("retry_until predicate never matched within %dms", cfg.Timeout.Milliseconds()),
+					LastResponse: lastResp,
+					Attempts:     attempts,
+				}
+			}
+			return lastResp, info, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, info, ctx.Err()
+		case <-time.After(cfg.Interval):
+		}
+	}
+}
+
 func (m *Manager) getAuthHandlers(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	inst, err := m.getApp(ctx)
 	if err != nil {

--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -661,10 +661,10 @@ func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.
 		}
 		lastResp = resp
 
-		status, _ := resp["status"].(float64)
+		status := extractStatusCode(resp)
 		body, _ := resp["body"].(string)
 
-		matched, evalErr := cfg.Predicate.evaluate(int(status), []byte(body))
+		matched, evalErr := cfg.Predicate.evaluate(status, []byte(body))
 		if evalErr != nil {
 			return nil, info, fmt.Errorf("predicate evaluation failed: %w", evalErr)
 		}
@@ -695,6 +695,20 @@ func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.
 		case <-time.After(cfg.Interval):
 		}
 	}
+}
+
+// extractStatusCode reads the numeric HTTP status from a run.CallAPI result,
+// which stores it under "status_code" (the "status" field holds the string
+// like "200 OK"). Handles int (direct from CallAPI) and float64 (in case the
+// caller round-trips through JSON).
+func extractStatusCode(resp map[string]any) int {
+	switch v := resp["status_code"].(type) {
+	case int:
+		return v
+	case float64:
+		return int(v)
+	}
+	return 0
 }
 
 func (m *Manager) getAuthHandlers(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cli/daemon/mcp/api_tools_test.go
+++ b/cli/daemon/mcp/api_tools_test.go
@@ -96,9 +96,9 @@ func TestRunRetryLoop_MatchesAfterRetries(t *testing.T) {
 	doCall := func(ctx context.Context) (map[string]any, error) {
 		calls++
 		if calls < 3 {
-			return map[string]any{"status": float64(200), "body": `{"events":[]}`}, nil
+			return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[]}`}, nil
 		}
-		return map[string]any{"status": float64(200), "body": `{"events":[{"id":7}]}`}, nil
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[{"id":7}]}`}, nil
 	}
 	cfg := retryConfig{
 		Predicate: predicate{Jq: ".events | length > 0"},
@@ -122,7 +122,7 @@ func TestRunRetryLoop_MatchesAfterRetries(t *testing.T) {
 
 func TestRunRetryLoop_TimeoutReturnsLastBody(t *testing.T) {
 	doCall := func(ctx context.Context) (map[string]any, error) {
-		return map[string]any{"status": float64(200), "body": `{"events":[]}`}, nil
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[]}`}, nil
 	}
 	cfg := retryConfig{
 		Predicate:     predicate{Jq: ".events | length > 0"},
@@ -147,7 +147,7 @@ func TestRunRetryLoop_TimeoutReturnsLastBody(t *testing.T) {
 
 func TestRunRetryLoop_FailOnTimeout_ReturnsError(t *testing.T) {
 	doCall := func(ctx context.Context) (map[string]any, error) {
-		return map[string]any{"status": float64(200), "body": `{"events":[]}`}, nil
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[]}`}, nil
 	}
 	cfg := retryConfig{
 		Predicate:     predicate{Jq: ".events | length > 0"},
@@ -165,5 +165,36 @@ func TestRunRetryLoop_FailOnTimeout_ReturnsError(t *testing.T) {
 	}
 	if rte.Attempts < 2 {
 		t.Errorf("expected attempts >= 2, got %d", rte.Attempts)
+	}
+}
+
+func TestRunRetryLoop_StatusPredicateMatchesIntStatusCode(t *testing.T) {
+	// Pin the bug: run.CallAPI returns status_code as int, not float64,
+	// and the numeric code lives under "status_code" not "status".
+	calls := 0
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		calls++
+		if calls == 1 {
+			return map[string]any{"status": "404 Not Found", "status_code": 404, "body": ""}, nil
+		}
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": ""}, nil
+	}
+	cfg := retryConfig{
+		Predicate: predicate{Status: 200},
+		Timeout:   500 * time.Millisecond,
+		Interval:  10 * time.Millisecond,
+	}
+	res, info, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !info.Matched {
+		t.Fatal("expected matched after status flipped to 200")
+	}
+	if info.Attempts != 2 {
+		t.Errorf("attempts: %d, want 2", info.Attempts)
+	}
+	if got := extractStatusCode(res); got != 200 {
+		t.Errorf("expected status_code 200, got %d", got)
 	}
 }

--- a/cli/daemon/mcp/api_tools_test.go
+++ b/cli/daemon/mcp/api_tools_test.go
@@ -1,0 +1,29 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStringifyBody_ConvertsBytesToString(t *testing.T) {
+	in := map[string]any{
+		"status": 200,
+		"body":   []byte(`{"hello":"world"}`),
+	}
+	got := stringifyBody(in)
+	want := map[string]any{
+		"status": 200,
+		"body":   `{"hello":"world"}`,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v want %+v", got, want)
+	}
+}
+
+func TestStringifyBody_PassesThroughOtherTypes(t *testing.T) {
+	in := map[string]any{"body": "already-a-string"}
+	got := stringifyBody(in)
+	if got["body"].(string) != "already-a-string" {
+		t.Fatalf("unexpected mutation: %+v", got)
+	}
+}

--- a/cli/daemon/mcp/api_tools_test.go
+++ b/cli/daemon/mcp/api_tools_test.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestStringifyBody_ConvertsBytesToString(t *testing.T) {
@@ -25,5 +28,142 @@ func TestStringifyBody_PassesThroughOtherTypes(t *testing.T) {
 	got := stringifyBody(in)
 	if got["body"].(string) != "already-a-string" {
 		t.Fatalf("unexpected mutation: %+v", got)
+	}
+}
+
+func TestParseRetryUntil_Empty(t *testing.T) {
+	cfg, ok, err := parseRetryUntil(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for empty input")
+	}
+	_ = cfg
+}
+
+func TestParseRetryUntil_StatusPredicate(t *testing.T) {
+	in := map[string]any{
+		"predicate":   map[string]any{"status": float64(200)},
+		"timeout_ms":  float64(5000),
+		"interval_ms": float64(250),
+	}
+	cfg, ok, err := parseRetryUntil(in)
+	if err != nil || !ok {
+		t.Fatalf("err: %v ok: %v", err, ok)
+	}
+	if cfg.Predicate.Status != 200 {
+		t.Errorf("status: %d", cfg.Predicate.Status)
+	}
+	if cfg.Timeout != 5*time.Second {
+		t.Errorf("timeout: %v", cfg.Timeout)
+	}
+	if cfg.Interval != 250*time.Millisecond {
+		t.Errorf("interval: %v", cfg.Interval)
+	}
+}
+
+func TestParseRetryUntil_BodyPathPredicate(t *testing.T) {
+	in := map[string]any{
+		"predicate": map[string]any{
+			"body_path": map[string]any{"path": ".id", "equals": float64(7)},
+		},
+	}
+	cfg, ok, err := parseRetryUntil(in)
+	if err != nil || !ok {
+		t.Fatal("expected ok")
+	}
+	if cfg.Predicate.Path == nil || cfg.Predicate.Path.Path != ".id" {
+		t.Errorf("got: %+v", cfg.Predicate.Path)
+	}
+}
+
+func TestParseRetryUntil_BodyJqPredicate(t *testing.T) {
+	in := map[string]any{
+		"predicate": map[string]any{"body_jq": ".events | length > 0"},
+	}
+	cfg, ok, err := parseRetryUntil(in)
+	if err != nil || !ok {
+		t.Fatal("expected ok")
+	}
+	if cfg.Predicate.Jq != ".events | length > 0" {
+		t.Errorf("jq: %q", cfg.Predicate.Jq)
+	}
+}
+
+func TestRunRetryLoop_MatchesAfterRetries(t *testing.T) {
+	calls := 0
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		calls++
+		if calls < 3 {
+			return map[string]any{"status": float64(200), "body": `{"events":[]}`}, nil
+		}
+		return map[string]any{"status": float64(200), "body": `{"events":[{"id":7}]}`}, nil
+	}
+	cfg := retryConfig{
+		Predicate: predicate{Jq: ".events | length > 0"},
+		Timeout:   time.Second,
+		Interval:  10 * time.Millisecond,
+	}
+	res, info, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !info.Matched {
+		t.Fatal("expected matched")
+	}
+	if info.Attempts != 3 {
+		t.Errorf("attempts: %d, want 3", info.Attempts)
+	}
+	if res["body"].(string) != `{"events":[{"id":7}]}` {
+		t.Errorf("got body: %v", res["body"])
+	}
+}
+
+func TestRunRetryLoop_TimeoutReturnsLastBody(t *testing.T) {
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		return map[string]any{"status": float64(200), "body": `{"events":[]}`}, nil
+	}
+	cfg := retryConfig{
+		Predicate:     predicate{Jq: ".events | length > 0"},
+		Timeout:       80 * time.Millisecond,
+		Interval:      20 * time.Millisecond,
+		FailOnTimeout: false,
+	}
+	res, info, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info.Matched {
+		t.Fatal("expected not matched")
+	}
+	if res["body"].(string) != `{"events":[]}` {
+		t.Errorf("expected last body to be returned")
+	}
+	if info.Attempts < 2 {
+		t.Errorf("expected at least 2 attempts, got %d", info.Attempts)
+	}
+}
+
+func TestRunRetryLoop_FailOnTimeout_ReturnsError(t *testing.T) {
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		return map[string]any{"status": float64(200), "body": `{"events":[]}`}, nil
+	}
+	cfg := retryConfig{
+		Predicate:     predicate{Jq: ".events | length > 0"},
+		Timeout:       50 * time.Millisecond,
+		Interval:      20 * time.Millisecond,
+		FailOnTimeout: true,
+	}
+	_, _, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var rte *retryTimeoutError
+	if !errors.As(err, &rte) {
+		t.Fatalf("expected retryTimeoutError, got %T: %v", err, err)
+	}
+	if rte.Attempts < 2 {
+		t.Errorf("expected attempts >= 2, got %d", rte.Attempts)
 	}
 }

--- a/cli/daemon/mcp/api_tools_test.go
+++ b/cli/daemon/mcp/api_tools_test.go
@@ -168,6 +168,48 @@ func TestRunRetryLoop_FailOnTimeout_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestParseRetryUntil_EmptyObjectMeansNoRetry(t *testing.T) {
+	cfg, ok, err := parseRetryUntil(map[string]any{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for empty object")
+	}
+	_ = cfg
+}
+
+func TestParseRetryUntil_StringFormParsedAsJSON(t *testing.T) {
+	cfg, ok, err := parseRetryUntil(`{"predicate":{"status":200},"timeout_ms":1000}`)
+	if err != nil || !ok {
+		t.Fatalf("err: %v ok: %v", err, ok)
+	}
+	if cfg.Predicate.Status != 200 {
+		t.Errorf("status: %d", cfg.Predicate.Status)
+	}
+	if cfg.Timeout != time.Second {
+		t.Errorf("timeout: %v", cfg.Timeout)
+	}
+}
+
+func TestParseRetryUntil_InvalidStringReturnsError(t *testing.T) {
+	_, _, err := parseRetryUntil(`not json`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestParseRetryUntil_EmptyStringMeansNoRetry(t *testing.T) {
+	cfg, ok, err := parseRetryUntil("")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for empty string")
+	}
+	_ = cfg
+}
+
 func TestRunRetryLoop_StatusPredicateMatchesIntStatusCode(t *testing.T) {
 	// Pin the bug: run.CallAPI returns status_code as int, not float64,
 	// and the numeric code lives under "status_code" not "status".

--- a/cli/daemon/mcp/api_tools_test.go
+++ b/cli/daemon/mcp/api_tools_test.go
@@ -240,3 +240,24 @@ func TestRunRetryLoop_StatusPredicateMatchesIntStatusCode(t *testing.T) {
 		t.Errorf("expected status_code 200, got %d", got)
 	}
 }
+
+func TestParseRetryUntil_RejectsMissingPredicate(t *testing.T) {
+	_, _, err := parseRetryUntil(map[string]any{"timeout_ms": float64(1000)})
+	if err == nil {
+		t.Fatal("expected error when predicate is missing")
+	}
+}
+
+func TestRunRetryLoop_BackwardsCompatNotInvokedWhenAbsent(t *testing.T) {
+	// This test pins the parseRetryUntil contract: nil input means "no retry".
+	// Without this guarantee, the call_endpoint backwards-compat path would
+	// silently invoke the retry loop with a zero-value config.
+	cfg, ok, err := parseRetryUntil(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false")
+	}
+	_ = cfg
+}

--- a/cli/daemon/mcp/mcp.go
+++ b/cli/daemon/mcp/mcp.go
@@ -25,6 +25,7 @@ type Manager struct {
 	run     *run.Manager
 	objects *objects.ClusterManager
 	apps    *apps.Manager
+	broker  *traceBroker
 
 	BaseURL string
 }
@@ -58,6 +59,9 @@ func NewManager(apps *apps.Manager, cluster *sqldb.ClusterManager, ns *namespace
 		server.WithHooks(hooks),
 	)
 
+	traceCh := make(chan trace2.NewSpanEvent, 64)
+	traces.Listen(traceCh)
+
 	m := &Manager{
 		server: s,
 		sse: server.NewSSEServer(s,
@@ -69,6 +73,7 @@ func NewManager(apps *apps.Manager, cluster *sqldb.ClusterManager, ns *namespace
 		cluster: cluster,
 		traces:  traces,
 		run:     runMgr,
+		broker:  newTraceBroker(traceCh),
 		BaseURL: baseURL,
 	}
 

--- a/cli/daemon/mcp/predicate.go
+++ b/cli/daemon/mcp/predicate.go
@@ -1,5 +1,13 @@
 package mcp
 
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
 // predicate represents a stop condition for retry_until. Exactly one field
 // should be populated — order of preference: Jq > Path > Status (per spec).
 type predicate struct {
@@ -28,6 +36,48 @@ func (p predicate) evaluate(status int, body []byte) (bool, error) {
 	return false, nil
 }
 
-// evaluatePath / evaluateJq are implemented in subsequent tasks.
-func evaluatePath(p pathPredicate, body []byte) (bool, error) { return false, nil }
-func evaluateJq(expr string, body []byte) (bool, error)       { return false, nil }
+// evaluateJq is implemented in a subsequent task.
+func evaluateJq(expr string, body []byte) (bool, error) { return false, nil }
+
+func evaluatePath(p pathPredicate, body []byte) (bool, error) {
+	if !strings.HasPrefix(p.Path, ".") {
+		return false, fmt.Errorf("path must start with '.': %q", p.Path)
+	}
+	parts := strings.Split(strings.TrimPrefix(p.Path, "."), ".")
+
+	var doc any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return false, nil
+	}
+	val, ok := traverseDocPath(doc, parts)
+	if !ok {
+		return false, nil
+	}
+	return reflect.DeepEqual(val, p.Equals), nil
+}
+
+func traverseDocPath(doc any, parts []string) (any, bool) {
+	cur := doc
+	for _, part := range parts {
+		if part == "" {
+			return nil, false
+		}
+		switch v := cur.(type) {
+		case map[string]any:
+			next, ok := v[part]
+			if !ok {
+				return nil, false
+			}
+			cur = next
+		case []any:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil, false
+			}
+			cur = v[idx]
+		default:
+			return nil, false
+		}
+	}
+	return cur, true
+}

--- a/cli/daemon/mcp/predicate.go
+++ b/cli/daemon/mcp/predicate.go
@@ -1,0 +1,33 @@
+package mcp
+
+// predicate represents a stop condition for retry_until. Exactly one field
+// should be populated — order of preference: Jq > Path > Status (per spec).
+type predicate struct {
+	Status int
+	Path   *pathPredicate
+	Jq     string
+}
+
+type pathPredicate struct {
+	Path   string
+	Equals any
+}
+
+// evaluate reports whether the response satisfies the predicate.
+func (p predicate) evaluate(status int, body []byte) (bool, error) {
+	if p.Jq != "" {
+		return evaluateJq(p.Jq, body)
+	}
+	if p.Path != nil {
+		return evaluatePath(*p.Path, body)
+	}
+	if p.Status != 0 {
+		return status == p.Status, nil
+	}
+	// No predicate set — never matches (caller should treat as "always retry").
+	return false, nil
+}
+
+// evaluatePath / evaluateJq are implemented in subsequent tasks.
+func evaluatePath(p pathPredicate, body []byte) (bool, error) { return false, nil }
+func evaluateJq(expr string, body []byte) (bool, error)       { return false, nil }

--- a/cli/daemon/mcp/predicate.go
+++ b/cli/daemon/mcp/predicate.go
@@ -126,6 +126,12 @@ func compareInt(a int, op string, b int) bool {
 	return false
 }
 
+// truthy intentionally diverges from real jq: in jq, only false and null are
+// falsy (0, "", [], {} are all truthy). For retry predicate use ("did the
+// response contain anything useful yet?") the empty-is-falsy interpretation
+// is what the agent actually wants — matching it here means `.events` returns
+// false until events arrive, instead of always being truthy as soon as the
+// field exists.
 func truthy(v any) bool {
 	if v == nil {
 		return false

--- a/cli/daemon/mcp/predicate.go
+++ b/cli/daemon/mcp/predicate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -36,8 +37,113 @@ func (p predicate) evaluate(status int, body []byte) (bool, error) {
 	return false, nil
 }
 
-// evaluateJq is implemented in a subsequent task.
-func evaluateJq(expr string, body []byte) (bool, error) { return false, nil }
+var jqLengthRe = regexp.MustCompile(`^(\.[A-Za-z0-9_.]*)\s*\|\s*length\s*(>=|<=|==|!=|>|<)\s*(-?\d+)$`)
+
+func evaluateJq(expr string, body []byte) (bool, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return false, fmt.Errorf("empty jq expression")
+	}
+
+	// Length form: <path> | length <op> <int>
+	if m := jqLengthRe.FindStringSubmatch(expr); m != nil {
+		pathStr, op, nStr := m[1], m[2], m[3]
+		n, err := strconv.Atoi(nStr)
+		if err != nil {
+			return false, fmt.Errorf("invalid integer in jq: %q", nStr)
+		}
+		val, ok := traverseDocBytes(body, pathStr)
+		if !ok {
+			return false, nil
+		}
+		length, ok := lengthOf(val)
+		if !ok {
+			return false, nil
+		}
+		return compareInt(length, op, n), nil
+	}
+
+	// Truthy form: <path> only
+	if strings.HasPrefix(expr, ".") && !strings.ContainsAny(expr, "|()[]{}") && !strings.Contains(expr, "==") && !strings.Contains(expr, "!=") {
+		val, ok := traverseDocBytes(body, expr)
+		if !ok {
+			return false, nil
+		}
+		return truthy(val), nil
+	}
+
+	return false, fmt.Errorf("unsupported jq expression: %q (supported: '<path>', '<path> | length <op> N')", expr)
+}
+
+func traverseDocBytes(body []byte, dotPath string) (any, bool) {
+	if !strings.HasPrefix(dotPath, ".") {
+		return nil, false
+	}
+	parts := strings.Split(strings.TrimPrefix(dotPath, "."), ".")
+	if len(parts) == 1 && parts[0] == "" {
+		// Top-level identity ("." alone)
+		var doc any
+		if err := json.Unmarshal(body, &doc); err != nil {
+			return nil, false
+		}
+		return doc, true
+	}
+	var doc any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, false
+	}
+	return traverseDocPath(doc, parts)
+}
+
+func lengthOf(v any) (int, bool) {
+	switch x := v.(type) {
+	case []any:
+		return len(x), true
+	case map[string]any:
+		return len(x), true
+	case string:
+		return len(x), true
+	default:
+		return 0, false
+	}
+}
+
+func compareInt(a int, op string, b int) bool {
+	switch op {
+	case ">":
+		return a > b
+	case ">=":
+		return a >= b
+	case "<":
+		return a < b
+	case "<=":
+		return a <= b
+	case "==":
+		return a == b
+	case "!=":
+		return a != b
+	}
+	return false
+}
+
+func truthy(v any) bool {
+	if v == nil {
+		return false
+	}
+	switch x := v.(type) {
+	case bool:
+		return x
+	case float64:
+		return x != 0
+	case string:
+		return x != ""
+	case []any:
+		return len(x) > 0
+	case map[string]any:
+		return len(x) > 0
+	}
+	return true
+}
 
 func evaluatePath(p pathPredicate, body []byte) (bool, error) {
 	if !strings.HasPrefix(p.Path, ".") {

--- a/cli/daemon/mcp/predicate_test.go
+++ b/cli/daemon/mcp/predicate_test.go
@@ -64,3 +64,47 @@ func TestPredicate_BodyPath(t *testing.T) {
 		})
 	}
 }
+
+func TestPredicate_BodyJq(t *testing.T) {
+	cases := []struct {
+		name    string
+		expr    string
+		body    string
+		want    bool
+		wantErr bool
+	}{
+		{name: "length > 0 with non-empty array", expr: ".events | length > 0", body: `{"events":[{}]}`, want: true},
+		{name: "length > 0 with empty array", expr: ".events | length > 0", body: `{"events":[]}`, want: false},
+		{name: "length >= 2 with two items", expr: ".events | length >= 2", body: `{"events":[1,2]}`, want: true},
+		{name: "length == 1", expr: ".events | length == 1", body: `{"events":[1]}`, want: true},
+		{name: "length != 0", expr: ".events | length != 0", body: `{"events":[1]}`, want: true},
+		{name: "length on string", expr: ".name | length > 3", body: `{"name":"alice"}`, want: true},
+		{name: "length on object", expr: ".attrs | length > 0", body: `{"attrs":{"k":"v"}}`, want: true},
+		{name: "truthy non-empty array", expr: ".events", body: `{"events":[1]}`, want: true},
+		{name: "truthy empty array", expr: ".events", body: `{"events":[]}`, want: false},
+		{name: "truthy true bool", expr: ".ready", body: `{"ready":true}`, want: true},
+		{name: "truthy zero number", expr: ".count", body: `{"count":0}`, want: false},
+		{name: "missing path treated as falsy", expr: ".missing", body: `{}`, want: false},
+		{name: "non-json body falsy", expr: ".x | length > 0", body: `garbage`, want: false},
+		{name: "unsupported jq returns error", expr: ".events | map(.id)", body: `{}`, wantErr: true},
+		{name: "syntax error returns error", expr: "this is not jq", body: `{}`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pred := predicate{Jq: tc.expr}
+			got, err := pred.evaluate(200, []byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/daemon/mcp/predicate_test.go
+++ b/cli/daemon/mcp/predicate_test.go
@@ -1,0 +1,27 @@
+package mcp
+
+import "testing"
+
+func TestPredicate_Status(t *testing.T) {
+	cases := []struct {
+		name   string
+		pred   predicate
+		status int
+		body   string
+		want   bool
+	}{
+		{name: "match", pred: predicate{Status: 200}, status: 200, body: "{}", want: true},
+		{name: "mismatch", pred: predicate{Status: 200}, status: 404, body: "", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.pred.evaluate(tc.status, []byte(tc.body))
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/daemon/mcp/predicate_test.go
+++ b/cli/daemon/mcp/predicate_test.go
@@ -25,3 +25,42 @@ func TestPredicate_Status(t *testing.T) {
 		})
 	}
 }
+
+func TestPredicate_BodyPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		equals  any
+		body    string
+		want    bool
+		wantErr bool
+	}{
+		{name: "top-level field", path: ".id", equals: float64(7), body: `{"id":7}`, want: true},
+		{name: "nested field", path: ".user.name", equals: "alice", body: `{"user":{"name":"alice"}}`, want: true},
+		{name: "array index", path: ".events.0.id", equals: float64(7), body: `{"events":[{"id":7}]}`, want: true},
+		{name: "top-level array index", path: ".0.id", equals: float64(7), body: `[{"id":7}]`, want: true},
+		{name: "missing key", path: ".missing", equals: nil, body: `{"id":7}`, want: false},
+		{name: "value mismatch", path: ".id", equals: float64(8), body: `{"id":7}`, want: false},
+		{name: "out-of-bounds index", path: ".events.5", equals: nil, body: `{"events":[]}`, want: false},
+		{name: "non-JSON body", path: ".id", equals: float64(7), body: `not json`, want: false, wantErr: false},
+		{name: "missing leading dot", path: "id", equals: float64(7), body: `{"id":7}`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pred := predicate{Path: &pathPredicate{Path: tc.path, Equals: tc.equals}}
+			got, err := pred.evaluate(200, []byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/daemon/mcp/pubsub_tools.go
+++ b/cli/daemon/mcp/pubsub_tools.go
@@ -20,7 +20,7 @@ func (m *Manager) registerPubSubTools() {
 		mcp.WithString("subscription", mcp.Description("Subscription name to wait on. Optional — if omitted, waits for ANY subscription on the topic to process its next message.")),
 		mcp.WithNumber("timeout_ms", mcp.Description("Max wait in milliseconds. Default 10000.")),
 		mcp.WithString("since", mcp.Description("Optional ISO/RFC3339 timestamp. If set, return the next message processed after this time. If omitted, waits for the next message after this MCP call begins.")),
-		mcp.WithObject("match", mcp.Description("Optional filter. If set, only return when a message whose JSON payload contains the given top-level key/value pairs is processed.")),
+		mcp.WithObject("match", mcp.Description("Optional filter. If set, only return when a message whose JSON payload contains the given top-level key/value pairs is processed. Accepts a JSON object or a JSON-encoded string.")),
 	), m.waitForSubscriptionMessage)
 }
 

--- a/cli/daemon/mcp/pubsub_tools.go
+++ b/cli/daemon/mcp/pubsub_tools.go
@@ -13,6 +13,15 @@ func (m *Manager) registerPubSubTools() {
 	m.server.AddTool(mcp.NewTool("get_pubsub",
 		mcp.WithDescription("Retrieve detailed information about all PubSub topics and their subscriptions in the currently open Encore. This includes topic configurations, subscription patterns, message schemas, and the services that publish to or subscribe to each topic."),
 	), m.getPubSub)
+
+	m.server.AddTool(mcp.NewTool("wait_for_subscription_message",
+		mcp.WithDescription("Block until the next message on a topic is fully processed by a subscription (handler returns or errors), then return the outcome. Use this to bridge async Pub/Sub work into a synchronous verification step instead of polling read-side endpoints in a loop."),
+		mcp.WithString("topic", mcp.Description("Topic name as declared in pubsub.NewTopic. Must match the live app.")),
+		mcp.WithString("subscription", mcp.Description("Subscription name to wait on. Optional — if omitted, waits for ANY subscription on the topic to process its next message.")),
+		mcp.WithNumber("timeout_ms", mcp.Description("Max wait in milliseconds. Default 10000.")),
+		mcp.WithString("since", mcp.Description("Optional ISO/RFC3339 timestamp. If set, return the next message processed after this time. If omitted, waits for the next message after this MCP call begins.")),
+		mcp.WithObject("match", mcp.Description("Optional filter. If set, only return when a message whose JSON payload contains the given top-level key/value pairs is processed.")),
+	), m.waitForSubscriptionMessage)
 }
 
 func (m *Manager) getPubSub(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -237,6 +237,14 @@ func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.Ca
 		return mcp.NewToolResultText(toJSON(map[string]any{"error": err.Error()})), nil
 	}
 
+	ns, err := m.ns.GetActive(ctx, inst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active namespace: %w", err)
+	}
+	if err := m.ensureAppRunning(ctx, inst, ns); err != nil {
+		return nil, err
+	}
+
 	subCh, cancel := m.broker.subscribe()
 	defer cancel()
 

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
+
 	"encr.dev/cli/daemon/engine/trace2"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
 	metav1 "encr.dev/proto/encore/parser/meta/v1"
@@ -178,4 +180,132 @@ func spanMatches(ev trace2.NewSpanEvent, p waitParams) bool {
 		}
 	}
 	return true
+}
+
+const defaultWaitTimeoutMS = 10000
+
+// waitForSubscriptionMessage is the MCP tool handler.
+func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	inst, err := m.getApp(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get app: %w", err)
+	}
+
+	topic, ok := request.Params.Arguments["topic"].(string)
+	if !ok || topic == "" {
+		return nil, fmt.Errorf("missing or invalid topic argument")
+	}
+	sub, _ := request.Params.Arguments["subscription"].(string)
+
+	timeoutMS := defaultWaitTimeoutMS
+	switch v := request.Params.Arguments["timeout_ms"].(type) {
+	case float64:
+		timeoutMS = int(v)
+	case int:
+		timeoutMS = v
+	}
+
+	since := time.Now()
+	if sinceStr, ok := request.Params.Arguments["since"].(string); ok && sinceStr != "" {
+		t, err := time.Parse(time.RFC3339Nano, sinceStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid since timestamp: %w", err)
+		}
+		since = t
+	}
+
+	var match map[string]any
+	if raw, ok := request.Params.Arguments["match"].(map[string]any); ok {
+		match = raw
+	}
+
+	md, err := inst.CachedMetadata()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get metadata: %w", err)
+	}
+	if err := validateTopicSub(md.PubsubTopics, topic, sub); err != nil {
+		return mcp.NewToolResultText(toJSON(map[string]any{"error": err.Error()})), nil
+	}
+
+	subCh, cancel := m.broker.subscribe()
+	defer cancel()
+
+	res, err := waitForMatch(ctx, waitParams{
+		AppID:   inst.PlatformOrLocalID(),
+		Topic:   topic,
+		Sub:     sub,
+		Since:   since,
+		Match:   match,
+		EventCh: subCh,
+		Getter:  m.traces,
+		Timeout: time.Duration(timeoutMS) * time.Millisecond,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return mcp.NewToolResultText(toJSON(formatWaitResult(topic, sub, timeoutMS, res))), nil
+}
+
+func formatWaitResult(topic, sub string, timeoutMS int, res *waitResult) map[string]any {
+	if res.Timeout {
+		return map[string]any{
+			"matched":                   false,
+			"timeout":                   true,
+			"topic":                     topic,
+			"waited_ms":                 timeoutMS,
+			"messages_seen_during_wait": res.MessagesSeen,
+		}
+	}
+
+	outcome := "success"
+	if res.Details.HandlerError != "" {
+		outcome = "error"
+	}
+
+	out := map[string]any{
+		"matched":      true,
+		"topic":        topic,
+		"subscription": res.Span.GetSubscriptionName(),
+		"trace_id":     res.Span.GetTraceId(),
+		"message": map[string]any{
+			"id":               res.Details.MessageID,
+			"published_at":     res.Details.PublishedAt.UTC().Format(time.RFC3339Nano),
+			"delivery_attempt": res.Details.Attempt,
+			"payload":          rawJSON(res.Details.Payload),
+		},
+		"handler": map[string]any{
+			"outcome":     outcome,
+			"duration_ms": res.Details.DurationMS,
+			"error":       nilIfEmpty(res.Details.HandlerError),
+		},
+	}
+	if sub != "" {
+		out["subscription"] = sub
+	}
+	return out
+}
+
+func toJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+// rawJSON returns the payload as decoded JSON when possible, otherwise a string.
+func rawJSON(b []byte) any {
+	if len(b) == 0 {
+		return nil
+	}
+	var v any
+	if err := json.Unmarshal(b, &v); err == nil {
+		return v
+	}
+	return string(b)
+}
+
+func nilIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -204,6 +204,9 @@ func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.Ca
 	case int:
 		timeoutMS = v
 	}
+	if timeoutMS <= 0 {
+		return nil, fmt.Errorf("timeout_ms must be a positive integer, got %d", timeoutMS)
+	}
 
 	since := time.Now()
 	if sinceStr, ok := request.Params.Arguments["since"].(string); ok && sinceStr != "" {
@@ -215,8 +218,15 @@ func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.Ca
 	}
 
 	var match map[string]any
-	if raw, ok := request.Params.Arguments["match"].(map[string]any); ok {
-		match = raw
+	switch v := request.Params.Arguments["match"].(type) {
+	case map[string]any:
+		match = v
+	case string:
+		if v != "" {
+			if err := json.Unmarshal([]byte(v), &match); err != nil {
+				return nil, fmt.Errorf("invalid match argument: %w", err)
+			}
+		}
 	}
 
 	md, err := inst.CachedMetadata()
@@ -263,10 +273,14 @@ func formatWaitResult(topic, sub string, timeoutMS int, res *waitResult) map[str
 		outcome = "error"
 	}
 
-	out := map[string]any{
+	subscriptionName := res.Span.GetSubscriptionName()
+	if sub != "" {
+		subscriptionName = sub
+	}
+	return map[string]any{
 		"matched":      true,
 		"topic":        topic,
-		"subscription": res.Span.GetSubscriptionName(),
+		"subscription": subscriptionName,
 		"trace_id":     res.Span.GetTraceId(),
 		"message": map[string]any{
 			"id":               res.Details.MessageID,
@@ -280,10 +294,6 @@ func formatWaitResult(topic, sub string, timeoutMS int, res *waitResult) map[str
 			"error":       nilIfEmpty(res.Details.HandlerError),
 		},
 	}
-	if sub != "" {
-		out["subscription"] = sub
-	}
-	return out
 }
 
 func toJSON(v any) string {

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -1,0 +1,29 @@
+package mcp
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// matchPayload reports whether the JSON-encoded payload satisfies the match
+// filter. A nil or empty filter always matches. The filter compares top-level
+// keys for deep equality only — no nested paths, no wildcards.
+func matchPayload(payload []byte, match map[string]any) bool {
+	if len(match) == 0 {
+		return true
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return false
+	}
+	for k, want := range match {
+		got, ok := decoded[k]
+		if !ok {
+			return false
+		}
+		if !reflect.DeepEqual(got, want) {
+			return false
+		}
+	}
+	return true
+}

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -1,8 +1,12 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
+	"time"
+
+	tracepb2 "encr.dev/proto/encore/engine/trace2"
 )
 
 // matchPayload reports whether the JSON-encoded payload satisfies the match
@@ -26,4 +30,51 @@ func matchPayload(payload []byte, match map[string]any) bool {
 		}
 	}
 	return true
+}
+
+// eventGetter abstracts trace2.Store for tests. trace2.Store.GetEvents matches
+// this signature exactly.
+type eventGetter interface {
+	GetEvents(ctx context.Context, appID, traceID, spanID string) ([]*tracepb2.TraceEvent, error)
+}
+
+type spanDetails struct {
+	MessageID    string
+	Attempt      uint32
+	PublishedAt  time.Time // zero if missing
+	Payload      []byte
+	DurationMS   int64
+	HandlerError string // empty when handler succeeded
+}
+
+// loadSpanDetails fetches the SpanStart and SpanEnd events for the given span
+// and synthesizes a spanDetails for the wait response.
+func loadSpanDetails(ctx context.Context, store eventGetter, appID, traceID, spanID string) (*spanDetails, error) {
+	events, err := store.GetEvents(ctx, appID, traceID, spanID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &spanDetails{}
+	for _, ev := range events {
+		switch e := ev.Event.(type) {
+		case *tracepb2.TraceEvent_SpanStart:
+			pm := e.SpanStart.GetPubsubMessage()
+			if pm == nil {
+				continue
+			}
+			out.MessageID = pm.GetMessageId()
+			out.Attempt = pm.GetAttempt()
+			if pt := pm.GetPublishTime(); pt != nil {
+				out.PublishedAt = pt.AsTime()
+			}
+			out.Payload = pm.GetMessagePayload()
+		case *tracepb2.TraceEvent_SpanEnd:
+			out.DurationMS = int64(e.SpanEnd.GetDurationNanos() / 1_000_000)
+			if errPB := e.SpanEnd.GetError(); errPB != nil {
+				out.HandlerError = errPB.GetMsg()
+			}
+		}
+	}
+	return out, nil
 }

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	"encr.dev/cli/daemon/engine/trace2"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
 )
 
@@ -77,4 +78,84 @@ func loadSpanDetails(ctx context.Context, store eventGetter, appID, traceID, spa
 		}
 	}
 	return out, nil
+}
+
+type waitParams struct {
+	AppID   string
+	Topic   string
+	Sub     string // "" means any subscription on the topic
+	Since   time.Time
+	Match   map[string]any
+	EventCh <-chan trace2.NewSpanEvent
+	Getter  eventGetter
+	Timeout time.Duration
+}
+
+type waitResult struct {
+	Matched      bool
+	Timeout      bool
+	Span         *tracepb2.SpanSummary
+	Details      *spanDetails
+	MessagesSeen int // count of messages seen during wait that didn't match
+}
+
+// waitForMatch reads from EventCh until a span matching the filters arrives,
+// the context is canceled, or Timeout elapses. It returns the matched span
+// and full event details, or a timeout result.
+func waitForMatch(ctx context.Context, p waitParams) (*waitResult, error) {
+	deadline := time.NewTimer(p.Timeout)
+	defer deadline.Stop()
+
+	res := &waitResult{}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			res.Timeout = true
+			return res, nil
+		case ev, ok := <-p.EventCh:
+			if !ok {
+				res.Timeout = true
+				return res, nil
+			}
+			if !spanMatches(ev, p) {
+				res.MessagesSeen++
+				continue
+			}
+			details, err := loadSpanDetails(ctx, p.Getter, ev.AppID, ev.Span.TraceId, ev.Span.SpanId)
+			if err != nil {
+				return nil, err
+			}
+			if !matchPayload(details.Payload, p.Match) {
+				res.MessagesSeen++
+				continue
+			}
+			res.Matched = true
+			res.Span = ev.Span
+			res.Details = details
+			return res, nil
+		}
+	}
+}
+
+func spanMatches(ev trace2.NewSpanEvent, p waitParams) bool {
+	if ev.AppID != p.AppID {
+		return false
+	}
+	if ev.Span == nil || ev.Span.Type != tracepb2.SpanSummary_PUBSUB_MESSAGE {
+		return false
+	}
+	if ev.Span.GetTopicName() != p.Topic {
+		return false
+	}
+	if p.Sub != "" && ev.Span.GetSubscriptionName() != p.Sub {
+		return false
+	}
+	if !p.Since.IsZero() && ev.Span.GetStartedAt() != nil {
+		if ev.Span.GetStartedAt().AsTime().Before(p.Since) {
+			return false
+		}
+	}
+	return true
 }

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -3,11 +3,13 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"time"
 
 	"encr.dev/cli/daemon/engine/trace2"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
+	metav1 "encr.dev/proto/encore/parser/meta/v1"
 )
 
 // matchPayload reports whether the JSON-encoded payload satisfies the match
@@ -137,6 +139,24 @@ func waitForMatch(ctx context.Context, p waitParams) (*waitResult, error) {
 			return res, nil
 		}
 	}
+}
+
+func validateTopicSub(topics []*metav1.PubSubTopic, topic, sub string) error {
+	for _, t := range topics {
+		if t.Name != topic {
+			continue
+		}
+		if sub == "" {
+			return nil
+		}
+		for _, s := range t.Subscriptions {
+			if s.Name == sub {
+				return nil
+			}
+		}
+		return fmt.Errorf("subscription %q not found on topic %q", sub, topic)
+	}
+	return fmt.Errorf("topic %q not found in current app", topic)
 }
 
 func spanMatches(ev trace2.NewSpanEvent, p waitParams) bool {

--- a/cli/daemon/mcp/pubsub_wait_e2e_test.go
+++ b/cli/daemon/mcp/pubsub_wait_e2e_test.go
@@ -1,0 +1,26 @@
+//go:build e2e
+
+package mcp
+
+import (
+	"testing"
+)
+
+// TestWaitForSubscriptionMessageE2E exercises the wait_for_subscription_message
+// MCP tool against a real Encore app fixture.
+//
+// Run with: go test -tags=e2e ./cli/daemon/mcp/ -run TestWaitForSubscriptionMessageE2E -v
+//
+// This is currently a scaffold — wiring requires either:
+//  1. Booting the daemon in-process and connecting via SSE, or
+//  2. Shelling out to `encore daemon -f` and an `encore mcp run` client.
+//
+// The unit tests in pubsub_wait_test.go cover the broker, match filter,
+// span detail extraction, wait orchestration, timeout, since-watermark,
+// and topic/subscription validation. Manual smoke testing of the MCP
+// tool happens out-of-band against a live fixture; see the plan at
+// docs/superpowers/plans/2026-05-08-encore-mcp-pubsub-improvements.md
+// (Task A9 Step 3) for the manual test recipe.
+func TestWaitForSubscriptionMessageE2E(t *testing.T) {
+	t.Skip("e2e wiring deferred; unit tests cover the core; see plan A9 for manual smoke test recipe")
+}

--- a/cli/daemon/mcp/pubsub_wait_test.go
+++ b/cli/daemon/mcp/pubsub_wait_test.go
@@ -1,6 +1,14 @@
 package mcp
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	tracepb2 "encr.dev/proto/encore/engine/trace2"
+)
 
 func TestMatchPayload_TopLevelEquality(t *testing.T) {
 	cases := []struct {
@@ -72,5 +80,103 @@ func TestMatchPayload_TopLevelEquality(t *testing.T) {
 				t.Fatalf("matchPayload() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+type fakeTraceStore struct {
+	events []*tracepb2.TraceEvent
+}
+
+func (f *fakeTraceStore) GetEvents(ctx context.Context, appID, traceID, spanID string) ([]*tracepb2.TraceEvent, error) {
+	return f.events, nil
+}
+
+func TestLoadSpanDetails_SuccessOutcome(t *testing.T) {
+	store := &fakeTraceStore{
+		events: []*tracepb2.TraceEvent{
+			{
+				EventTime: timestamppb.New(time.Unix(1700000000, 0)),
+				Event: &tracepb2.TraceEvent_SpanStart{
+					SpanStart: &tracepb2.SpanStart{
+						Data: &tracepb2.SpanStart_PubsubMessage{
+							PubsubMessage: &tracepb2.PubsubMessageSpanStart{
+								MessageId:      "msg-1",
+								Attempt:        1,
+								PublishTime:    timestamppb.New(time.Unix(1699999999, 0)),
+								MessagePayload: []byte(`{"orderID":7}`),
+							},
+						},
+					},
+				},
+			},
+			{
+				EventTime: timestamppb.New(time.Unix(1700000001, 0)),
+				Event: &tracepb2.TraceEvent_SpanEnd{
+					SpanEnd: &tracepb2.SpanEnd{
+						DurationNanos: 42_000_000,
+						Error:         nil,
+					},
+				},
+			},
+		},
+	}
+
+	details, err := loadSpanDetails(context.Background(), store, "app-1", "trace-1", "span-1")
+	if err != nil {
+		t.Fatalf("loadSpanDetails returned error: %v", err)
+	}
+	if details.MessageID != "msg-1" {
+		t.Errorf("MessageID = %q, want %q", details.MessageID, "msg-1")
+	}
+	if details.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", details.Attempt)
+	}
+	if string(details.Payload) != `{"orderID":7}` {
+		t.Errorf("Payload = %q", string(details.Payload))
+	}
+	if details.HandlerError != "" {
+		t.Errorf("HandlerError = %q, want empty", details.HandlerError)
+	}
+	if details.DurationMS != 42 {
+		t.Errorf("DurationMS = %d, want 42", details.DurationMS)
+	}
+}
+
+func TestLoadSpanDetails_ErrorOutcome(t *testing.T) {
+	store := &fakeTraceStore{
+		events: []*tracepb2.TraceEvent{
+			{
+				Event: &tracepb2.TraceEvent_SpanStart{
+					SpanStart: &tracepb2.SpanStart{
+						Data: &tracepb2.SpanStart_PubsubMessage{
+							PubsubMessage: &tracepb2.PubsubMessageSpanStart{
+								MessageId: "msg-2",
+							},
+						},
+					},
+				},
+			},
+			{
+				Event: &tracepb2.TraceEvent_SpanEnd{
+					SpanEnd: &tracepb2.SpanEnd{
+						DurationNanos: 12_000_000,
+						Error: &tracepb2.Error{
+							Msg: "pq: violates foreign key",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	details, err := loadSpanDetails(context.Background(), store, "app-1", "trace-1", "span-1")
+	if err != nil {
+		t.Fatalf("loadSpanDetails returned error: %v", err)
+	}
+	if details.HandlerError == "" {
+		t.Errorf("HandlerError should be populated")
+	}
+	if details.HandlerError != "pq: violates foreign key" {
+		t.Errorf("HandlerError = %q", details.HandlerError)
 	}
 }

--- a/cli/daemon/mcp/pubsub_wait_test.go
+++ b/cli/daemon/mcp/pubsub_wait_test.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"encr.dev/cli/daemon/engine/trace2"
+	metav1 "encr.dev/proto/encore/parser/meta/v1"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
 )
 
@@ -245,6 +246,60 @@ func TestWaitForMatch_HappyPath(t *testing.T) {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func TestValidateTopicAndSub(t *testing.T) {
+	cases := []struct {
+		name    string
+		topics  []*metav1.PubSubTopic
+		topic   string
+		sub     string
+		wantErr string
+	}{
+		{
+			name:   "topic exists, no sub specified",
+			topics: []*metav1.PubSubTopic{{Name: "order-created"}},
+			topic:  "order-created",
+		},
+		{
+			name: "topic + sub both exist",
+			topics: []*metav1.PubSubTopic{
+				{Name: "order-created", Subscriptions: []*metav1.PubSubTopic_Subscription{{Name: "audit"}}},
+			},
+			topic: "order-created",
+			sub:   "audit",
+		},
+		{
+			name:    "topic missing",
+			topics:  []*metav1.PubSubTopic{{Name: "other"}},
+			topic:   "order-created",
+			wantErr: `topic "order-created" not found in current app`,
+		},
+		{
+			name: "topic exists, sub missing",
+			topics: []*metav1.PubSubTopic{
+				{Name: "order-created", Subscriptions: []*metav1.PubSubTopic_Subscription{{Name: "other"}}},
+			},
+			topic:   "order-created",
+			sub:     "audit",
+			wantErr: `subscription "audit" not found on topic "order-created"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTopicSub(tc.topics, tc.topic, tc.sub)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
 
 func TestWaitForMatch_Timeout(t *testing.T) {
 	ch := make(chan trace2.NewSpanEvent)

--- a/cli/daemon/mcp/pubsub_wait_test.go
+++ b/cli/daemon/mcp/pubsub_wait_test.go
@@ -1,0 +1,76 @@
+package mcp
+
+import "testing"
+
+func TestMatchPayload_TopLevelEquality(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload []byte
+		match   map[string]any
+		want    bool
+	}{
+		{
+			name:    "no match map matches anything",
+			payload: []byte(`{"customerID":"cust_42"}`),
+			match:   nil,
+			want:    true,
+		},
+		{
+			name:    "empty match map matches anything",
+			payload: []byte(`{"customerID":"cust_42"}`),
+			match:   map[string]any{},
+			want:    true,
+		},
+		{
+			name:    "single key matches",
+			payload: []byte(`{"customerID":"cust_42","amount":10}`),
+			match:   map[string]any{"customerID": "cust_42"},
+			want:    true,
+		},
+		{
+			name:    "single key mismatches",
+			payload: []byte(`{"customerID":"cust_42"}`),
+			match:   map[string]any{"customerID": "cust_99"},
+			want:    false,
+		},
+		{
+			name:    "missing key mismatches",
+			payload: []byte(`{"customerID":"cust_42"}`),
+			match:   map[string]any{"orderID": 7},
+			want:    false,
+		},
+		{
+			name:    "number equality with json.Number-like decoding",
+			payload: []byte(`{"orderID":7}`),
+			match:   map[string]any{"orderID": float64(7)},
+			want:    true,
+		},
+		{
+			name:    "all keys must match",
+			payload: []byte(`{"a":1,"b":2}`),
+			match:   map[string]any{"a": float64(1), "b": float64(3)},
+			want:    false,
+		},
+		{
+			name:    "non-JSON payload never matches a non-empty filter",
+			payload: []byte("not json"),
+			match:   map[string]any{"a": float64(1)},
+			want:    false,
+		},
+		{
+			name:    "non-JSON payload matches an empty filter",
+			payload: []byte("not json"),
+			match:   map[string]any{},
+			want:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchPayload(tc.payload, tc.match)
+			if got != tc.want {
+				t.Fatalf("matchPayload() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/daemon/mcp/pubsub_wait_test.go
+++ b/cli/daemon/mcp/pubsub_wait_test.go
@@ -245,3 +245,70 @@ func TestWaitForMatch_HappyPath(t *testing.T) {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func TestWaitForMatch_Timeout(t *testing.T) {
+	ch := make(chan trace2.NewSpanEvent)
+	res, err := waitForMatch(context.Background(), waitParams{
+		AppID:   "app-1",
+		Topic:   "order-created",
+		EventCh: ch,
+		Getter:  &fakeTraceStore{},
+		Timeout: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !res.Timeout {
+		t.Fatal("expected timeout")
+	}
+	if res.Matched {
+		t.Fatal("matched should be false")
+	}
+}
+
+func TestWaitForMatch_StaleEventsBeforeSince_Skipped(t *testing.T) {
+	ch := make(chan trace2.NewSpanEvent, 4)
+	since := time.Now()
+
+	// Stale event from before Since.
+	ch <- trace2.NewSpanEvent{
+		AppID: "app-1",
+		Span: &tracepb2.SpanSummary{
+			Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+			TopicName: ptr("order-created"),
+			StartedAt: timestamppb.New(since.Add(-time.Hour)),
+		},
+	}
+	// Then a fresh event after Since.
+	ch <- trace2.NewSpanEvent{
+		AppID: "app-1",
+		Span: &tracepb2.SpanSummary{
+			Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+			TraceId:   "trace-2",
+			SpanId:    "span-2",
+			TopicName: ptr("order-created"),
+			StartedAt: timestamppb.New(since.Add(time.Second)),
+		},
+	}
+
+	res, err := waitForMatch(context.Background(), waitParams{
+		AppID:   "app-1",
+		Topic:   "order-created",
+		Since:   since,
+		EventCh: ch,
+		Getter:  &fakeTraceStore{events: []*tracepb2.TraceEvent{}},
+		Timeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !res.Matched {
+		t.Fatal("expected matched on the fresh event")
+	}
+	if res.Span.TraceId != "trace-2" {
+		t.Errorf("expected trace-2, got %s", res.Span.TraceId)
+	}
+	if res.MessagesSeen != 1 {
+		t.Errorf("expected 1 stale message seen, got %d", res.MessagesSeen)
+	}
+}

--- a/cli/daemon/mcp/pubsub_wait_test.go
+++ b/cli/daemon/mcp/pubsub_wait_test.go
@@ -7,6 +7,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"encr.dev/cli/daemon/engine/trace2"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
 )
 
@@ -180,3 +181,67 @@ func TestLoadSpanDetails_ErrorOutcome(t *testing.T) {
 		t.Errorf("HandlerError = %q", details.HandlerError)
 	}
 }
+
+func TestWaitForMatch_HappyPath(t *testing.T) {
+	ch := make(chan trace2.NewSpanEvent, 4)
+	getter := &fakeTraceStore{
+		events: []*tracepb2.TraceEvent{
+			{
+				Event: &tracepb2.TraceEvent_SpanStart{
+					SpanStart: &tracepb2.SpanStart{
+						Data: &tracepb2.SpanStart_PubsubMessage{
+							PubsubMessage: &tracepb2.PubsubMessageSpanStart{
+								MessageId:      "msg-1",
+								MessagePayload: []byte(`{"customerID":"cust_42"}`),
+							},
+						},
+					},
+				},
+			},
+			{
+				Event: &tracepb2.TraceEvent_SpanEnd{
+					SpanEnd: &tracepb2.SpanEnd{DurationNanos: 5_000_000},
+				},
+			},
+		},
+	}
+
+	go func() {
+		ch <- trace2.NewSpanEvent{
+			AppID: "app-1",
+			Span: &tracepb2.SpanSummary{
+				Type:             tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TraceId:          "trace-1",
+				SpanId:           "span-1",
+				TopicName:        ptr("order-created"),
+				SubscriptionName: ptr("audit"),
+				StartedAt:        timestamppb.Now(),
+			},
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	res, err := waitForMatch(ctx, waitParams{
+		AppID:   "app-1",
+		Topic:   "order-created",
+		Sub:     "audit",
+		Since:   time.Now().Add(-time.Hour),
+		Match:   map[string]any{"customerID": "cust_42"},
+		EventCh: ch,
+		Getter:  getter,
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("waitForMatch returned error: %v", err)
+	}
+	if !res.Matched {
+		t.Fatal("expected matched")
+	}
+	if res.Details.MessageID != "msg-1" {
+		t.Errorf("MessageID = %q", res.Details.MessageID)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/cli/daemon/mcp/trace_broker.go
+++ b/cli/daemon/mcp/trace_broker.go
@@ -17,9 +17,10 @@ const subscriberBufSize = 16
 type traceBroker struct {
 	src <-chan trace2.NewSpanEvent
 
-	mu   sync.Mutex
-	subs map[chan trace2.NewSpanEvent]struct{}
-	done chan struct{}
+	mu        sync.Mutex
+	subs      map[chan trace2.NewSpanEvent]struct{}
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 func newTraceBroker(src <-chan trace2.NewSpanEvent) *traceBroker {
@@ -61,26 +62,37 @@ func (b *traceBroker) dispatch(ev trace2.NewSpanEvent) {
 func (b *traceBroker) subscribe() (<-chan trace2.NewSpanEvent, func()) {
 	ch := make(chan trace2.NewSpanEvent, subscriberBufSize)
 	b.mu.Lock()
-	b.subs[ch] = struct{}{}
-	b.mu.Unlock()
+	defer b.mu.Unlock()
 
+	if b.subs == nil {
+		// Broker is closed; return a closed channel and a no-op cancel.
+		close(ch)
+		return ch, func() {}
+	}
+
+	b.subs[ch] = struct{}{}
 	cancel := func() {
 		b.mu.Lock()
+		defer b.mu.Unlock()
 		if _, ok := b.subs[ch]; ok {
 			delete(b.subs, ch)
 			close(ch)
 		}
-		b.mu.Unlock()
 	}
 	return ch, cancel
 }
 
 func (b *traceBroker) close() {
-	close(b.done)
+	b.closeOnce.Do(func() {
+		close(b.done)
+	})
 	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.subs == nil {
+		return
+	}
 	for ch := range b.subs {
 		close(ch)
 	}
 	b.subs = nil
-	b.mu.Unlock()
 }

--- a/cli/daemon/mcp/trace_broker.go
+++ b/cli/daemon/mcp/trace_broker.go
@@ -1,0 +1,86 @@
+package mcp
+
+import (
+	"sync"
+
+	"encr.dev/cli/daemon/engine/trace2"
+)
+
+// subscriberBufSize is the per-subscriber channel buffer.
+// If a subscriber is slower than this, events are dropped for that subscriber
+// rather than blocking the broker (and thus all other subscribers and the store).
+const subscriberBufSize = 16
+
+// traceBroker fans out trace2.NewSpanEvent events to per-call subscribers.
+// trace2.Store.Listen only appends listeners and never removes them, so we
+// register exactly one channel with the store and broker it ourselves.
+type traceBroker struct {
+	src <-chan trace2.NewSpanEvent
+
+	mu   sync.Mutex
+	subs map[chan trace2.NewSpanEvent]struct{}
+	done chan struct{}
+}
+
+func newTraceBroker(src <-chan trace2.NewSpanEvent) *traceBroker {
+	b := &traceBroker{
+		src:  src,
+		subs: make(map[chan trace2.NewSpanEvent]struct{}),
+		done: make(chan struct{}),
+	}
+	go b.run()
+	return b
+}
+
+func (b *traceBroker) run() {
+	for {
+		select {
+		case <-b.done:
+			return
+		case ev, ok := <-b.src:
+			if !ok {
+				return
+			}
+			b.dispatch(ev)
+		}
+	}
+}
+
+func (b *traceBroker) dispatch(ev trace2.NewSpanEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		select {
+		case ch <- ev:
+		default:
+			// Subscriber is slow; drop rather than block.
+		}
+	}
+}
+
+func (b *traceBroker) subscribe() (<-chan trace2.NewSpanEvent, func()) {
+	ch := make(chan trace2.NewSpanEvent, subscriberBufSize)
+	b.mu.Lock()
+	b.subs[ch] = struct{}{}
+	b.mu.Unlock()
+
+	cancel := func() {
+		b.mu.Lock()
+		if _, ok := b.subs[ch]; ok {
+			delete(b.subs, ch)
+			close(ch)
+		}
+		b.mu.Unlock()
+	}
+	return ch, cancel
+}
+
+func (b *traceBroker) close() {
+	close(b.done)
+	b.mu.Lock()
+	for ch := range b.subs {
+		close(ch)
+	}
+	b.subs = nil
+	b.mu.Unlock()
+}

--- a/cli/daemon/mcp/trace_broker_test.go
+++ b/cli/daemon/mcp/trace_broker_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"encr.dev/cli/daemon/engine/trace2"
+	tracepb2 "encr.dev/proto/encore/engine/trace2"
+)
+
+func TestTraceBroker_FanOut(t *testing.T) {
+	src := make(chan trace2.NewSpanEvent, 4)
+	b := newTraceBroker(src)
+	defer b.close()
+
+	subA, cancelA := b.subscribe()
+	defer cancelA()
+	subB, cancelB := b.subscribe()
+	defer cancelB()
+
+	ev := trace2.NewSpanEvent{
+		AppID: "app-1",
+		Span: &tracepb2.SpanSummary{
+			TraceId: "trace-1",
+			SpanId:  "span-1",
+			Type:    tracepb2.SpanSummary_PUBSUB_MESSAGE,
+		},
+	}
+	src <- ev
+
+	for _, sub := range []<-chan trace2.NewSpanEvent{subA, subB} {
+		select {
+		case got := <-sub:
+			if got.AppID != "app-1" || got.Span.TraceId != "trace-1" {
+				t.Fatalf("unexpected event: %+v", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for event")
+		}
+	}
+}
+
+func TestTraceBroker_UnsubscribeStopsDelivery(t *testing.T) {
+	src := make(chan trace2.NewSpanEvent, 4)
+	b := newTraceBroker(src)
+	defer b.close()
+
+	sub, cancel := b.subscribe()
+	cancel()
+
+	src <- trace2.NewSpanEvent{AppID: "app-1", Span: &tracepb2.SpanSummary{}}
+
+	select {
+	case _, ok := <-sub:
+		if ok {
+			t.Fatal("received event after unsubscribe")
+		}
+		// channel closed is acceptable
+	case <-time.After(100 * time.Millisecond):
+		// no delivery is acceptable
+	}
+}
+
+func TestTraceBroker_SlowSubscriberDoesNotBlock(t *testing.T) {
+	src := make(chan trace2.NewSpanEvent, 1)
+	b := newTraceBroker(src)
+	defer b.close()
+
+	// Subscribe but never read.
+	_, cancel := b.subscribe()
+	defer cancel()
+
+	// Push more events than the subscriber's buffer.
+	for i := 0; i < 100; i++ {
+		select {
+		case src <- trace2.NewSpanEvent{AppID: "app-1", Span: &tracepb2.SpanSummary{}}:
+		case <-time.After(time.Second):
+			t.Fatalf("broker blocked on slow subscriber at iteration %d", i)
+		}
+	}
+}

--- a/cli/daemon/mcp/trace_broker_test.go
+++ b/cli/daemon/mcp/trace_broker_test.go
@@ -79,3 +79,31 @@ func TestTraceBroker_SlowSubscriberDoesNotBlock(t *testing.T) {
 		}
 	}
 }
+
+func TestTraceBroker_SubscribeAfterCloseDoesNotPanic(t *testing.T) {
+	src := make(chan trace2.NewSpanEvent)
+	b := newTraceBroker(src)
+	b.close()
+
+	sub, cancel := b.subscribe()
+	defer cancel() // must be safe to call
+
+	// The returned channel must be closed (i.e. read returns ok=false immediately).
+	select {
+	case _, ok := <-sub:
+		if ok {
+			t.Fatal("expected closed channel, got value")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("read on returned channel did not complete (channel should be already closed)")
+	}
+}
+
+func TestTraceBroker_CloseIsIdempotent(t *testing.T) {
+	src := make(chan trace2.NewSpanEvent)
+	b := newTraceBroker(src)
+
+	// Calling close twice must not panic.
+	b.close()
+	b.close()
+}


### PR DESCRIPTION
## Summary

Adds two MCP tools to eliminate the "async-introspection loop" failure mode AI agents hit when working with Encore Pub/Sub — where the agent publishes a message, polls a read endpoint, sees empty results, then burns turns introspecting via `get_pubsub`/`get_metadata`/`get_traces`.

- **`wait_for_subscription_message`** — synchronous probe that blocks until the next message on a topic is fully processed by a subscription (handler returns or errors), then returns the outcome (handler error message, message payload, duration, trace ID). Reuses the existing `trace2.Store` event listener via a new fan-out broker so we register exactly one listener regardless of concurrent MCP calls.
- **`retry_until` on `call_endpoint`** — optional parameter that makes the daemon poll the endpoint server-side until a predicate matches, instead of the agent looping turn-by-turn. Predicates: `status` (HTTP code), `body_path` (dot-path JSON equality), `body_jq` (minimal subset: `.path | length <op> N` and `.path` truthy).

Backwards compatible: when `retry_until` is omitted, `call_endpoint` behaves byte-for-byte as before (pinned by regression test).

## What's in here

- `cli/daemon/mcp/trace_broker.go` — single listener registered with `trace2.Store`, fan-out to per-call subscribers, hardened against close-then-subscribe and double-close
- `cli/daemon/mcp/pubsub_wait.go` — `wait_for_subscription_message` handler with topic/sub validation, since-watermark dedup, shallow payload match, auto-start of the app
- `cli/daemon/mcp/predicate.go` — predicate evaluator (status, body_path, body_jq subset)
- `cli/daemon/mcp/api_tools.go` — refactored `callEndpoint` into `ensureAppRunning` + `singleShotCall` + `stringifyBody`, then wrapped in `runRetryLoop`
- 57 new unit tests across the broker, payload match, span details, wait orchestration (happy/timeout/since), topic validation, all predicate forms, retry parsing/loop (including transient status flips and timeout shapes)

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cli/daemon/mcp/...` passes all 57 tests
- [x] `go vet ./cli/daemon/mcp/...` clean
- [x] Backwards-compat regression test for `call_endpoint` without `retry_until`
- [ ] **Manual smoke test (reviewer):** run an Encore app with a Pub/Sub topic + subscription; verify
  - publish → `wait_for_subscription_message` returns `matched: true` with handler outcome
  - subscriber that throws returns `outcome: "error"` with the error message
  - non-existent topic returns the validation error
  - `call_endpoint` without `retry_until` returns the legacy shape
  - `call_endpoint` with `retry_until: { predicate: { body_jq: ".events | length > 0" } }` polls server-side until data arrives
  - `fail_on_timeout: true` returns `{error, last_response, retry: {...}}`

## Known follow-ups (not blocking)

- Retry loop currently fails fast on transient `singleShotCall` errors (connection refused mid-loop kills retry). Worth a `retry_on_transient` flag.
- Broker drops events silently when a slow subscriber's 16-slot buffer fills. Counter or larger buffer would help under load.
- `match` (top-level eq, wait tool) and `body_path` (deep eq, retry predicate) overlap conceptually — could unify if a third filter feature lands.
- Build-tagged e2e scaffold at `pubsub_wait_e2e_test.go` is a `t.Skip` placeholder; fill in when a Pub/Sub fixture is wired into the daemon e2e harness.