### PR TITLE
cli/daemon/mcp: lookback + diagnostic envelopes for Pub/Sub MCP tools

### DIFF
--- a/cli/daemon/mcp/api_tools.go
+++ b/cli/daemon/mcp/api_tools.go
@@ -38,7 +38,7 @@ func (m *Manager) registerAPITools() {
 		mcp.WithString("auth_payload", mcp.Description("Optional authentication payload in JSON format. This is used for custom authentication schemes.")),
 		mcp.WithString("correlation_id", mcp.Description("Optional correlation ID to track the request through the system. Useful for debugging and tracing.")),
 		mcp.WithObject("retry_until",
-			mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. Accepts a JSON object or a JSON-encoded string."),
+			mcp.Description("Optional. If set, the MCP server repeatedly calls the endpoint until the predicate matches OR the timeout elapses, then returns the final response. On `matched: false`, the response includes `retry.last_response` (the final body and status code) and `retry.body_unchanged` (true when every attempt returned a byte-identical body — a signal the upstream isn't producing new data, e.g. a missing Pub/Sub subscription or wrong predicate path, vs. the predicate just racing a slow update). Accepts a JSON object or a JSON-encoded string. Canonical Pub/Sub verify recipe: call `wait_for_subscription_message` first to confirm the handler ran, then `call_endpoint` with `retry_until` to confirm the read endpoint surfaces the result."),
 			mcp.Properties(map[string]any{
 				"predicate": map[string]any{
 					"type":        "object",
@@ -209,10 +209,12 @@ func (m *Manager) callEndpoint(ctx context.Context, request mcp.CallToolRequest)
 				"error":         rte.Message,
 				"last_response": rte.LastResponse,
 				"retry": map[string]any{
-					"matched":       false,
-					"attempts":      rte.Attempts,
-					"total_wait_ms": info.TotalWaitMS,
-					"predicate":     info.Predicate,
+					"matched":        false,
+					"attempts":       rte.Attempts,
+					"total_wait_ms":  info.TotalWaitMS,
+					"predicate":      info.Predicate,
+					"last_response":  rte.LastResponse,
+					"body_unchanged": rte.BodyUnchanged,
 				},
 			})
 			return mcp.NewToolResultText(string(body)), nil
@@ -220,17 +222,40 @@ func (m *Manager) callEndpoint(ctx context.Context, request mcp.CallToolRequest)
 		return nil, fmt.Errorf("API call failed: %w", err)
 	}
 
-	result["retry"] = map[string]any{
+	retryEnvelope := map[string]any{
 		"matched":       info.Matched,
 		"attempts":      info.Attempts,
 		"total_wait_ms": info.TotalWaitMS,
 		"predicate":     info.Predicate,
 	}
+	if !info.Matched {
+		// Surface the last response and a no-progress hint so the agent can
+		// distinguish "predicate is racing with a slow update" from "upstream
+		// isn't moving" (typically: missing subscription, wrong endpoint, or
+		// wrong predicate path).
+		retryEnvelope["last_response"] = lastResponseSummary(result)
+		retryEnvelope["body_unchanged"] = info.BodyUnchanged
+	}
+	result["retry"] = retryEnvelope
 	jsonData, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal response: %w", err)
 	}
 	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+// lastResponseSummary extracts the status_code and body fields from a CallAPI
+// result map for inclusion in the retry envelope. Returns an empty map if the
+// fields are absent, never nil.
+func lastResponseSummary(resp map[string]any) map[string]any {
+	out := map[string]any{}
+	if code := extractStatusCode(resp); code != 0 {
+		out["status_code"] = code
+	}
+	if body, ok := resp["body"]; ok {
+		out["body"] = body
+	}
+	return out
 }
 
 func predicateAsMap(p predicate) map[string]any {
@@ -685,16 +710,18 @@ type retryConfig struct {
 }
 
 type retryInfo struct {
-	Matched     bool
-	Attempts    int
-	TotalWaitMS int64
-	Predicate   map[string]any // for echoing back to the agent
+	Matched       bool
+	Attempts      int
+	TotalWaitMS   int64
+	Predicate     map[string]any // for echoing back to the agent
+	BodyUnchanged bool           // true if every attempt returned a byte-identical body string
 }
 
 type retryTimeoutError struct {
-	Message      string
-	LastResponse map[string]any
-	Attempts     int
+	Message       string
+	LastResponse  map[string]any
+	Attempts      int
+	BodyUnchanged bool
 }
 
 func (e *retryTimeoutError) Error() string { return e.Message }
@@ -766,8 +793,11 @@ func parseRetryUntil(raw any) (retryConfig, bool, error) {
 func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.Context) (map[string]any, error)) (map[string]any, retryInfo, error) {
 	deadline := time.Now().Add(cfg.Timeout)
 	var (
-		lastResp map[string]any
-		attempts int
+		lastResp      map[string]any
+		attempts      int
+		firstBody     string
+		seenFirstBody bool
+		bodyUnchanged = true
 	)
 	info := retryInfo{}
 
@@ -782,6 +812,13 @@ func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.
 		status := extractStatusCode(resp)
 		body, _ := resp["body"].(string)
 
+		if !seenFirstBody {
+			firstBody = body
+			seenFirstBody = true
+		} else if body != firstBody {
+			bodyUnchanged = false
+		}
+
 		matched, evalErr := cfg.Predicate.evaluate(status, []byte(body))
 		if evalErr != nil {
 			return nil, info, fmt.Errorf("predicate evaluation failed: %w", evalErr)
@@ -790,6 +827,7 @@ func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.
 			info.Matched = true
 			info.Attempts = attempts
 			info.TotalWaitMS = int64(time.Since(deadline.Add(-cfg.Timeout)) / time.Millisecond)
+			info.BodyUnchanged = bodyUnchanged
 			return resp, info, nil
 		}
 
@@ -797,11 +835,13 @@ func runRetryLoop(ctx context.Context, cfg retryConfig, doCall func(ctx context.
 			info.Matched = false
 			info.Attempts = attempts
 			info.TotalWaitMS = cfg.Timeout.Milliseconds()
+			info.BodyUnchanged = bodyUnchanged
 			if cfg.FailOnTimeout {
 				return nil, info, &retryTimeoutError{
-					Message:      fmt.Sprintf("retry_until predicate never matched within %dms", cfg.Timeout.Milliseconds()),
-					LastResponse: lastResp,
-					Attempts:     attempts,
+					Message:       fmt.Sprintf("retry_until predicate never matched within %dms", cfg.Timeout.Milliseconds()),
+					LastResponse:  lastResp,
+					Attempts:      attempts,
+					BodyUnchanged: bodyUnchanged,
 				}
 			}
 			return lastResp, info, nil

--- a/cli/daemon/mcp/api_tools_test.go
+++ b/cli/daemon/mcp/api_tools_test.go
@@ -248,6 +248,108 @@ func TestParseRetryUntil_RejectsMissingPredicate(t *testing.T) {
 	}
 }
 
+func TestRunRetryLoop_BodyUnchangedTrueWhenAllResponsesIdentical(t *testing.T) {
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[]}`}, nil
+	}
+	cfg := retryConfig{
+		Predicate: predicate{Jq: ".events | length > 0"},
+		Timeout:   80 * time.Millisecond,
+		Interval:  20 * time.Millisecond,
+	}
+	_, info, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info.Matched {
+		t.Fatal("expected not matched")
+	}
+	if !info.BodyUnchanged {
+		t.Errorf("expected BodyUnchanged=true when all bodies are identical")
+	}
+	if info.Attempts < 2 {
+		t.Errorf("expected multiple attempts, got %d", info.Attempts)
+	}
+}
+
+func TestRunRetryLoop_BodyUnchangedFalseWhenBodiesDiffer(t *testing.T) {
+	calls := 0
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		calls++
+		// First attempt: empty. Subsequent: a different body (still doesn't satisfy
+		// the predicate, so we still time out — but body_unchanged should be false).
+		if calls == 1 {
+			return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[]}`}, nil
+		}
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":null}`}, nil
+	}
+	cfg := retryConfig{
+		Predicate: predicate{Jq: ".events | length > 0"},
+		Timeout:   80 * time.Millisecond,
+		Interval:  20 * time.Millisecond,
+	}
+	_, info, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info.Matched {
+		t.Fatal("expected not matched")
+	}
+	if info.BodyUnchanged {
+		t.Errorf("expected BodyUnchanged=false when bodies differed across attempts")
+	}
+}
+
+func TestRunRetryLoop_FailOnTimeout_PropagatesBodyUnchanged(t *testing.T) {
+	doCall := func(ctx context.Context) (map[string]any, error) {
+		return map[string]any{"status": "200 OK", "status_code": 200, "body": `{"events":[]}`}, nil
+	}
+	cfg := retryConfig{
+		Predicate:     predicate{Jq: ".events | length > 0"},
+		Timeout:       50 * time.Millisecond,
+		Interval:      20 * time.Millisecond,
+		FailOnTimeout: true,
+	}
+	_, _, err := runRetryLoop(context.Background(), cfg, doCall)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var rte *retryTimeoutError
+	if !errors.As(err, &rte) {
+		t.Fatalf("expected retryTimeoutError, got %T", err)
+	}
+	if !rte.BodyUnchanged {
+		t.Errorf("expected rte.BodyUnchanged=true when all bodies were identical")
+	}
+}
+
+func TestLastResponseSummary(t *testing.T) {
+	in := map[string]any{
+		"status":      "200 OK",
+		"status_code": 200,
+		"body":        `{"events":[]}`,
+		"headers":     map[string]any{"x": "y"},
+	}
+	got := lastResponseSummary(in)
+	if got["status_code"] != 200 {
+		t.Errorf("status_code: %v", got["status_code"])
+	}
+	if got["body"] != `{"events":[]}` {
+		t.Errorf("body: %v", got["body"])
+	}
+	// headers should not be in the summary
+	if _, present := got["headers"]; present {
+		t.Errorf("headers should not be in the summary, got %v", got)
+	}
+}
+
+func TestLastResponseSummary_EmptyWhenFieldsMissing(t *testing.T) {
+	got := lastResponseSummary(map[string]any{})
+	if len(got) != 0 {
+		t.Errorf("expected empty summary, got %v", got)
+	}
+}
+
 func TestRunRetryLoop_BackwardsCompatNotInvokedWhenAbsent(t *testing.T) {
 	// This test pins the parseRetryUntil contract: nil input means "no retry".
 	// Without this guarantee, the call_endpoint backwards-compat path would

--- a/cli/daemon/mcp/pubsub_tools.go
+++ b/cli/daemon/mcp/pubsub_tools.go
@@ -15,10 +15,11 @@ func (m *Manager) registerPubSubTools() {
 	), m.getPubSub)
 
 	m.server.AddTool(mcp.NewTool("wait_for_subscription_message",
-		mcp.WithDescription("Block until the next message on a topic is fully processed by a subscription (handler returns or errors), then return the outcome. Use this to bridge async Pub/Sub work into a synchronous verification step instead of polling read-side endpoints in a loop."),
+		mcp.WithDescription("Block until a matching message has been processed by a subscription (handler returns or errors), then return the outcome. Scans recent history (`lookback_ms`) BEFORE opening a forward wait window (`timeout_ms`), so the typical agent flow is: publish first, then wait. Set `lookback_ms` larger than the expected handler latency. Returns `subscriptions_on_topic` on timeout so a typo'd subscription name is self-diagnosable. Canonical verify recipe: call this tool to confirm the handler ran, then call `call_endpoint` with `retry_until` to confirm the read endpoint surfaces the result."),
 		mcp.WithString("topic", mcp.Description("Topic name as declared in pubsub.NewTopic. Must match the live app.")),
 		mcp.WithString("subscription", mcp.Description("Subscription name to wait on. Optional — if omitted, waits for ANY subscription on the topic to process its next message.")),
-		mcp.WithNumber("timeout_ms", mcp.Description("Max wait in milliseconds. Default 10000.")),
+		mcp.WithNumber("timeout_ms", mcp.Description("Max forward-wait in milliseconds (applied after the lookback scan finds no match). Default 10000.")),
+		mcp.WithNumber("lookback_ms", mcp.Description("Look back this many milliseconds for a matching message that has already been processed before opening the forward wait window. Default 5000, capped at 60000. Set to 0 to disable and only watch for future messages.")),
 		mcp.WithString("since", mcp.Description("Optional ISO/RFC3339 timestamp. If set, return the next message processed after this time. If omitted, waits for the next message after this MCP call begins.")),
 		mcp.WithObject("match", mcp.Description("Optional filter. If set, only return when a message whose JSON payload contains the given top-level key/value pairs is processed. Accepts a JSON object or a JSON-encoded string.")),
 	), m.waitForSubscriptionMessage)

