### PR TITLE
Fix: intersect() drops Validated types when merging interface with extends

### DIFF
--- a/tsparser/src/parser/types/typ.rs
+++ b/tsparser/src/parser/types/typ.rs
@@ -1352,6 +1352,30 @@ pub fn intersect<'a: 'b, 'b>(
             expr: expr.clone(),
         })),
 
+        // Intersect two validated types: intersect inner types and combine validation exprs.
+        (Type::Validated(a), Type::Validated(b)) => {
+            let inner = intersect(ctx, Cow::Borrowed(&a.typ), Cow::Borrowed(&b.typ));
+            Cow::Owned(Type::Validated(Validated {
+                typ: Box::new(inner.into_owned()),
+                expr: a.expr.clone().and(b.expr.clone()),
+            }))
+        }
+        // Intersect a validated type with any other type: keep validation, intersect inner.
+        (Type::Validated(a), _) => {
+            let inner = intersect(ctx, Cow::Borrowed(&a.typ), b);
+            Cow::Owned(Type::Validated(Validated {
+                typ: Box::new(inner.into_owned()),
+                expr: a.expr.clone(),
+            }))
+        }
+        (_, Type::Validated(b)) => {
+            let inner = intersect(ctx, a, Cow::Borrowed(&b.typ));
+            Cow::Owned(Type::Validated(Validated {
+                typ: Box::new(inner.into_owned()),
+                expr: b.expr.clone(),
+            }))
+        }
+
         (Type::Generic(_), _) | (_, Type::Generic(_)) => {
             Cow::Owned(Type::Generic(Generic::Intersection(Intersection {
                 x: Box::new(a.into_owned()),

--- a/tsparser/tests/testdata/interface_extends_validation.txt
+++ b/tsparser/tests/testdata/interface_extends_validation.txt
@@ -1,0 +1,30 @@
+-- foo/foo.ts --
+import { api } from "encore.dev/api";
+import { MinLen, MaxLen } from "encore.dev/validate";
+
+interface BaseRequest {
+  text: string;
+  count: number;
+}
+
+// Derived interface adds validators to fields inherited from base.
+export interface CreateRequest extends BaseRequest {
+  text: string & MinLen<1> & MaxLen<100>;
+}
+
+// Two levels of extends with validators.
+interface Extended extends CreateRequest {
+  extra?: string & MaxLen<50>;
+}
+
+export const create = api<CreateRequest, void>({}, () => {});
+export const extended = api<Extended, void>({}, () => {});
+
+-- package.json --
+{
+  "name": "foo",
+  "type": "module",
+  "dependencies": {
+    "encore.dev": "^1.35.0"
+  }
+}


### PR DESCRIPTION
## What

Add `(Validated, Validated)`, `(Validated, _)` and `(_, Validated)` arms to `intersect()` in `tsparser/src/parser/types/typ.rs`.

## Why

When resolving `interface Derived extends Base`, fields present in both interfaces with validators in the derived type (e.g. `string & MinLen<1>`) fell through all existing patterns to the catch-all `(_, _) => Type::Basic(Basic::Never)`, silently erasing the field from the parsed schema.

Root cause path:
1. `do_interface_decl` intersects the derived interface body with each base type via `intersect(derived, base)`
2. For a field present in both, the derived field type is `Validated { typ: Basic(String), expr: MinLen∧MaxLen }` and the base is `Basic(String)`
3. `intersect(Validated{…}, Basic(String))` matched none of the existing `Validation`/`Validated` arms (which only handle `Validation` — the unapplied expression type, not `Validated` — the already-applied wrapper)
4. Fell through to `(_, _) => Type::Basic(Basic::Never)`

## Verification

Added `tests/testdata/interface_extends_validation.txt` covering:
- Single `extends` with `MinLen`/`MaxLen` validators on an inherited field
- Two levels of `extends` with optional validated fields

`cargo test -p encore-tsparser test_parser` passes.