### PR TITLE
infracfg: propagate push_config.id into PubSubSubscription.rid (fix self-host push 404)

### DIFF
--- a/runtimes/core/src/infracfg.rs
+++ b/runtimes/core/src/infracfg.rs
@@ -827,7 +827,18 @@ pub fn map_infra_to_runtime(infra: InfraConfig) -> RuntimeConfig {
                             .flat_map(|(topic_name, topic)| {
                                 topic.subscriptions.iter().map(|(sub_name, sub)| {
                                     PubSubSubscription {
-                                        rid: String::new(),
+                                        // The `rid` is used as the subscription_id key in the
+                                        // push registry HashMap (see gcp/push_sub.rs::Inner) and
+                                        // as the gateway's `/__encore/pubsub/push/:subscription_id`
+                                        // proxy lookup key (see lib.rs::proxied_push_subs).
+                                        // Without populating it from `push_config.id`, every
+                                        // push request returned 404 "no handler registered for
+                                        // push subscription".
+                                        rid: sub
+                                            .push_config
+                                            .as_ref()
+                                            .map(|pc| pc.id.clone())
+                                            .unwrap_or_default(),
                                         topic_encore_name: topic_name.clone(),
                                         subscription_encore_name: sub_name.clone(),
                                         topic_cloud_name: topic.name.clone(),


### PR DESCRIPTION
Closes #2449.

## What

One-line behavior fix in `runtimes/core/src/infracfg.rs`: when mapping the GCP arm of the infra config, populate `PubSubSubscription.rid` from `push_config.id` instead of leaving it `String::new()`.

## Why

`rid` is the HashMap key used by:
- `gcp/push_sub.rs::PushSubscription::Inner::subscription_id` — push registry key.
- `lib.rs::proxied_push_subs` — gateway proxy lookup key for cross-container push delivery.

With `rid` permanently empty for GCP, the push registry never matches any incoming `/__encore/pubsub/push/<id>` request, and every self-host push delivery returns:

```
{"code":"not_found","message":"no handler registered for push subscription"}
```

The schema documents `push_config.id` as *"ID of the push url path for the subscription, e.g. `/__encore/pubsub/push/<id>`"*, but no code path reads that field — it was parsed and silently dropped.

See #2449 for full repro and discussion (incl. Discord thread from 5/5/25).

## Verification

I built a CLI from this branch and ran the resulting `encore build docker` against our sandbox. Before the patch: every GCP push returned 404. After: handler routes correctly and runs. Cloud Run log line:

```
[workers] subscription=quest-level-completed topic=level.completed "starting request"
[workers] subscription=quest-level-completed topic=level.completed "request completed" (65ms)
```

## Scope

- AWS SQS/SNS and NSQ paths are untouched — they don't support `push_config` (`push_only: false` is hardcoded for them).
- Pull subscriptions are unaffected — `push_handler()` already returns `None` when there's no push_service_account, so the empty rid was never registered for them.
- I'd be happy to add a regression test in a follow-up if you'd like to suggest the right harness (the runtime crate doesn't seem to have an obvious integration-test setup for the GCP cluster path).