--- a/cli/daemon/mcp/pubsub_wait.go
+++ b/cli/daemon/mcp/pubsub_wait.go
@@ -43,6 +43,13 @@ type eventGetter interface {
 	GetEvents(ctx context.Context, appID, traceID, spanID string) ([]*tracepb2.TraceEvent, error)
 }
 
+// spanLister abstracts trace2.Store.List for tests. Used to scan completed
+// PubSub message spans during the lookback window before opening the forward
+// wait window. trace2.Store.List matches this signature exactly.
+type spanLister interface {
+	List(ctx context.Context, q *trace2.Query, iter trace2.ListEntryIterator) error
+}
+
 type spanDetails struct {
 	MessageID    string
 	Attempt      uint32
@@ -95,6 +102,68 @@ type waitParams struct {
 	Timeout time.Duration
 }
 
+// findRecentMatch scans the trace store for completed PubSub message spans on
+// the given topic/subscription whose payload satisfies match. It only
+// considers spans started no earlier than the larger of (now-lookback, since).
+//
+// Returns a matched waitResult when found, or (nil, nil) on no match. Errors
+// from the store are surfaced; payload decode failures are treated as misses
+// so the forward window can still pick the message up if it arrives again.
+func findRecentMatch(ctx context.Context, lister spanLister, getter eventGetter, appID, topic, sub string, since time.Time, lookback time.Duration, match map[string]any) (*waitResult, error) {
+	if lookback <= 0 {
+		return nil, nil
+	}
+	cutoff := time.Now().Add(-lookback)
+	if !since.IsZero() && since.After(cutoff) {
+		cutoff = since
+	}
+
+	// trace2.Store.List ignores Topic/Subscription/StartTime filters today and
+	// returns most-recent-first. Filter client-side; the default Limit=100 is
+	// enough headroom for any plausible lookback window.
+	var candidates []*tracepb2.SpanSummary
+	err := lister.List(ctx, &trace2.Query{
+		AppID:        appID,
+		Topic:        topic,
+		Subscription: sub,
+		StartTime:    cutoff,
+	}, func(span *tracepb2.SpanSummary) bool {
+		if span == nil || span.Type != tracepb2.SpanSummary_PUBSUB_MESSAGE {
+			return true
+		}
+		if span.GetTopicName() != topic {
+			return true
+		}
+		if sub != "" && span.GetSubscriptionName() != sub {
+			return true
+		}
+		if started := span.GetStartedAt(); started != nil && started.AsTime().Before(cutoff) {
+			return true
+		}
+		candidates = append(candidates, span)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, span := range candidates {
+		details, err := loadSpanDetails(ctx, getter, appID, span.TraceId, span.SpanId)
+		if err != nil {
+			return nil, err
+		}
+		if !matchPayload(details.Payload, match) {
+			continue
+		}
+		return &waitResult{
+			Matched: true,
+			Span:    span,
+			Details: details,
+		}, nil
+	}
+	return nil, nil
+}
+
 type waitResult struct {
 	Matched      bool
 	Timeout      bool
@@ -143,6 +212,22 @@ func waitForMatch(ctx context.Context, p waitParams) (*waitResult, error) {
 	}
 }
 
+// subscriptionsOnTopic returns the names of subscriptions registered against
+// the given topic, in declaration order, or nil if the topic isn't found.
+func subscriptionsOnTopic(topics []*metav1.PubSubTopic, topic string) []string {
+	for _, t := range topics {
+		if t.Name != topic {
+			continue
+		}
+		out := make([]string, 0, len(t.Subscriptions))
+		for _, s := range t.Subscriptions {
+			out = append(out, s.Name)
+		}
+		return out
+	}
+	return nil
+}
+
 func validateTopicSub(topics []*metav1.PubSubTopic, topic, sub string) error {
 	for _, t := range topics {
 		if t.Name != topic {
@@ -182,7 +267,11 @@ func spanMatches(ev trace2.NewSpanEvent, p waitParams) bool {
 	return true
 }
 
-const defaultWaitTimeoutMS = 10000
+const (
+	defaultWaitTimeoutMS  = 10000
+	defaultWaitLookbackMS = 5000
+	maxWaitLookbackMS     = 60000
+)
 
 // waitForSubscriptionMessage is the MCP tool handler.
 func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -206,6 +295,22 @@ func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.Ca
 	}
 	if timeoutMS <= 0 {
 		return nil, fmt.Errorf("timeout_ms must be a positive integer, got %d", timeoutMS)
+	}
+
+	lookbackMS := defaultWaitLookbackMS
+	if _, set := request.Params.Arguments["lookback_ms"]; set {
+		switch v := request.Params.Arguments["lookback_ms"].(type) {
+		case float64:
+			lookbackMS = int(v)
+		case int:
+			lookbackMS = v
+		}
+	}
+	if lookbackMS < 0 {
+		return nil, fmt.Errorf("lookback_ms must be a non-negative integer, got %d", lookbackMS)
+	}
+	if lookbackMS > maxWaitLookbackMS {
+		lookbackMS = maxWaitLookbackMS
 	}
 
 	since := time.Now()
@@ -245,11 +350,24 @@ func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.Ca
 		return nil, err
 	}
 
+	// Subscribe to the forward window BEFORE the lookback scan so a message
+	// completing mid-scan doesn't fall in the gap between the two.
 	subCh, cancel := m.broker.subscribe()
 	defer cancel()
 
+	appID := inst.PlatformOrLocalID()
+	if lookbackMS > 0 {
+		hit, err := findRecentMatch(ctx, m.traces, m.traces, appID, topic, sub, since, time.Duration(lookbackMS)*time.Millisecond, match)
+		if err != nil {
+			return nil, fmt.Errorf("lookback scan failed: %w", err)
+		}
+		if hit != nil {
+			return mcp.NewToolResultText(toJSON(formatWaitResult(topic, sub, timeoutMS, hit, md.PubsubTopics))), nil
+		}
+	}
+
 	res, err := waitForMatch(ctx, waitParams{
-		AppID:   inst.PlatformOrLocalID(),
+		AppID:   appID,
 		Topic:   topic,
 		Sub:     sub,
 		Since:   since,
@@ -262,18 +380,22 @@ func (m *Manager) waitForSubscriptionMessage(ctx context.Context, request mcp.Ca
 		return nil, err
 	}
 
-	return mcp.NewToolResultText(toJSON(formatWaitResult(topic, sub, timeoutMS, res))), nil
+	return mcp.NewToolResultText(toJSON(formatWaitResult(topic, sub, timeoutMS, res, md.PubsubTopics))), nil
 }
 
-func formatWaitResult(topic, sub string, timeoutMS int, res *waitResult) map[string]any {
+func formatWaitResult(topic, sub string, timeoutMS int, res *waitResult, topics []*metav1.PubSubTopic) map[string]any {
 	if res.Timeout {
-		return map[string]any{
+		out := map[string]any{
 			"matched":                   false,
 			"timeout":                   true,
 			"topic":                     topic,
 			"waited_ms":                 timeoutMS,
 			"messages_seen_during_wait": res.MessagesSeen,
 		}
+		if subs := subscriptionsOnTopic(topics, topic); subs != nil {
+			out["subscriptions_on_topic"] = subs
+		}
+		return out
 	}
 
 	outcome := "success"

--- a/cli/daemon/mcp/pubsub_wait_test.go
+++ b/cli/daemon/mcp/pubsub_wait_test.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"encr.dev/cli/daemon/engine/trace2"
-	metav1 "encr.dev/proto/encore/parser/meta/v1"
 	tracepb2 "encr.dev/proto/encore/engine/trace2"
+	metav1 "encr.dev/proto/encore/parser/meta/v1"
 )
 
 func TestMatchPayload_TopLevelEquality(t *testing.T) {
@@ -87,10 +87,26 @@ func TestMatchPayload_TopLevelEquality(t *testing.T) {
 
 type fakeTraceStore struct {
 	events []*tracepb2.TraceEvent
+	// eventsBySpan, if non-nil, overrides events with a per-span lookup.
+	eventsBySpan map[string][]*tracepb2.TraceEvent
+	// spans is the list returned by List, in store order (newest first).
+	spans []*tracepb2.SpanSummary
 }
 
 func (f *fakeTraceStore) GetEvents(ctx context.Context, appID, traceID, spanID string) ([]*tracepb2.TraceEvent, error) {
+	if f.eventsBySpan != nil {
+		return f.eventsBySpan[spanID], nil
+	}
 	return f.events, nil
+}
+
+func (f *fakeTraceStore) List(ctx context.Context, q *trace2.Query, iter trace2.ListEntryIterator) error {
+	for _, s := range f.spans {
+		if !iter(s) {
+			return nil
+		}
+	}
+	return nil
 }
 
 func TestLoadSpanDetails_SuccessOutcome(t *testing.T) {
@@ -318,6 +334,238 @@ func TestWaitForMatch_Timeout(t *testing.T) {
 	}
 	if res.Matched {
 		t.Fatal("matched should be false")
+	}
+}
+
+func TestFindRecentMatch_HitFromLookback(t *testing.T) {
+	store := &fakeTraceStore{
+		spans: []*tracepb2.SpanSummary{
+			{
+				Type:             tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TraceId:          "trace-recent",
+				SpanId:           "span-recent",
+				TopicName:        ptr("site.added"),
+				SubscriptionName: ptr("audit-site-added"),
+				StartedAt:        timestamppb.New(time.Now().Add(-1 * time.Second)),
+			},
+		},
+		eventsBySpan: map[string][]*tracepb2.TraceEvent{
+			"span-recent": {
+				{
+					Event: &tracepb2.TraceEvent_SpanStart{
+						SpanStart: &tracepb2.SpanStart{
+							Data: &tracepb2.SpanStart_PubsubMessage{
+								PubsubMessage: &tracepb2.PubsubMessageSpanStart{
+									MessageId:      "msg-7",
+									MessagePayload: []byte(`{"siteID":"s1"}`),
+								},
+							},
+						},
+					},
+				},
+				{
+					Event: &tracepb2.TraceEvent_SpanEnd{
+						SpanEnd: &tracepb2.SpanEnd{DurationNanos: 3_000_000},
+					},
+				},
+			},
+		},
+	}
+
+	hit, err := findRecentMatch(context.Background(), store, store, "app-1", "site.added", "audit-site-added", time.Time{}, 5*time.Second, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hit == nil {
+		t.Fatal("expected lookback hit")
+	}
+	if !hit.Matched {
+		t.Fatal("expected Matched=true")
+	}
+	if hit.Details.MessageID != "msg-7" {
+		t.Errorf("MessageID = %q", hit.Details.MessageID)
+	}
+}
+
+func TestFindRecentMatch_LookbackZeroDisables(t *testing.T) {
+	store := &fakeTraceStore{
+		spans: []*tracepb2.SpanSummary{
+			{
+				Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TopicName: ptr("site.added"),
+				StartedAt: timestamppb.New(time.Now()),
+			},
+		},
+	}
+	hit, err := findRecentMatch(context.Background(), store, store, "app-1", "site.added", "", time.Time{}, 0, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hit != nil {
+		t.Fatal("expected no hit when lookback is zero")
+	}
+}
+
+func TestFindRecentMatch_OldSpansOutsideWindowIgnored(t *testing.T) {
+	store := &fakeTraceStore{
+		spans: []*tracepb2.SpanSummary{
+			{
+				Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TraceId:   "trace-old",
+				SpanId:    "span-old",
+				TopicName: ptr("site.added"),
+				StartedAt: timestamppb.New(time.Now().Add(-30 * time.Second)),
+			},
+		},
+		eventsBySpan: map[string][]*tracepb2.TraceEvent{
+			"span-old": {
+				{Event: &tracepb2.TraceEvent_SpanStart{SpanStart: &tracepb2.SpanStart{
+					Data: &tracepb2.SpanStart_PubsubMessage{PubsubMessage: &tracepb2.PubsubMessageSpanStart{}},
+				}}},
+				{Event: &tracepb2.TraceEvent_SpanEnd{SpanEnd: &tracepb2.SpanEnd{}}},
+			},
+		},
+	}
+
+	hit, err := findRecentMatch(context.Background(), store, store, "app-1", "site.added", "", time.Time{}, 5*time.Second, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hit != nil {
+		t.Fatal("expected no hit when span is outside the lookback window")
+	}
+}
+
+func TestFindRecentMatch_TopicMismatchIgnored(t *testing.T) {
+	store := &fakeTraceStore{
+		spans: []*tracepb2.SpanSummary{
+			{
+				Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TopicName: ptr("other.topic"),
+				StartedAt: timestamppb.New(time.Now()),
+			},
+		},
+	}
+	hit, err := findRecentMatch(context.Background(), store, store, "app-1", "site.added", "", time.Time{}, 5*time.Second, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hit != nil {
+		t.Fatal("expected no hit on topic mismatch")
+	}
+}
+
+func TestFindRecentMatch_MatchFilterAppliesToPayload(t *testing.T) {
+	store := &fakeTraceStore{
+		spans: []*tracepb2.SpanSummary{
+			{
+				Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TraceId:   "t1",
+				SpanId:    "s1",
+				TopicName: ptr("site.added"),
+				StartedAt: timestamppb.New(time.Now()),
+			},
+			{
+				Type:      tracepb2.SpanSummary_PUBSUB_MESSAGE,
+				TraceId:   "t2",
+				SpanId:    "s2",
+				TopicName: ptr("site.added"),
+				StartedAt: timestamppb.New(time.Now()),
+			},
+		},
+		eventsBySpan: map[string][]*tracepb2.TraceEvent{
+			"s1": {
+				{Event: &tracepb2.TraceEvent_SpanStart{SpanStart: &tracepb2.SpanStart{
+					Data: &tracepb2.SpanStart_PubsubMessage{PubsubMessage: &tracepb2.PubsubMessageSpanStart{
+						MessagePayload: []byte(`{"siteID":"other"}`),
+					}},
+				}}},
+				{Event: &tracepb2.TraceEvent_SpanEnd{SpanEnd: &tracepb2.SpanEnd{}}},
+			},
+			"s2": {
+				{Event: &tracepb2.TraceEvent_SpanStart{SpanStart: &tracepb2.SpanStart{
+					Data: &tracepb2.SpanStart_PubsubMessage{PubsubMessage: &tracepb2.PubsubMessageSpanStart{
+						MessageId:      "msg-2",
+						MessagePayload: []byte(`{"siteID":"wanted"}`),
+					}},
+				}}},
+				{Event: &tracepb2.TraceEvent_SpanEnd{SpanEnd: &tracepb2.SpanEnd{}}},
+			},
+		},
+	}
+
+	hit, err := findRecentMatch(context.Background(), store, store, "app-1", "site.added", "", time.Time{}, 5*time.Second, map[string]any{"siteID": "wanted"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if hit == nil {
+		t.Fatal("expected hit on the matching payload")
+	}
+	if hit.Details.MessageID != "msg-2" {
+		t.Errorf("MessageID = %q, want msg-2", hit.Details.MessageID)
+	}
+}
+
+func TestSubscriptionsOnTopic(t *testing.T) {
+	topics := []*metav1.PubSubTopic{
+		{Name: "site.added", Subscriptions: []*metav1.PubSubTopic_Subscription{
+			{Name: "audit-site-added"},
+			{Name: "check-site"},
+		}},
+		{Name: "other"},
+	}
+	got := subscriptionsOnTopic(topics, "site.added")
+	want := []string{"audit-site-added", "check-site"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got := subscriptionsOnTopic(topics, "nope"); got != nil {
+		t.Errorf("expected nil for unknown topic, got %v", got)
+	}
+}
+
+func TestFormatWaitResult_TimeoutIncludesSubscriptionsRegistry(t *testing.T) {
+	topics := []*metav1.PubSubTopic{
+		{Name: "site.added", Subscriptions: []*metav1.PubSubTopic_Subscription{
+			{Name: "audit-site-added"},
+			{Name: "check-site"},
+		}},
+	}
+	res := &waitResult{Timeout: true, MessagesSeen: 0}
+	out := formatWaitResult("site.added", "audit", 10000, res, topics)
+	subs, ok := out["subscriptions_on_topic"].([]string)
+	if !ok {
+		t.Fatalf("expected subscriptions_on_topic []string, got %T (%v)", out["subscriptions_on_topic"], out)
+	}
+	if len(subs) != 2 || subs[0] != "audit-site-added" || subs[1] != "check-site" {
+		t.Errorf("got %v", subs)
+	}
+}
+
+func TestFormatWaitResult_TimeoutOmitsRegistryWhenTopicUnknown(t *testing.T) {
+	res := &waitResult{Timeout: true}
+	out := formatWaitResult("site.added", "", 10000, res, nil)
+	if _, present := out["subscriptions_on_topic"]; present {
+		t.Errorf("subscriptions_on_topic should be absent when topic isn't registered, got %v", out)
+	}
+}
+
+func TestFormatWaitResult_MatchedDoesNotIncludeRegistry(t *testing.T) {
+	topics := []*metav1.PubSubTopic{
+		{Name: "site.added", Subscriptions: []*metav1.PubSubTopic_Subscription{{Name: "audit-site-added"}}},
+	}
+	res := &waitResult{
+		Matched: true,
+		Span: &tracepb2.SpanSummary{
+			TraceId:          "trace-1",
+			TopicName:        ptr("site.added"),
+			SubscriptionName: ptr("audit-site-added"),
+		},
+		Details: &spanDetails{MessageID: "m1", PublishedAt: time.Unix(0, 0)},
+	}
+	out := formatWaitResult("site.added", "audit-site-added", 10000, res, topics)
+	if _, present := out["subscriptions_on_topic"]; present {
+		t.Errorf("subscriptions_on_topic should not be in the matched-success envelope, got %v", out)
 	}
 }
 

--- a/docs/go/cli/mcp.md
+++ b/docs/go/cli/mcp.md
@@ -78,7 +78,7 @@ Encore's MCP server exposes the following tools that provide AI models with deta
 
 #### API Tools
 
-- **call_endpoint**: Make HTTP requests to any API endpoint in the application.
+- **call_endpoint**: Make HTTP requests to any API endpoint in the application. Supports an optional `retry_until` parameter that polls the endpoint until a predicate matches (`status`, `body_path`, or `body_jq`) or the timeout elapses. On `matched: false`, the envelope includes `retry.last_response` and `retry.body_unchanged` so you can tell "predicate is racing with a slow update" apart from "upstream isn't moving" (typically: missing Pub/Sub subscription, wrong endpoint, or wrong predicate path).
 - **get_services**: Retrieve comprehensive information about all services and their endpoints in the application.
 - **get_middleware**: Retrieve detailed information about all middleware components in the application.
 - **get_auth_handlers**: Retrieve information about all authentication handlers in the application.
@@ -96,6 +96,27 @@ Encore's MCP server exposes the following tools that provide AI models with deta
 #### PubSub Tools
 
 - **get_pubsub**: Retrieve detailed information about all PubSub topics and their subscriptions in the application.
+- **wait_for_subscription_message**: Block until a matching message has been processed by a subscription, then return the outcome (message ID, payload, delivery attempt, handler duration, handler error). Scans recent history (`lookback_ms`, default 5s, capped at 60s) before opening a forward wait window (`timeout_ms`, default 10s). On timeout, the response includes `subscriptions_on_topic` so a typo'd subscription name is self-diagnosable in a single turn.
+
+##### Canonical Pub/Sub verify recipe
+
+When verifying a Pub/Sub flow end-to-end, compose the two synchronous tools — `wait_for_subscription_message` first to confirm the handler ran, then `call_endpoint` with `retry_until` to confirm the read endpoint surfaces the result:
+
+```jsonc
+// 1. Trigger the publish.
+call_endpoint { "service": "site", "endpoint": "Add", "method": "POST", "path": "/site", "payload": "{\"url\":\"https://example.com\"}" }
+
+// 2. Confirm the subscription handler ran (lookback catches it even after the publish).
+wait_for_subscription_message { "topic": "site.added", "subscription": "audit-site-added", "lookback_ms": 5000, "timeout_ms": 10000 }
+
+// 3. Confirm the read endpoint surfaces the new state.
+call_endpoint {
+  "service": "audit", "endpoint": "ListEvents", "method": "GET", "path": "/events",
+  "retry_until": { "predicate": { "body_jq": ".events | length >= 1" }, "timeout_ms": 5000, "interval_ms": 250 }
+}
+```
+
+If step 2 times out with `subscriptions_on_topic` listing a name you didn't expect, the subscription argument is wrong. If step 3 returns `retry.matched: false` with `retry.body_unchanged: true`, the upstream isn't producing data — investigate the subscription or the read endpoint rather than retrying with a larger timeout.
 
 #### Storage Tools
 

--- a/docs/ts/cli/mcp.md
+++ b/docs/ts/cli/mcp.md
@@ -78,7 +78,7 @@ Encore's MCP server exposes the following tools that provide AI models with deta
 
 #### API Tools
 
-- **call_endpoint**: Make HTTP requests to any API endpoint in the application.
+- **call_endpoint**: Make HTTP requests to any API endpoint in the application. Supports an optional `retry_until` parameter that polls the endpoint until a predicate matches (`status`, `body_path`, or `body_jq`) or the timeout elapses. On `matched: false`, the envelope includes `retry.last_response` and `retry.body_unchanged` so you can tell "predicate is racing with a slow update" apart from "upstream isn't moving" (typically: missing Pub/Sub subscription, wrong endpoint, or wrong predicate path).
 - **get_services**: Retrieve comprehensive information about all services and their endpoints in the application.
 - **get_middleware**: Retrieve detailed information about all middleware components in the application.
 - **get_auth_handlers**: Retrieve information about all authentication handlers in the application.
@@ -96,6 +96,27 @@ Encore's MCP server exposes the following tools that provide AI models with deta
 #### PubSub Tools
 
 - **get_pubsub**: Retrieve detailed information about all PubSub topics and their subscriptions in the application.
+- **wait_for_subscription_message**: Block until a matching message has been processed by a subscription, then return the outcome (message ID, payload, delivery attempt, handler duration, handler error). Scans recent history (`lookback_ms`, default 5s, capped at 60s) before opening a forward wait window (`timeout_ms`, default 10s). On timeout, the response includes `subscriptions_on_topic` so a typo'd subscription name is self-diagnosable in a single turn.
+
+##### Canonical Pub/Sub verify recipe
+
+When verifying a Pub/Sub flow end-to-end, compose the two synchronous tools — `wait_for_subscription_message` first to confirm the handler ran, then `call_endpoint` with `retry_until` to confirm the read endpoint surfaces the result:
+
+```jsonc
+// 1. Trigger the publish.
+call_endpoint { "service": "site", "endpoint": "add", "method": "POST", "path": "/site", "payload": "{\"url\":\"https://example.com\"}" }
+
+// 2. Confirm the subscription handler ran (lookback catches it even after the publish).
+wait_for_subscription_message { "topic": "site.added", "subscription": "audit-site-added", "lookback_ms": 5000, "timeout_ms": 10000 }
+
+// 3. Confirm the read endpoint surfaces the new state.
+call_endpoint {
+  "service": "audit", "endpoint": "listEvents", "method": "GET", "path": "/events",
+  "retry_until": { "predicate": { "body_jq": ".events | length >= 1" }, "timeout_ms": 5000, "interval_ms": 250 }
+}
+```
+
+If step 2 times out with `subscriptions_on_topic` listing a name you didn't expect, the subscription argument is wrong. If step 3 returns `retry.matched: false` with `retry.body_unchanged: true`, the upstream isn't producing data — investigate the subscription or the read endpoint rather than retrying with a larger timeout.
 
 #### Storage Tools
 


### PR DESCRIPTION
## Why

Two benchmark batches (`20260519-154806`, `20260520-115208`) where agents had the synchronous Pub/Sub MCP tools from #2440 available showed:

- **16 / 16** `wait_for_subscription_message` calls returned `matched:false, messages_seen_during_wait:0` — every call landed *after* the publish, so the forward-only wait window had nothing left to catch.
- **4 / 5** `retry_until` calls failed with a stable empty body and no signal to distinguish "predicate is racing a slow update" from "upstream isn't producing data at all".
- No prompt composed the two tools in sequence; nothing in either tool's surface area hinted that they solve different parts of the same problem.

The tools contributed zero positive signal to the benchmark wins and ~160 s of wasted timeouts. This PR turns each of the observed failure modes into a self-diagnosing response.

## Changes

- **`cli/daemon/mcp/pubsub_wait.go`** — new `findRecentMatch` helper scans `trace2.Store` history for matching completed PubSub spans before opening the forward channel; the handler now accepts `lookback_ms` (default 5000, capped at 60000, 0 disables) and subscribes to the forward channel *before* the scan to close the publish-then-wait race. `formatWaitResult` includes `subscriptions_on_topic` on timeout only.
- **`cli/daemon/mcp/pubsub_tools.go`** — `wait_for_subscription_message` schema gains `lookback_ms`; description rewritten to spell out the publish-first/then-wait flow, the `subscriptions_on_topic` self-diagnosis, and the canonical verify recipe cross-link.
- **`cli/daemon/mcp/api_tools.go`** — `retryInfo` and `retryTimeoutError` track `BodyUnchanged` across attempts. The `matched:false` envelope (default and `fail_on_timeout` paths) now carries `retry.last_response` (`status_code` + `body`) and `retry.body_unchanged`. The success envelope and the legacy no-`retry_until` shape are byte-for-byte unchanged. `call_endpoint` description updated to document the new fields and the canonical recipe.
- **`cli/daemon/mcp/pubsub_wait_test.go`** — new tests cover lookback hits, `lookback_ms:0` disabling, spans outside the window ignored, topic mismatch ignored, `match` filter applied during lookback, `subscriptionsOnTopic`, timeout envelope includes registry, matched envelope omits registry.
- **`cli/daemon/mcp/api_tools_test.go`** — new tests cover `body_unchanged: true` when bodies are byte-identical, `false` when they differ, propagation through the `fail_on_timeout` error path, and `lastResponseSummary` extraction.
- **`docs/go/cli/mcp.md`, `docs/ts/cli/mcp.md`** — document `wait_for_subscription_message`, the updated `retry_until` envelope, and a three-step canonical Pub/Sub verify recipe (publish → wait_for_subscription_message → call_endpoint with retry_until) plus a one-paragraph reading guide for the new diagnostic fields.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cli/daemon/mcp/...` clean (existing tests still pass; legacy `call_endpoint` no-`retry_until` shape unchanged)
- [ ] Manual smoke against a small app: publish → `wait_for_subscription_message` with default `lookback_ms` returns `matched:true` from history
- [ ] Manual smoke: `wait_for_subscription_message` with a typo'd subscription name returns `subscriptions_on_topic`
- [ ] Manual smoke: `call_endpoint` with `retry_until` against a stable empty array surfaces `body_unchanged:true` and `last_response`