### PR TITLE
Rewrite ts/go LLM instructions with benchmark-tuned content

### DIFF
--- a/go_llm_instructions.txt
+++ b/go_llm_instructions.txt
@@ -1,11 +1,80 @@
-<go_style_guide>
-You MUST write valid Go code using state-of-the-art Go v1.22+ features and best practices.
-</go_style_guide>
+## Go style guide
 
-<encore_go_domain_knowledge>
+MUST write valid Go v1.22+ code, best practices.
 
-<app_structure>
-Encore uses a monorepo design where one app contains the entire backend. Enables distributed tracing and Encore Flow through unified application model. Supports both monolith and microservices architectures with monolith-style developer experience.
+## Generated folders — do not edit
+
+`encore.gen/` + `.encore/` CLI-regenerated; never edit.
+
+`encore.app` at repo root = app manifest — CUE-formatted **text** file, not binary, despite `.app` extension. Read like any source file.
+
+## Encore local MCP server
+
+Local Encore MCP wired via `.mcp.json` (registered **`encore-local`**, tool prefix `mcp__encore-local__`). Prefer for live app introspection over `Read`/grep; use docs tools when unsure of Encore API surface.
+
+### Tools
+
+20 tools, all prefixed `mcp__encore-local__`. MCP client gets full catalog (names, descriptions, input schemas) via `tools/list` on session init — no need enumerate here.
+
+### Important tools (runtime-only — no filesystem equivalent)
+
+Do what `Glob`/`Grep`/`Read` can't. For static config (services, endpoints, topics, schemas), see "When NOT to use it" below.
+
+- **`call_endpoint`** — args: `service`, `endpoint`, `method`, `path`, `payload` (JSON string with body/query/headers/path-params), optional `auth_token` / `auth_payload` / `correlation_id`. Optional `retry_until: { predicate, timeout_ms?, interval_ms?, fail_on_timeout? }` polls **server-side** until predicate matches — predicate = `status: 200` OR `body_path: { path: ".events.0.orderID", equals: 7 }` OR `body_jq: ".events | length > 0"` (minimal subset: `<path> | length <op> N` or `<path>` truthy). Use instead of agent-side polling loops for eventually-consistent reads. **auto-starts app** if not running. Use instead of `curl` to test endpoints.
+- **`wait_for_subscription_message`** — args: `topic`, optional `subscription`, `timeout_ms` (default 10000), `since` (ISO/RFC3339), `match` (top-level key/value JSON filter, e.g. `{"CustomerID":"cust_42"}`). Blocks until the next message on the topic is fully processed by a subscription handler (returns or errors), then returns `{outcome, payload, duration_ms, handler_error, trace_id}`. Use to bridge async Pub/Sub work into a synchronous verify step — beats polling read-side endpoints + introspecting via `get_pubsub`/`get_traces`.
+- **`query_database`** — args: `queries` (array of `{database, query}`). Runs SQL against named DBs, multiple queries one call. Beats `encore db conn-uri` + `psql` round-trips.
+- **`get_traces`** — args: optional `service`, `endpoint`, `error` (`"true"`/`"false"`), `start_time` / `end_time` (ISO), `limit`. Returns recent request traces (timing, status, ids).
+- **`get_trace_spans`** — args: `trace_ids` (array IDs from `get_traces`). Returns full per-span details for deep debugging.
+- **`get_objects`** — args: `buckets` (array of bucket names). Lists objects + metadata in storage buckets.
+- **`search_docs`** — args: `query`, optional `hits_per_page`, `page`, `facet_filters`. Algolia-backed Encore docs search.
+- **`get_docs`** — args: `paths` (array of doc paths, e.g. `/docs/go/primitives/databases`). Fetches full doc pages found via `search_docs`.
+
+### When to reach for it
+
+| Situation | Tool |
+|---|---|
+| "What services / endpoints / databases exist?" | `get_metadata` once |
+| "Test my new POST /orders endpoint" | `call_endpoint` (auto-starts app) |
+| "Did the Pub/Sub handler run after I published?" | `wait_for_subscription_message` |
+| "Endpoint output is eventually consistent (e.g. read-after-publish)" | `call_endpoint` with `retry_until` |
+| "Why did last request fail?" | `get_traces` then `get_trace_spans` |
+| "How does Encore API surface work?" | `search_docs` then `get_docs` |
+
+- **MCP only for runtime data** (`call_endpoint`, `query_database`, `get_traces`, `get_objects`, `search_docs`/`get_docs`). For **static structure** declared in source (services, endpoints, topics, subscriptions, schemas, secrets, middleware, cron jobs), `Glob`+`Grep`+`Read` faster + more reliable than `get_*` tool.
+
+### Cloud MCP (deployed environments)
+
+If deployed Encore Cloud, also register `encore-cloud` via `claude mcp add --transport http encore-cloud https://api.encore.cloud/mcp` for prod traces / deploy state — `encore-local` only sees local app.
+
+## Encore check (verify app builds + endpoints work)
+
+`encore check` compiles, boots, health-checks app, optionally runs `curl` once healthy. Use instead of manual `encore run + healthz poll + curl`.
+
+```bash
+encore check                                          # compile + boot only
+encore check 'curl /ping'                             # GET a relative path
+encore check 'curl /orders -X POST -d "{\"customer_id\":\"c1\",\"amount_cents\":1999}"'   # POST with JSON body (flags after path)
+encore check 'curl /a; curl /b'                       # chain in one quoted string
+encore check 'curl /a' 'curl /b'                      # or as separate quoted args
+encore check < commands.txt                           # one curl per line, piped from file
+```
+
+Rules embedded curl DSL:
+- **Paths relative** (start with `/`). Use `curl /orders/1`, **not** `curl http://localhost:4000/orders/1` — host/port supplied by `encore check`. Absolute URL fails with `curl path "http..." must be relative`.
+- **Path first, flags after.** `curl /orders -X POST -d '...'` works; `curl -X POST /orders ...` fails — parser reads first token after `curl` as path, rejects flags there (`curl path "-X" must be relative`).
+- One curl per quoted command. Chain `;` inside one quoted string, pass multiple quoted args, or pipe file one curl per line.
+
+## Pub/sub verification
+
+- Delivery async + at-least-once + not order-preserving.
+- For "most-recent first" by publish order, DO NOT sort by `created_at = NOW()` or subscription-side row id — both subscription-insert order, at-least-once can flip. Sort by column monotonic with publish (entity id from event payload, or publish-time sequence in event).
+- Handler-only checks, skip infra: `et.Topic(T).PublishedMessages()`.
+
+## Encore Go domain knowledge
+
+### Application structure
+
+Encore uses monorepo design — one app = entire backend. Enables distributed tracing + Encore Flow via unified application model. Supports monolith + microservices with monolith-style DX.
 
 Directory structure:
 /app-name
@@ -18,9 +87,9 @@ Directory structure:
   service2/
     service2.go
 
-Sub-packages are internal to services, cannot define APIs, used for helpers and code organization.
+Sub-packages internal to services, cannot define APIs, used for helpers + code organization.
 
-For large apps, group related services into system directories (logical groupings with no special runtime behavior):
+Large apps — group related services into system directories (logical groupings, no special runtime behavior):
 /app-name
   encore.app
   system1/
@@ -28,15 +97,15 @@ For large apps, group related services into system directories (logical grouping
     service2/
   system2/
     service3/
-</app_structure>
 
-<api_definition>
-Create type-safe APIs from regular Go functions using //encore:api annotation.
+### API definition
+
+Create type-safe APIs from regular Go functions via //encore:api annotation.
 
 Access controls:
-- public: Accessible to anyone on the internet
-- private: Only accessible within app and via cron jobs
-- auth: Public but requires valid authentication
+- public: Accessible to anyone on internet
+- private: Only accessible within app + via cron jobs
+- auth: Public but requires valid auth
 
 Function signatures:
 func Foo(ctx context.Context, p *Params) (*Response, error)  // full
@@ -46,8 +115,8 @@ func Foo(ctx context.Context) error                          // minimal
 
 Request/response data locations:
 - header: Use `header` tag for HTTP headers
-- query: Default for GET/HEAD/DELETE, uses snake_case, supports basic types/slices
-- body: Default for other methods, uses `json` tag, supports complex types
+- query: Default GET/HEAD/DELETE, uses snake_case, supports basic types/slices
+- body: Default other methods, uses `json` tag, supports complex types
 
 Path parameters: Use :name for variables, *name for wildcards. Place at end of path.
 
@@ -59,12 +128,12 @@ Type support by location:
 - headers/path: bool, numeric, string, time.Time, UUID, json.RawMessage
 - query: All above plus lists
 - body: All types including structs, maps, pointers
-</api_definition>
 
-<services>
-A service is defined by creating at least one API within a Go package. Package name becomes service name.
+### Services
 
-//encore:service annotation enables custom initialization and graceful shutdown:
+Service defined by creating at least one API within Go package. Package name = service name.
+
+//encore:service annotation enables custom init + graceful shutdown:
 
 type Service struct {
     // Dependencies here
@@ -83,10 +152,10 @@ Graceful shutdown via Shutdown method:
 func (s *Service) Shutdown(force context.Context)
 - Graceful phase: Several seconds for completion
 - Forced phase: When force context canceled, terminate immediately
-</services>
 
-<raw_endpoints>
-For lower-level HTTP access (webhooks, WebSockets):
+### Raw endpoints
+
+Lower-level HTTP access (webhooks, WebSockets):
 
 //encore:api public raw
 func Webhook(w http.ResponseWriter, req *http.Request) {
@@ -97,9 +166,9 @@ func Webhook(w http.ResponseWriter, req *http.Request) {
 func Webhook(w http.ResponseWriter, req *http.Request) {
     id := encore.CurrentRequest().PathParams.Get("id")
 }
-</raw_endpoints>
 
-<sql_databases>
+### SQL databases
+
 Encore treats SQL databases as logical resources with native PostgreSQL support.
 
 Create database:
@@ -128,14 +197,16 @@ err := tododb.QueryRow(ctx, `
 `).Scan(&item.ID, &item.Title, &item.Done)
 // Use errors.Is(err, sqldb.ErrNoRows) for no results
 
-CLI commands:
-- encore db shell database-name [--env=name] - Opens psql shell
-- encore db conn-uri database-name [--env=name] - Outputs connection string
-- encore db proxy [--env=name] - Sets up local connection proxy
-</sql_databases>
+Always Scan into typed struct fields, never `interface{}` slots — compiler enforces column-to-field shape + catches drift between SELECT list + destination struct.
 
-<external_databases>
-For existing databases, create dedicated package with lazy connection pool:
+CLI commands:
+- encore db shell database-name [--env=name] - Open psql shell
+- encore db conn-uri database-name [--env=name] - Output connection string
+- encore db proxy [--env=name] - Setup local connection proxy
+
+### External databases
+
+Existing databases — create dedicated package with lazy connection pool:
 
 package externaldb
 
@@ -170,11 +241,11 @@ func setup(ctx context.Context) (*pgxpool.Pool, error) {
     return pgxpool.Connect(ctx, connString)
 }
 
-Works with Cassandra, DynamoDB, BigTable, MongoDB, Neo4j, and other services.
-</external_databases>
+Works with Cassandra, DynamoDB, BigTable, MongoDB, Neo4j, other services.
 
-<shared_databases>
-Default: per-service databases for isolation. To share, reference using sqldb.Named:
+### Shared databases
+
+Default: per-service databases for isolation. Share via sqldb.Named:
 
 // In report service, access todo service's database:
 var todoDB = sqldb.Named("todo")
@@ -187,9 +258,9 @@ func CountCompletedTodos(ctx context.Context) (*ReportResponse, error) {
     `).Scan(&report.Total)
     return &report, err
 }
-</shared_databases>
 
-<cron_jobs>
+### Cron jobs
+
 Declarative periodic tasks. Does not run locally or in Preview Environments.
 
 import "encore.dev/cron"
@@ -210,10 +281,10 @@ Scheduling options:
 - Schedule: Cron expressions (e.g., "0 4 15 * *" for 4am UTC on 15th)
 
 Requirements: Endpoints must be idempotent, no request parameters, signature func(context.Context) error or func(context.Context) (*T, error)
-</cron_jobs>
 
-<caching>
-Redis-based distributed caching system.
+### Caching
+
+Redis-based distributed caching.
 
 import "encore.dev/storage/cache"
 
@@ -237,11 +308,11 @@ var ResourceRequestsPerUser = cache.NewIntKeyspace[MyKey](cluster, cache.Keyspac
     DefaultExpiry: cache.ExpireIn(10 * time.Second),
 })
 
-Supports strings, integers, floats, structs, sets, and ordered lists.
-</caching>
+Supports strings, integers, floats, structs, sets, ordered lists.
 
-<object_storage>
-Cloud-agnostic API compatible with S3, GCS, and S3-compatible services.
+### Object storage
+
+Cloud-agnostic API compatible with S3, GCS, S3-compatible services.
 
 var ProfilePictures = objects.NewBucket("profile-pictures", objects.BucketConfig{
     Versioned: false,
@@ -260,10 +331,10 @@ type myPerms interface {
     objects.Uploader
 }
 ref := objects.BucketRef[myPerms](bucket)
-</object_storage>
 
-<pubsub>
-Asynchronous event broadcasting with automatic infrastructure provisioning.
+### Pub/Sub
+
+Async event broadcasting with automatic infra provisioning.
 
 type SignupEvent struct{ UserID int }
 
@@ -302,9 +373,9 @@ Ordering: Use OrderingAttribute matching pubsub-attr tag
 Testing:
 msgs := et.Topic(Signups).PublishedMessages()
 assert.Len(t, msgs, 1)
-</pubsub>
 
-<secrets>
+### Secrets
+
 Built-in secrets manager for API keys, passwords, private keys.
 
 var secrets struct {
@@ -319,15 +390,15 @@ func callGitHub(ctx context.Context) {
 CLI management:
 - encore secret set --type production secret-name
 - encore secret set --type development secret-name
-- encore secret set --env env-name secret-name (environment-specific override)
+- encore secret set --env env-name secret-name (env-specific override)
 
 Types: production (prod), development (dev), preview (pr), local
 
 Local override via .secrets.local.cue:
 GitHubAPIToken: "my-local-override-token"
-</secrets>
 
-<api_calls>
+### API calls
+
 Call APIs like regular functions with automatic type checking:
 
 import "encore.app/hello"
@@ -340,9 +411,9 @@ func MyOtherAPI(ctx context.Context) error {
     }
     return err
 }
-</api_calls>
 
-<errors>
+### Errors
+
 Structured errors via encore.dev/beta/errs package.
 
 return &errs.Error{
@@ -362,9 +433,9 @@ return eb.Code(errs.NotFound).Msg("board not found").Err()
 Error codes: OK(200), Canceled(499), Unknown(500), InvalidArgument(400), DeadlineExceeded(504), NotFound(404), AlreadyExists(409), PermissionDenied(403), ResourceExhausted(429), FailedPrecondition(400), Aborted(409), OutOfRange(400), Unimplemented(501), Internal(500), Unavailable(503), DataLoss(500), Unauthenticated(401)
 
 Inspection: errs.Code(err), errs.Meta(err), errs.Details(err)
-</errors>
 
-<authentication>
+### Authentication
+
 Flexible auth with different access levels.
 
 import "encore.dev/beta/auth"
@@ -405,10 +476,10 @@ return "", &errs.Error{
     Code: errs.Unauthenticated,
     Message: "invalid token",
 }
-</authentication>
 
-<configuration>
-Environment-specific config using CUE files.
+### Configuration
+
+Env-specific config via CUE files.
 
 package mysvc
 
@@ -438,19 +509,19 @@ Testing: et.SetCfg(cfg.SendEmails, true)
 CUE patterns:
 - Defaults: value: type | *default_value
 - Switch: array with conditionals, take [0]
-</configuration>
 
-<cors>
+### CORS
+
 Configure in encore.app file:
 - debug: Enable CORS debug logging
 - allow_headers: Additional accepted headers ("*" allows all)
 - expose_headers: Additional exposed headers
 - allow_origins_without_credentials: Defaults to ["*"]
 - allow_origins_with_credentials: For authenticated requests, supports wildcards like "https://*.example.com"
-</cors>
 
-<metadata>
-Access app and request info via encore.dev package.
+### Metadata
+
+Access app + request info via encore.dev package.
 
 // Application metadata
 meta := encore.Meta()
@@ -467,9 +538,9 @@ case encore.CloudAWS:
 case encore.CloudGCP:
     return writeIntoBigQuery(ctx, action, user)
 }
-</metadata>
 
-<middleware>
+### Middleware
+
 Reusable code running before/after API requests.
 
 //encore:middleware global target=all
@@ -502,9 +573,9 @@ func GetUser(ctx context.Context, id string) (*User, error) {
 }
 
 Ordering: Global before service-specific, lexicographic by filename.
-</middleware>
 
-<mocking>
+### Mocking
+
 Built-in mocking for isolated testing.
 
 // Mock endpoint for single test
@@ -530,21 +601,21 @@ et.MockService("products", &products.Service{
 
 // Type-safe service mocking
 et.MockService[products.Interface]("products", &myMockObject{})
-</mocking>
 
-<testing>
-Run tests with: encore test ./...
+### Testing
+
+Run tests: encore test ./...
 Supports all standard go test flags. Built-in tracing at localhost:9400.
 
 Database testing:
 - Automatic setup in separate cluster, optimized for speed
 - Temporary databases: et.NewTestDatabase() creates isolated, fully migrated DB
 
-Service structs: Lazy initialization, instance sharing between tests
-- Isolate with: et.EnableServiceInstanceIsolation()
-</testing>
+Service structs: Lazy init, instance sharing between tests
+- Isolate: et.EnableServiceInstanceIsolation()
 
-<validation>
+### Validation
+
 Automatic request validation via Validate() method.
 
 type MyRequest struct {
@@ -559,9 +630,9 @@ func (r *MyRequest) Validate() error {
 }
 
 Validation runs after deserialization, before handler. Non-errs.Error errors become InvalidArgument (HTTP 400).
-</validation>
 
-<cgo>
+### CGO
+
 Enable in encore.app:
 {
   "id": "my-app-id",
@@ -570,10 +641,10 @@ Enable in encore.app:
   }
 }
 Uses Ubuntu builder with gcc. Libraries must support static linking.
-</cgo>
 
-<clerk_auth>
-Implement Clerk authentication:
+### Clerk auth
+
+Implement Clerk auth:
 
 package auth
 
@@ -609,9 +680,9 @@ func (s *Service) AuthHandler(ctx context.Context, token string) (auth.UID, *Use
 Set secrets:
 - encore secret set --prod ClientSecretKey
 - encore secret set --dev ClientSecretKey
-</clerk_auth>
 
-<dependency_injection>
+### Dependency injection
+
 Add dependencies as struct fields for easy testing:
 
 package email
@@ -643,9 +714,9 @@ func TestFoo(t *testing.T) {
     svc := &Service{sendgridClient: &myMockClient{}}
     // Test
 }
-</dependency_injection>
 
-<pubsub_outbox>
+### Pub/Sub outbox
+
 Transactional outbox pattern for database + Pub/Sub consistency.
 
 var SignupsTopic = pubsub.NewTopic[*SignupEvent](/* ... */)
@@ -675,27 +746,31 @@ func initService() (*Service, error) {
 }
 
 Supports: encore.dev/storage/sqldb, database/sql, github.com/jackc/pgx/v5
-</pubsub_outbox>
 
-<example_apps>
+### Encore Toolbar (frontend dev panel)
+
+Dev-only browser panel: intercepts frontend HTTP calls, captures Encore trace IDs, jumps to traces in the dashboard. Install: add `<script src="https://encore.dev/encore-toolbar.js"></script>` early in `<head>` (no `async`/`defer`). Reach for it when a frontend talks to an Encore Go backend.
+
+### Example apps
+
 - Hello World: https://github.com/encoredev/examples/tree/main/hello-world
 - URL Shortener: https://github.com/encoredev/examples/tree/main/url-shortener
 - Uptime Monitor: https://github.com/encoredev/examples/tree/main/uptime
-</example_apps>
 
-</encore_go_domain_knowledge>
+## Encore CLI reference
 
-<encore_cli_reference>
 Execution:
-- encore run [--debug] [--watch=true] - Run application
-- encore test ./... [go test flags] - Test application
-- encore check - Check for compile-time errors
+- encore help [command] - Lists available commands (or shows usage for specific command). Reach for it when unsure which subcommand or flag to use.
+- encore run [--debug] [--watch=true] [-p port] [flags] - Runs app. Before starting yourself, check if already running by polling `http://localhost:<port>/__encore/healthz` (default port `4000`) — `200` = healthy, hit endpoints directly without re-running.
+- encore check ['curl ...'; 'curl ...'] | encore check < commands.txt - Compile + boot app, verify every service healthy, optionally run curl commands. See dedicated section above.
+- encore test ./... [go test flags] - Wraps `go test ./...` with Encore's infra provisioning — boots isolated test databases, Pub/Sub, etc. before handing off to `go test`. Accepts all `go test` flags, plus `--prepare`, `--codegen-debug`, `--trace`.
+- encore exec path/to/script [args...] - Run an executable script against the local Encore app
 
 App management:
 - encore app clone [app-id] [directory] - Clone app
-- encore app create [name] - Create new app
+- encore app create [name] [--example=name] [-l go] - Create new app
 - encore app init [name] - Create from existing repo
-- encore app link [app-id] - Link app with server
+- encore app link [app-id] [-f] - Link app with server
 
 Authentication:
 - encore auth login/logout/signup/whoami
@@ -708,31 +783,55 @@ Database:
 - encore db shell database-name [--env=name] - psql shell (--write, --admin, --superuser)
 - encore db conn-uri database-name [--env=name] - Connection string
 - encore db proxy [--env=name] - Local proxy
-- encore db reset [service-names...] - Reset databases
+- encore db reset <db-names...|--all> - Reset databases
 
 Code generation:
 - encore gen client [app-id] [--env=name] [--lang=lang] - Generate API client
   Languages: go, typescript, javascript, openapi
 
 Logging:
-- encore logs [--env=prod] [--json] - Stream logs
+- encore logs [--env=prod] [--json] [-q] - Stream logs
 
 Kubernetes:
 - encore k8s configure --env=ENV_NAME - Update kubectl config
 
 Secrets:
-- encore secret set --type TYPE secret-name (types: production, development, preview, local)
-- encore secret set --env env-name secret-name
+- encore secret set --type TYPE <secret-name> (types: production, development, preview, local)
+- encore secret set --env env-name <secret-name>
 - encore secret list [keys...]
-- encore secret archive/unarchive id
+- encore secret delete <id>
+
+Namespaces (infrastructure environments, alias `encore ns`):
+- encore namespace list [--output=columns|json] - List infra namespaces
+- encore namespace create NAME - Create a namespace
+- encore namespace switch [--create] NAME - Switch active namespace
+- encore namespace delete NAME - Delete a namespace
+
+MCP (programmatic access to the local app — same surface as `.mcp.json`):
+- encore mcp run - stdio-based MCP session
+- encore mcp start - SSE-based MCP session; prints the SSE URL
+
+Config:
+- encore config <key> [<value>] [--app|--global|--all] - Get/set CLI configuration
+
+Telemetry:
+- encore telemetry - Status
+- encore telemetry enable / disable - Toggle telemetry reporting
+
+LLM rules:
+- encore llm-rules init - Generate LLM rule files for this project
+
+Random data (utility):
+- encore rand uuid [-1|-4|-6|-7] - Generate UUID (default v4)
+- encore rand bytes N [-f format] - Generate N random bytes
+- encore rand words [--sep=SEP] NUM - Generate memorable passphrase
+
+Deploy (alpha):
+- encore alpha deploy --env=<name> (--commit=<sha> | --branch=<name>) - Deploy app to a cloud env
 
 Version:
 - encore version - Report version
 - encore version update - Check and apply updates
 
-VPN:
-- encore vpn start/status/stop
-
 Build:
-- encore build docker [--base string] [--push] - Build Docker image
-</encore_cli_reference>
+- encore build docker IMAGE_TAG [--base string] [--push] [--cgo] [--os] [--arch] - Build Docker image

--- a/ts_llm_instructions.txt
+++ b/ts_llm_instructions.txt
@@ -1,22 +1,93 @@
-<nodejs_style_guide>
-You MUST write valid TypeScript code using state-of-the-art Node.js v20+ features and best practices:
-- Always use ES6+ syntax.
-- Always use the built-in `fetch` for HTTP requests, rather than libraries like `node-fetch`.
-- Always use Node.js `import`, never use `require`.
-</nodejs_style_guide>
-<typescript_style_guide>
-- Use interface or type definitions for complex objects
-- Prefer TypeScript's built-in utility types (e.g., Record, Partial, Pick) over any
-</typescript_style_guide>
-<encore_ts_domain_knowledge>
-<api_definition>
-Encore.ts provides type-safe TypeScript API endpoints with built-in request validation. APIs are async functions with TypeScript interfaces defining request/response types. Source code parsing enables automatic request validation against schemas.
+## Node.js style guide
+
+MUST write valid TypeScript w/ Node.js v20+ features + best practices:
+- ES6+ syntax always.
+- Built-in `fetch` for HTTP, not `node-fetch`.
+- Node.js `import`, never `require`.
+## TypeScript style guide
+
+- interface/type for complex objects
+- Built-in utility types (Record, Partial, Pick) over any
+
+## Generated folders — do not edit
+
+`encore.gen/` + `.encore/` = CLI-regenerated; never edit.
+
+`encore.app` at repo root = app manifest — JSON **text** file, not binary despite `.app` ext. Read like any source file.
+
+## Encore local MCP server
+
+Local Encore MCP wired via `.mcp.json` (registered as **`encore-local`**, tool prefix `mcp__encore-local__`). Prefer for live app introspection over `Read`/grep; use docs tools when unsure of Encore API surface.
+
+### Tools
+
+20 tools, all prefixed `mcp__encore-local__`. MCP client gets full catalog (names, descriptions, schemas) via `tools/list` on session init — no list here.
+
+### Important tools (runtime-only — no filesystem equivalent)
+
+These do what `Glob`/`Grep`/`Read` can't. For static config (services, endpoints, topics, schemas), see "When NOT to use it" below.
+
+- **`call_endpoint`** — args: `service`, `endpoint`, `method`, `path`, `payload` (JSON string w/ body/query/headers/path-params), optional `auth_token` / `auth_payload` / `correlation_id`. Optional `retry_until: { predicate, timeout_ms?, interval_ms?, fail_on_timeout? }` polls **server-side** until predicate matches — predicate = `status: 200` OR `body_path: { path: ".events.0.orderID", equals: 7 }` OR `body_jq: ".events | length > 0"` (minimal subset: `<path> | length <op> N` or `<path>` truthy). Use instead of agent-side polling loops for eventually-consistent reads. **auto-starts app** if not running. Use instead of `curl` to test endpoints.
+- **`wait_for_subscription_message`** — args: `topic`, optional `subscription`, `timeout_ms` (default 10000), `since` (ISO/RFC3339), `match` (top-level key/value JSON filter, e.g. `{"customerID":"cust_42"}`). Blocks until the next message on the topic is fully processed by a subscription handler (returns or errors), then returns `{outcome, payload, duration_ms, handler_error, trace_id}`. Use to bridge async Pub/Sub work into a synchronous verify step — beats polling read-side endpoints + introspecting via `get_pubsub`/`get_traces`.
+- **`query_database`** — args: `queries` (array of `{database, query}`). Runs SQL against named DBs, multi queries per call. Beats `encore db conn-uri` + `psql` round-trips.
+- **`get_traces`** — args: optional `service`, `endpoint`, `error` (`"true"`/`"false"`), `start_time` / `end_time` (ISO), `limit`. Recent request traces (timing, status, ids).
+- **`get_trace_spans`** — args: `trace_ids` (array from `get_traces`). Full per-span details for deep debug.
+- **`get_objects`** — args: `buckets` (array of bucket names). Lists objects + metadata in storage buckets.
+- **`search_docs`** — args: `query`, optional `hits_per_page`, `page`, `facet_filters`. Algolia-backed Encore docs search.
+- **`get_docs`** — args: `paths` (array of doc paths, e.g. `/docs/ts/primitives/databases`). Fetches full doc pages found via `search_docs`.
+
+### When to reach for it
+
+| Situation | Tool |
+|---|---|
+| "What services / endpoints / databases exist?" | `get_metadata` once |
+| "Test my new POST /orders endpoint" | `call_endpoint` (auto-starts app) |
+| "Did the Pub/Sub handler run after I published?" | `wait_for_subscription_message` |
+| "Endpoint output is eventually consistent (e.g. read-after-publish)" | `call_endpoint` w/ `retry_until` |
+| "Why did last request fail?" | `get_traces` then `get_trace_spans` |
+| "How does Encore API surface work?" | `search_docs` then `get_docs` |
+
+- **MCP only for runtime data** - For **static structure** in source (services, endpoints, topics, subscriptions, schemas, secrets, middleware, cron jobs), `Glob`+`Grep`+`Read` = faster + more reliable than `get_*` tool.
+
+### Cloud MCP (deployed environments)
+
+If deployed to Encore Cloud, also register `encore-cloud` via `claude mcp add --transport http encore-cloud https://api.encore.cloud/mcp` for prod traces / deploy state — `encore-local` only sees local app.
+
+## Encore check (verify app builds + endpoints work)
+
+`encore check` compiles, boots, health-checks app, optionally runs `curl` cmds once healthy. Use instead of manual `encore run + healthz poll + curl` pattern.
+
+```bash
+encore check                                          # compile + boot only
+encore check 'curl /ping'                             # GET a relative path
+encore check 'curl /orders -X POST -d "{\"customer_id\":\"c1\",\"amount_cents\":1999}"'   # POST with JSON body (flags after path)
+encore check 'curl /a; curl /b'                       # chain in one quoted string
+encore check 'curl /a' 'curl /b'                      # or as separate quoted args
+encore check < commands.txt                           # one curl per line, piped from file
+```
+
+Rules for embedded curl DSL:
+- **Paths MUST be relative** (start w/ `/`). Use `curl /orders/1`, **not** `curl http://localhost:4000/orders/1` — host/port supplied by `encore check`. Absolute URL fails w/ `curl path "http..." must be relative`.
+- **Path first, flags after.** `curl /orders -X POST -d '...'` works; `curl -X POST /orders ...` fails — parser reads first token after `curl` as path, rejects flags (`curl path "-X" must be relative`).
+- One curl per quoted cmd. Chain w/ `;` inside one quoted string, pass multi quoted args, or pipe file w/ one curl per line.
+
+## Pub/sub verification
+
+- Delivery = async + at-least-once + not order-preserving.
+- For "most-recent first" by publish order, do NOT sort by `created_at = NOW()` nor subscription-side row id — both = subscription-insert order, at-least-once can flip. Sort by column monotonic w/ publish (entity id from event payload, or publish-time seq in event).
+- For handler-only checks, skip infra: `et.Topic(T).PublishedMessages()`.
+
+## Encore.ts domain knowledge
+
+### API definition
+
+Encore.ts = type-safe TS API endpoints w/ built-in request validation. APIs = async fns w/ TS interfaces for req/resp. Source parsing enables auto req validation against schemas.
 
 Syntax:
 import { api } from "encore.dev/api";
 export const endpoint = api(options, async handler);
 
-Options: method (HTTP method), expose (boolean for public access, default: false), auth (boolean requiring authentication), path (URL path pattern)
+Options: method (HTTP method), expose (bool public access, default: false), auth (bool requires auth), path (URL path pattern)
 
 Example:
 import { api } from "encore.dev/api";
@@ -35,17 +106,17 @@ export const ping = api(
 
 Schema patterns:
 - Full: api({ ... }, async (params: Params): Promise<Response> => {})
-- Response only: api({ ... }, async (): Promise<Response> => {})
-- Request only: api({ ... }, async (params: Params): Promise<void> => {})
+- Resp only: api({ ... }, async (): Promise<Response> => {})
+- Req only: api({ ... }, async (params: Params): Promise<void> => {})
 - No data: api({ ... }, async (): Promise<void> => {})
 
-Parameter types:
-- Header<"Header-Name">: Maps field to HTTP header
-- Query<type>: Maps field to URL query parameter
-- Path: Maps to URL path parameters using :param or *wildcard syntax
-</api_definition>
-<api_calls>
-Service-to-service calls use simple function call syntax. Services are imported from ~encore/clients module. Provides compile-time type checking and IDE autocompletion.
+Param types:
+- Header<"Header-Name">: maps field to HTTP header
+- Query<type>: maps field to URL query param
+- Path: maps to URL path params via :param or *wildcard
+### API calls
+
+Service-to-service calls = simple fn call syntax. Services imported from ~encore/clients. Compile-time type check + IDE autocomplete.
 
 Example:
 import { hello } from "~encore/clients";
@@ -53,21 +124,21 @@ export const myOtherAPI = api({}, async (): Promise<void> => {
   const resp = await hello.ping({ name: "World" });
   console.log(resp.message); // "Hello World!"
 });
-</api_calls>
-<application_structure>
-Core principles:
-- Use monorepo design for entire backend application
-- One Encore app enables full application model benefits
-- Supports both monolith and microservices approaches
-- Services cannot be nested within other services
+### Application structure
 
-Service definition:
+Core:
+- Monorepo design for entire backend
+- One Encore app = full app model benefits
+- Supports monolith + microservices
+- Services cannot nest
+
+Service def:
 import { Service } from "encore.dev/service";
 export default new Service("my-service");
 
-Application patterns:
+Patterns:
 
-Single service (best starting point):
+Single service (best start):
 /my-app
 ├── package.json
 ├── encore.app
@@ -99,9 +170,9 @@ Large scale (systems-based):
 └── usr/               // system
     ├── org/           // service
     └── user/          // service
-</application_structure>
-<raw_endpoints>
-Raw endpoints provide lower-level HTTP request access using Node.js/Express.js style request handling. Useful for webhook implementations and custom HTTP handling.
+### Raw endpoints
+
+Raw endpoints = lower-level HTTP req access via Node.js/Express.js style handling. For webhooks + custom HTTP handling.
 
 Example:
 import { api } from "encore.dev/api";
@@ -114,9 +185,9 @@ export const myRawEndpoint = api.raw(
 );
 
 Usage: curl http://localhost:4000/raw → Hello, raw world!
-Use cases: Webhook handling, custom HTTP response formatting, direct request/response control
-</raw_endpoints>
-<api_errors>
+Use: webhooks, custom HTTP resp format, direct req/resp control
+### API errors
+
 Error format:
 {
     "code": "not_found",
@@ -124,10 +195,10 @@ Error format:
     "details": null
 }
 
-Implementation:
+Impl:
 import { APIError, ErrCode } from "encore.dev/api";
 throw new APIError(ErrCode.NotFound, "sprocket not found");
-// shorthand version:
+// shorthand:
 throw APIError.notFound("sprocket not found");
 
 Error codes (name → string_value → HTTP status):
@@ -149,12 +220,12 @@ Error codes (name → string_value → HTTP status):
 - DataLoss → data_loss → 500 Internal Server Error
 - Unauthenticated → unauthenticated → 401 Unauthorized
 
-Use withDetails method on APIError to attach structured details that will be returned to external clients.
-</api_errors>
-<sql_databases>
-Encore treats SQL databases as logical resources and natively supports PostgreSQL databases.
+withDetails on APIError = attach structured details returned to external clients.
+### SQL databases
 
-Database creation:
+Encore treats SQL DBs as logical resources + natively supports PostgreSQL.
+
+DB creation:
 import { SQLDatabase } from "encore.dev/storage/sqldb";
 
 const db = new SQLDatabase("todo", {
@@ -168,16 +239,17 @@ CREATE TABLE todo_item (
   done BOOLEAN NOT NULL DEFAULT false
 );
 
-Migration naming: Start with number followed by underscore, must increase sequentially, end with .up.sql (e.g., 001_first_migration.up.sql, 002_second_migration.up.sql)
+Migration naming: starts w/ number + underscore, must increase sequentially, ends w/ .up.sql (e.g., 001_first_migration.up.sql, 002_second_migration.up.sql)
 
-Database operations (only use these methods):
-- query: Returns async iterator for multiple rows
+DB ops (use only these methods):
+- query: async iterator for multi rows
 const allTodos = await db.query`SELECT * FROM todo_item`;
 for await (const todo of allTodos) {
   // Process each todo
 }
 
-With type safety:
+**Always parameterize `db.query` / `db.queryRow` w/ explicit row generic.** Without it `row.*` accesses typed `any` + silently drop into resp (e.g. `TIMESTAMPTZ` col lands as `Date` in `string`-typed resp field, no compile error). Row type fields = snake_case SQL cols, not camelCase API resp — map between yourself in loop.
+
 const rows = await db.query<{ email: string; source_url: string; scraped_at: Date }>`
     SELECT email, source_url, created_at as scraped_at
     FROM scraped_emails
@@ -189,27 +261,27 @@ for await (const row of rows) {
 }
 return { emails };
 
-- queryRow: Returns single row or null
+- queryRow: single row or null
 async function getTodoTitle(id: number): string | undefined {
   const row = await db.queryRow`SELECT title FROM todo_item WHERE id = ${id}`;
   return row?.title;
 }
 
-- exec: For inserts and queries not returning rows
+- exec: inserts + queries not returning rows
 await db.exec`
   INSERT INTO todo_item (title, done)
   VALUES (${title}, false)
 `;
 
-CLI commands: db shell (opens psql), db conn-uri (outputs connection string), db proxy (sets up local connection proxy)
+CLI: db shell (opens psql), db conn-uri (outputs conn string), db proxy (local conn proxy)
 
 Advanced:
-- Sharing databases: Export SQLDatabase object from shared module or use SQLDatabase.named("name") to reference existing database
-- Extensions available: pgvector, PostGIS (uses encoredotdev/postgres Docker image)
-- ORM support: Prisma, Drizzle (must support standard SQL driver connection and generate standard SQL files)
-</sql_databases>
-<cron_jobs>
-Encore.ts provides declarative Cron Jobs for periodic and recurring tasks.
+- Sharing DBs: export SQLDatabase from shared module or use SQLDatabase.named("name") to ref existing DB
+- Extensions: pgvector, PostGIS (uses encoredotdev/postgres Docker image)
+- ORM: Prisma, Drizzle (must support std SQL driver + gen std SQL files)
+### Cron jobs
+
+Encore.ts = declarative Cron Jobs for periodic + recurring tasks.
 
 Example:
 import { CronJob } from "encore.dev/cron";
@@ -225,14 +297,14 @@ export const sendWelcomeEmail = api({}, async () => {
     // Send welcome emails...
 });
 
-Scheduling:
-- every: Periodic basis starting at midnight UTC. Interval must divide 24 hours evenly. Valid: 10m, 6h. Invalid: 7h
-- schedule: Cron expressions for complex scheduling (e.g., "0 4 15 * *" = 4am UTC on 15th of each month)
-</cron_jobs>
-<pubsub>
-System for asynchronous event broadcasting between services. Decouples services for better reliability, improves system responsiveness, cloud-agnostic implementation.
+Schedule:
+- every: periodic, starts midnight UTC. Interval must divide 24h evenly. Valid: 10m, 6h. Invalid: 7h
+- schedule: cron exprs for complex (e.g., "0 4 15 * *" = 4am UTC on 15th)
+### Pub/Sub
 
-Topics (must be package level variables, cannot be created inside functions, accessible from any service):
+Async event broadcasting between services. Decouples services for reliability, improves responsiveness, cloud-agnostic.
+
+Topics (must be package-level vars, cannot create in fns, accessible from any service):
 import { Topic } from "encore.dev/pubsub"
 
 export interface SignupEvent {
@@ -243,7 +315,7 @@ export const signups = new Topic<SignupEvent>("signups", {
     deliveryGuarantee: "at-least-once",
 });
 
-Publishing:
+Publish:
 const messageID = await signups.publish({userID: id});
 
 Subscriptions:
@@ -255,13 +327,13 @@ const _ = new Subscription(signups, "send-welcome-email", {
     },
 });
 
-Error handling: Failed events are retried based on retry policy. After max retries, events move to dead-letter queue.
+Errors: failed events retried per retry policy. After max retries → dead-letter queue.
 
 Delivery guarantees:
-- at-least-once: Default, possible message duplication, handlers must be idempotent
-- exactly-once: Stronger guarantees, minimized duplicates. Limits: AWS 300 msg/s/topic, GCP 3000+ msg/s/region. Does not deduplicate on publish side.
+- at-least-once: default, possible dup, handlers must be idempotent
+- exactly-once: stronger, minimized dups. Limits: AWS 300 msg/s/topic, GCP 3000+ msg/s/region. No publish-side dedup.
 
-Message attributes (key-value pairs for filtering or ordering):
+Message attributes (key-value for filter/order):
 import { Topic, Attribute } from "encore.dev/pubsub";
 
 export interface SignupEvent {
@@ -269,7 +341,7 @@ export interface SignupEvent {
     source: Attribute<string>;
 }
 
-Ordered delivery (messages delivered in order by orderingAttribute):
+Ordered delivery (delivered in order by orderingAttribute):
 import { Topic, Attribute } from "encore.dev/pubsub";
 
 export interface CartEvent {
@@ -282,19 +354,20 @@ export const cartEvents = new Topic<CartEvent>("cart-events", {
     orderingAttribute: "shoppingCartID",
 })
 
-Limits: AWS 300 msg/s/topic, GCP 1 MBps/ordering key. No effect in local environments.
-</pubsub>
-<object_storage>
-Simple and scalable solution for storing files and unstructured data.
+Limits: AWS 300 msg/s/topic, GCP 1 MBps/ordering key. No effect locally.
 
-Buckets (must be package level variables, cannot be created inside functions, accessible from any service):
+### Object storage
+
+Simple + scalable file/unstructured data store.
+
+Buckets (must be package-level vars, cannot create in fns, accessible from any service):
 import { Bucket } from "encore.dev/storage/objects";
 
 export const profilePictures = new Bucket("profile-pictures", {
   versioned: false
 });
 
-Operations:
+Ops:
 - Upload:
 const data = Buffer.from(...); // image data
 const attributes = await profilePictures.upload("my-image.jpeg", data, {
@@ -312,7 +385,7 @@ for await (const entry of profilePictures.list({})) {
 - Delete:
 await profilePictures.remove("my-image.jpeg");
 
-- Attributes:
+- Attrs:
 const attrs = await profilePictures.attrs("my-image.jpeg");
 const exists = await profilePictures.exists("my-image.jpeg");
 
@@ -323,31 +396,31 @@ export const publicProfilePictures = new Bucket("public-profile-pictures", {
 });
 const url = publicProfilePictures.publicUrl("my-image.jpeg");
 
-Errors: ObjectNotFound (object doesn't exist), PreconditionFailed (upload preconditions not met), ObjectsError (base error type)
+Errors: ObjectNotFound (no such object), PreconditionFailed (upload preconditions failed), ObjectsError (base)
 
-Bucket references (controlled access permissions):
+Bucket refs (controlled access):
 Permissions: Downloader, Uploader, Lister, Attrser, Remover, ReadWriter
 import { Uploader } from "encore.dev/storage/objects";
 const ref = profilePictures.ref<Uploader>();
-Must be called from within a service for proper permission tracking.
-</object_storage>
-<caching>
-Type-safe caching layer backed by Redis with automatic infrastructure provisioning.
+Must call from within service for proper permission tracking.
+### Caching
 
-Cache cluster definition:
+Type-safe cache layer backed by Redis w/ auto infra provisioning.
+
+Cluster def:
 import { CacheCluster } from "encore.dev/storage/cache";
 
 const cluster = new CacheCluster("my-cache", {
   evictionPolicy: "allkeys-lru",
 });
 
-Reference existing cluster from another service: const cluster = CacheCluster.named("my-cache");
+Ref existing cluster from another service: const cluster = CacheCluster.named("my-cache");
 
 Eviction policies: "allkeys-lru" (default), "noeviction", "allkeys-lfu", "allkeys-random", "volatile-lru", "volatile-lfu", "volatile-ttl", "volatile-random"
 
-Keyspaces (type-safe storage, Key type combines with keyPattern to generate Redis keys):
+Keyspaces (type-safe storage, Key type + keyPattern → Redis keys):
 
-Example with StringKeyspace:
+StringKeyspace example:
 import { CacheCluster, StringKeyspace, expireIn } from "encore.dev/storage/cache";
 
 const cluster = new CacheCluster("my-cache", { evictionPolicy: "allkeys-lru" });
@@ -361,7 +434,7 @@ await tokens.set({ tokenId: "abc123" }, "value");
 const token = await tokens.get({ tokenId: "abc123" }); // undefined on miss
 await tokens.delete({ tokenId: "abc123" });
 
-Example with IntKeyspace:
+IntKeyspace example:
 import { IntKeyspace } from "encore.dev/storage/cache";
 
 const counters = new IntKeyspace<{ id: string }>(cluster, {
@@ -371,7 +444,7 @@ const counters = new IntKeyspace<{ id: string }>(cluster, {
 await counters.increment({ id: "visits" }, 1);
 await counters.decrement({ id: "visits" }, 1);
 
-Example with StructKeyspace:
+StructKeyspace example:
 import { StructKeyspace } from "encore.dev/storage/cache";
 
 interface UserProfile { name: string; email: string; }
@@ -384,27 +457,27 @@ const profiles = new StructKeyspace<{ userId: string }, UserProfile>(cluster, {
 await profiles.set({ userId: "user123" }, { name: "Alice", email: "alice@example.com" });
 
 Other keyspaces (all from "encore.dev/storage/cache"):
-- FloatKeyspace<Key>: Float values. Has increment().
-- StringListKeyspace<Key>: String lists. Has pushRight, pushLeft, popRight, popLeft, getRange, items.
-- NumberListKeyspace<Key>: Number lists. Has pushRight, pushLeft, popRight, popLeft, items.
-- StringSetKeyspace<Key>: String sets. Has add, remove, contains, items.
-- NumberSetKeyspace<Key>: Number sets. Has add, remove, contains, items.
+- FloatKeyspace<Key>: float vals. Has increment().
+- StringListKeyspace<Key>: string lists. pushRight, pushLeft, popRight, popLeft, getRange, items.
+- NumberListKeyspace<Key>: number lists. pushRight, pushLeft, popRight, popLeft, items.
+- StringSetKeyspace<Key>: string sets. add, remove, contains, items.
+- NumberSetKeyspace<Key>: number sets. add, remove, contains, items.
 
 Expiry helpers (from "encore.dev/storage/cache"): expireIn(ms), expireInSeconds(s), expireInMinutes(m), expireInHours(h), expireDailyAt(hour, min, sec), neverExpire, keepTTL
 
-Write options:
+Write opts:
 await keyspace.set(key, value, { expiry: expireInMinutes(30) }); // override default
 await keyspace.setIfNotExists(key, value); // only if not exists
 await keyspace.replace(key, value); // only if exists, throws CacheMiss if absent
 
-Error types: CacheMiss, CacheKeyExists (from "encore.dev/storage/cache"). get() returns undefined on miss.
+Error types: CacheMiss, CacheKeyExists (from "encore.dev/storage/cache"). get() → undefined on miss.
 
-Local development uses an in-memory Redis implementation with ~100 key limit.
-</caching>
-<secrets_management>
-Built-in secrets manager for secure storage of API keys, passwords, and private keys.
+Local dev = in-memory Redis impl w/ ~100 key limit.
+### Secrets management
 
-Definition:
+Built-in secrets mgr for API keys, passwords, private keys.
+
+Def:
 import { secret } from "encore.dev/config";
 const githubToken = secret("GitHubAPIToken");
 
@@ -418,18 +491,18 @@ async function callGitHub() {
   });
 }
 
-Secret keys are globally unique across the application.
+Secret keys globally unique across app.
 
 Storage methods:
 - Cloud dashboard: https://app.encore.cloud → Settings → Secrets
 - CLI: encore secret set --type <types> <secret-name> (types: production/prod, development/dev, preview/pr, local)
 - Local override: .secrets.local.cue file (e.g., GitHubAPIToken: "my-local-override-token")
 
-Environment settings: One secret value per environment type. Environment-specific values override environment type values.
-</secrets_management>
-<streaming_apis>
-API endpoints that enable data streaming via WebSocket connections.
-Stream types: StreamIn (client to server), StreamOut (server to client), StreamInOut (bidirectional)
+Env settings: one secret value per env type. Env-specific overrides env-type values.
+### Streaming APIs
+
+API endpoints for data streaming via WebSocket.
+Stream types: StreamIn (client→server), StreamOut (server→client), StreamInOut (bidirectional)
 
 StreamIn:
 import { api } from "encore.dev/api";
@@ -469,7 +542,7 @@ export const chatStream = api.streamInOut<InMessage, OutMessage>(
   }
 );
 
-Handshake supports: Path parameters, query parameters, headers, authentication data
+Handshake supports: path params, query params, headers, auth data
 
 Client usage:
 const stream = client.serviceName.endpointName();
@@ -481,9 +554,9 @@ for await (const msg of stream) {
 Service-to-service:
 import { service } from "~encore/clients";
 const stream = await service.streamEndpoint();
-</streaming_apis>
-<validation>
-Built-in request validation using TypeScript types for both runtime and compile-time type safety.
+### Validation
+
+Built-in req validation via TS types — runtime + compile-time.
 
 Example:
 import { Header, Query, api } from "encore.dev/api";
@@ -508,36 +581,36 @@ Modifiers:
 - Optional: fieldName?: type;
 - Nullable: fieldName: type | null;
 
-Validation rules:
+Rules:
 - Min/Max: count: number & (Min<3> & Max<1000>);
 - MinLen/MaxLen: username: string & (MinLen<5> & MaxLen<20>);
 - Format: contact: string & (IsURL | IsEmail);
 
 Source types:
-- Body: Default for methods with request bodies, parsed from JSON request body
-- Query: URL query parameters, use Query type or default for GET/HEAD/DELETE
+- Body: default for methods w/ req bodies, parsed from JSON body
+- Query: URL query params, use Query type or default for GET/HEAD/DELETE
 - Headers: HTTP headers, use Header<"Name-Of-Header"> type
-- Params: URL path parameters (e.g., path: "/user/:id", param: { id: string })
+- Params: URL path params (e.g., path: "/user/:id", param: { id: string })
 
-Error response (400 Bad Request):
+Error resp (400 Bad Request):
 {
   "code": "invalid_argument",
   "message": "unable to decode request body",
   "internal_message": "Error details"
 }
-</validation>
-<static_assets>
-Built-in support for serving static assets (images, HTML, CSS, JavaScript). Use for static websites or pre-compiled SPAs.
+### Static assets
 
-Basic usage:
+Built-in serving for static assets (images, HTML, CSS, JS). For static sites or pre-compiled SPAs.
+
+Basic:
 import { api } from "encore.dev/api";
 export const assets = api.static(
   { expose: true, path: "/frontend/*path", dir: "./assets" },
 );
 
-Serves files from ./assets under /frontend path prefix. Automatically serves index.html files at directory roots.
+Serves files from ./assets under /frontend prefix. Auto-serves index.html at dir roots.
 
-Root serving (uses !path syntax to avoid conflicts):
+Root serving (uses !path to avoid conflicts):
 export const assets = api.static(
   { expose: true, path: "/!path", dir: "./assets" },
 );
@@ -551,9 +624,9 @@ export const assets = api.static(
     notFound: "./not_found.html"
   },
 );
-</static_assets>
-<graphql>
-Encore.ts has GraphQL support through raw endpoints with automatic tracing.
+### GraphQL
+
+Encore.ts has GraphQL via raw endpoints w/ auto tracing.
 
 Apollo example:
 import { HeaderMap } from "@apollo/server";
@@ -636,9 +709,9 @@ export const list = api(
     return { books: db };
   }
 );
-</graphql>
-<authentication>
-Authentication system for identifying API callers. Activation: Set auth: true in API endpoint options.
+### Authentication
+
+Auth system for identifying API callers. Enable: set auth: true in endpoint options.
 
 Auth handler:
 import { Header, Gateway } from "encore.dev/api";
@@ -663,18 +736,18 @@ export const gateway = new Gateway({
     authHandler: auth,
 })
 
-Rejection: throw APIError.unauthenticated("bad credentials");
+Reject: throw APIError.unauthenticated("bad credentials");
 
-Authentication process:
-1. Determine auth: Triggers on any request containing auth parameters. Returns AuthData (success), throws Unauthenticated (treated as no auth), or throws other error (request aborted).
-2. Endpoint call: If endpoint requires auth and request not authenticated - reject. If authenticated, auth data passed to endpoint regardless of requirements.
+Auth process:
+1. Determine auth: triggers on any req w/ auth params. Returns AuthData (success), throws Unauthenticated (treated as no auth), or throws other error (req aborted).
+2. Endpoint call: if endpoint needs auth + req unauth → reject. If authed, auth data passed regardless of requirements.
 
-Auth data access: Import getAuthData from ~encore/auth for type-safe resolution. Automatic propagation in internal API calls. Calls to auth-required endpoints fail if original request lacks auth.
-</authentication>
-<metadata>
-Access environment and application information through metadata API from encore.dev package.
+Auth data access: import getAuthData from ~encore/auth for type-safe resolution. Auto propagates in internal API calls. Calls to auth-required endpoints fail if orig req lacks auth.
+### Metadata
 
-appMeta() returns: appId (app name), apiBaseUrl (public API access URL), environment (current running environment), build (version control revision), deploy (deployment ID and timestamp)
+Access env + app info via metadata API from encore.dev.
+
+appMeta() returns: appId (app name), apiBaseUrl (public API URL), environment (current env), build (VCS revision), deploy (deploy ID + timestamp)
 
 currentRequest() returns:
 - API call:
@@ -700,7 +773,7 @@ interface PubSubMessageMeta {
   parsedPayload?: Record<string, any>;
 }
 
-Returns undefined if called during service initialization.
+Returns undefined if called during service init.
 
 Use cases:
 import { appMeta } from "encore.dev";
@@ -726,11 +799,11 @@ switch (appMeta().environment.type) {
     await sendVerificationEmail(userID);
     break;
 }
-</metadata>
-<middleware>
-Reusable code running before/after API requests across multiple endpoints.
+### Middleware
 
-Basic usage:
+Reusable code running before/after API reqs across endpoints.
+
+Basic:
 import { middleware } from "encore.dev/api";
 
 export default new Service("myService", {
@@ -744,16 +817,16 @@ export default new Service("myService", {
     ]
 });
 
-Request access types:
+Req access types:
 - Typed API: req.requestMeta
 - Streaming: req.requestMeta, req.stream
 - Raw: req.rawRequest, req.rawResponse
 
-Response handling (HandlerResponse object):
+Resp handling (HandlerResponse):
 resp.header.set(key, value)
 resp.header.add(key, value)
 
-Ordering (executes in order of definition):
+Ordering (executes in definition order):
 export default new Service("myService", {
     middlewares: [
         first,
@@ -762,13 +835,13 @@ export default new Service("myService", {
     ],
 });
 
-Targeting: Use target option instead of runtime filtering for better performance. Defaults to all endpoints if target not specified.
-</middleware>
-<orm_integration>
-Built-in support for ORMs and migration frameworks through named databases and SQL migration files.
-Requirements: ORM must support standard SQL driver connections. Migration framework must generate standard SQL migration files.
+Targeting: use target option instead of runtime filter for perf. Defaults to all endpoints if target unset.
+### ORM integration
 
-Database connection:
+Built-in ORM + migration framework support via named DBs + SQL migration files.
+Requires: ORM must support std SQL driver. Migration framework must gen std SQL files.
+
+DB conn:
 import { SQLDatabase } from "encore.dev/storage/sqldb";
 
 const SiteDB = new SQLDatabase("siteDB", {
@@ -776,9 +849,9 @@ const SiteDB = new SQLDatabase("siteDB", {
 });
 
 const connStr = SiteDB.connectionString;
-</orm_integration>
-<drizzle_integration>
-Database setup (database.ts):
+### Drizzle integration
+
+DB setup (database.ts):
 import { api } from "encore.dev/api";
 import { SQLDatabase } from "encore.dev/storage/sqldb";
 import { drizzle } from "drizzle-orm/node-postgres";
@@ -813,40 +886,40 @@ export const users = p.pgTable("users", {
   email: p.text().unique(),
 });
 
-Generate migrations: drizzle-kit generate (run in directory containing drizzle.config.ts)
-Migrations automatically applied during Encore application runtime.
-</drizzle_integration>
-<cors>
-CORS controls which website origins can access your API. Scope: Browser requests to resources on different origins (scheme, domain, port).
+Gen migrations: drizzle-kit generate (run in dir w/ drizzle.config.ts)
+Migrations auto-applied at Encore runtime.
+### CORS
 
-Configuration in encore.app under global_cors key:
-- debug: boolean, enables CORS debug logging
-- allow_headers: string[], additional accepted headers ("*" for all)
-- expose_headers: string[], additional exposed headers ("*" for all)
-- allow_origins_without_credentials: string[], allowed origins for non-credentialed requests (default: ["*"])
-- allow_origins_with_credentials: string[], allowed origins for credentialed requests (supports wildcards: https://*.example.com, https://*-myapp.example.com)
+CORS controls which origins can access API. Scope: browser reqs to resources on different origins (scheme, domain, port).
 
-Defaults: Allows unauthenticated requests from all origins, disallows authenticated requests from other origins, all origins allowed in local development.
+Config in encore.app under global_cors:
+- debug: bool, CORS debug logging
+- allow_headers: string[], additional accepted headers ("*" = all)
+- expose_headers: string[], additional exposed headers ("*" = all)
+- allow_origins_without_credentials: string[], allowed origins for non-cred reqs (default: ["*"])
+- allow_origins_with_credentials: string[], allowed origins for credentialed (wildcards: https://*.example.com, https://*-myapp.example.com)
 
-Header handling: Encore automatically configures headers through static analysis. Additional headers can be configured via allow_headers and expose_headers for custom headers in raw endpoints.
-</cors>
-<logging>
-Built-in structured logging combining free-form messages with type-safe key-value pairs.
+Defaults: allow unauth reqs from all origins, disallow auth reqs from other origins, all origins allowed in local dev.
+
+Header handling: Encore auto-configures headers via static analysis. Additional headers configurable via allow_headers + expose_headers for custom headers in raw endpoints.
+### Logging
+
+Built-in structured logging — free-form msgs + type-safe key-value pairs.
 
 import log from "encore.dev/log";
 
-Log levels: error, warn, info, debug, trace
+Levels: error, warn, info, debug, trace
 
-Basic usage:
+Basic:
 log.info("log message", {is_subscriber: true})
 log.error(err, "something went terribly wrong!")
 
-With context (group logs with shared key-value pairs):
+With context (group logs w/ shared key-value pairs):
 const logger = log.with({is_subscriber: true})
 logger.info("user logged in", {login_method: "oauth"}) // includes is_subscriber=true
-</logging>
-<testing>
-Encore.ts uses standard TypeScript testing tools. Recommended setup is Vitest.
+### Testing
+
+Encore.ts uses std TS testing tools. Recommended: Vitest.
 
 Setup:
 npm install -D vitest
@@ -858,11 +931,11 @@ Add to package.json:
   }
 }
 
-Running tests:
-- encore test: Recommended - sets up test databases automatically, provides isolated infrastructure per test, handles service dependencies
-- npm test: Direct execution without infrastructure setup
+Run tests:
+- encore test: recommended — auto sets up test DBs, isolated infra per test, handles service deps
+- npm test: direct, no infra setup
 
-Test an API endpoint:
+Test API endpoint:
 import { describe, it, expect } from "vitest";
 import { hello } from "./api";
 
@@ -873,7 +946,7 @@ describe("hello endpoint", () => {
   });
 });
 
-Test with request parameters:
+Test w/ req params:
 import { describe, it, expect } from "vitest";
 import { getUser } from "./api";
 
@@ -885,7 +958,7 @@ describe("getUser endpoint", () => {
   });
 });
 
-Test database operations (Encore provides isolated test databases):
+Test DB ops (Encore gives isolated test DBs):
 import { describe, it, expect, beforeEach } from "vitest";
 import { createUser, getUser, db } from "./user";
 
@@ -938,7 +1011,7 @@ describe("pub/sub", () => {
   });
 });
 
-Test Cron Jobs (test the underlying function, not the cron schedule):
+Test Cron Jobs (test underlying fn, not cron schedule):
 import { describe, it, expect } from "vitest";
 import { cleanupExpiredSessions } from "./cleanup";
 
@@ -951,7 +1024,7 @@ describe("cleanup job", () => {
   });
 });
 
-Vitest configuration (vitest.config.ts):
+Vitest config (vitest.config.ts):
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -966,74 +1039,101 @@ export default defineConfig({
 });
 
 Guidelines:
-- Use `encore test` to run tests with infrastructure setup
-- Each test file gets an isolated database transaction (rolled back after)
-- Test API endpoints by calling them directly as functions
+- Use `encore test` to run w/ infra setup
+- Each test file gets isolated DB transaction (rolled back after)
+- Test API endpoints by calling directly as fns
 - Service-to-service calls work normally in tests
-- Mock external dependencies (third-party APIs, email services)
-- Don't mock Encore infrastructure (databases, Pub/Sub) - use the real thing
-</testing>
-<example_apps>
+- Mock external deps (third-party APIs, email services)
+- Don't mock Encore infra (DBs, Pub/Sub) — use real thing
+### Encore Toolbar (frontend dev panel)
+
+Dev-only browser panel: intercepts frontend HTTP calls, captures Encore trace IDs, jumps to traces in the dashboard. Install: add `<script src="https://encore.dev/encore-toolbar.js"></script>` early in `<head>` (no `async`/`defer`). Reach for it when a frontend talks to an Encore backend.
+### Example apps
+
 - Hello World: https://github.com/encoredev/examples/tree/main/ts/hello-world
 - URL Shortener: https://github.com/encoredev/examples/tree/main/ts/url-shortener
 - Uptime Monitor: https://github.com/encoredev/examples/tree/main/ts/uptime
-</example_apps>
-<package_management>
-Default: Use a single root-level package.json file (monorepo approach) for Encore.ts projects including frontend dependencies.
-Alternative: Separate package.json files in sub-packages, but Encore.ts application must use one package with a single package.json file, and other separate packages must be pre-transpiled to JavaScript.
-</package_management>
-</encore_ts_domain_knowledge>
-<encore_cli_reference>
+### Package management
+
+Default: single root-level package.json (monorepo) for Encore.ts projects including frontend deps.
+Alt: separate package.json in sub-packages, but Encore.ts app must use one package w/ single package.json, other separate packages must be pre-transpiled to JS.
+## Encore CLI reference
+
 Execution:
-- encore run [--debug] [--watch=true] [flags]: Runs your application
-- encore test [flags]: Run tests with infrastructure setup (sets up test databases, provides isolated infrastructure per test)
+- encore help [command]: lists cmds (or shows usage for specific cmd). Use when unsure of subcommand/flag.
+- encore run [--debug] [--watch=true] [-p port] [flags]: runs app. Before starting yourself, check if already running by polling `http://localhost:<port>/__encore/healthz` (default `4000`) — `200` = healthy, hit endpoints directly w/o re-running.
+- encore check ['curl ...'; 'curl ...'] | encore check < commands.txt: compile + boot app, verify services healthy, optionally run curls. See section above.
+- encore test [flags]: provisions isolated test infra (DBs, Pub/Sub, etc.) then runs `test` script from `package.json` (Vitest recommended). Test DBs skip fsync + use in-memory FS for speed. Use instead of `npm test` / `vitest` direct when code touches Encore infra.
+- encore exec path/to/script [args...]: run executable script against local app.
 
-App management:
-- encore app clone [app-id] [directory]: Clone an Encore app
-- encore app create [name]: Create a new Encore app
-- encore app init [name]: Create new app from existing repository
-- encore app link [app-id]: Link app with server
+App mgmt:
+- encore app clone [app-id] [directory]: clone Encore app
+- encore app create [name] [--example=name] [-l ts]: create new Encore app
+- encore app init [name]: create new app from existing repo
+- encore app link [app-id] [-f]: link app w/ server
 
-Authentication:
-- encore auth login: Log in to Encore
-- encore auth logout: Log out current user
-- encore auth signup: Create new account
-- encore auth whoami: Show current user
+Auth:
+- encore auth login [-k auth-key]: log in
+- encore auth logout: log out
+- encore auth signup: create account
+- encore auth whoami: show current user
 
 Daemon:
-- encore daemon: Restart daemon for unexpected behavior
-- encore daemon env: Output environment information
+- encore daemon: restart daemon for unexpected behavior
+- encore daemon env: output env info
 
-Database:
-- encore db shell database-name [--env=name]: Connect via psql shell (--write, --admin, --superuser flags available)
-- encore db conn-uri database-name [--env=name]: Output connection string
-- encore db proxy [--env=name]: Set up local database connection proxy
-- encore db reset [service-names...]: Reset specified service databases
+DB:
+- encore db shell database-name [--env=name]: connect via psql (--write, --admin, --superuser flags)
+- encore db conn-uri database-name [--env=name]: output conn string
+- encore db proxy [--env=name]: local DB conn proxy
+- encore db reset <db-names...|--all>: reset specified DBs
 
-Code generation:
-- encore gen client [app-id] [--env=name] [--lang=lang]: Generate API client (languages: go, typescript, javascript, openapi)
+Code gen:
+- encore gen client [app-id] [--env=name] [--lang=lang]: gen API client (langs: go, typescript, javascript, openapi)
 
-Logging:
-- encore logs [--env=prod] [--json]: Stream application logs
+Logs:
+- encore logs [--env=prod] [--json] [-q]: stream app logs
 
-Kubernetes:
-- encore k8s configure --env=ENV_NAME: Update kubectl config for environment
+K8s:
+- encore k8s configure --env=ENV_NAME: update kubectl config for env
 
 Secrets:
-- encore secret set --type types secret-name: Set secret value (types: production, development, preview, local)
-- encore secret list [keys...]: List secrets
-- encore secret archive id: Archive secret value
-- encore secret unarchive id: Unarchive secret value
+- encore secret set --type types <secret-name>: set secret (types: production/prod, development/dev, preview/pr, local)
+- encore secret set --env <env-name> <secret-name>: set env-specific secret
+- encore secret list [keys...]: list secrets
+- encore secret delete <id>: delete secret value
+
+Namespaces (infra envs, alias `encore ns`):
+- encore namespace list [--output=columns|json]: list infra namespaces
+- encore namespace create NAME: create new namespace
+- encore namespace switch [--create] NAME: switch active namespace
+- encore namespace delete NAME: delete namespace
+
+MCP (programmatic access to the local app — same surface as `.mcp.json`):
+- encore mcp run: stdio-based MCP session
+- encore mcp start: SSE-based MCP session; prints the SSE URL
+
+Config:
+- encore config <key> [<value>] [--app|--global|--all]: get/set CLI config
+
+Telemetry:
+- encore telemetry: status
+- encore telemetry enable / disable: toggle telemetry reporting
+
+LLM rules:
+- encore llm-rules init: generate LLM rule files for this project
+
+Random data (utility):
+- encore rand uuid [-1|-4|-6|-7]: gen UUID (default v4)
+- encore rand bytes N [-f format]: gen N random bytes
+- encore rand words [--sep=SEP] NUM: gen memorable passphrase
+
+Deploy (alpha):
+- encore alpha deploy --env=<name> (--commit=<sha> | --branch=<name>): deploy app to a cloud env
 
 Version:
-- encore version: Report current version
-- encore version update: Check and apply updates
-
-VPN:
-- encore vpn start: Set up secure connection to private environments
-- encore vpn status: Check VPN connection status
-- encore vpn stop: Stop VPN connection
+- encore version: report current
+- encore version update: check + apply updates
 
 Build:
-- encore build docker: Build portable Docker image (--base string: Define base image, --push: Push to remote repository)
-</encore_cli_reference>
+- encore build docker IMAGE_TAG [--base string] [--push] [--cgo] [--os] [--arch]: build portable Docker image


### PR DESCRIPTION
## Summary

Replaces both `ts_llm_instructions.txt` and `go_llm_instructions.txt` with the markdown-heading variant developed and benchmarked in [`encoredev/ai-setup-benchmarks`](https://github.com/encoredev/ai-setup-benchmarks) (the `claude-md-improved` setup). Filenames unchanged so existing tooling that points at `*_llm_instructions.txt` keeps working.

Key changes vs. the previous XML-tag content:

- **Structure**: `<tag>` → `## heading`. Benchmark `tags-vs-headings-v1` showed the heading variant cut wall clock and reduced codebase-enumeration loops vs. the tag form.
- **Documents the two new MCP tools from #2440** — `wait_for_subscription_message` and `call_endpoint`'s `retry_until` parameter — with their arg shapes, a canonical Pub/Sub verify recipe (wait → then `retry_until`), and an updated "When to reach for it" decision table that routes Pub/Sub-handler and eventually-consistent reads to the right tool.
- **`db.query<>` row-generic rule** (TS) / **typed `Scan` rule** (Go): always parameterize with an explicit row type. The `20260518-110747` batch had 6/6 uptime runs drop the row generic and let `TIMESTAMPTZ` columns flow into `string`-typed response fields with no compile error.
- **Publish-order ordering trap**: don't sort Pub/Sub-fed audit logs by `created_at = NOW()` — receive order ≠ publish order under at-least-once delivery. Three failing prompts in `20260518-110747` traced to this exact mistake.
- **New `### Encore Toolbar` section** — 3-line pointer at `https://encore.dev/encore-toolbar.js`.
- **CLI reference reconciled with `encore help`**:
  - Removes commands that don't exist: `encore vpn start/status/stop`, `encore secret archive`, `encore secret unarchive`.
  - Adds current commands: `encore exec`, `encore namespace list/create/switch/delete` (alias `encore ns`), `encore mcp run/start`, `encore config`, `encore telemetry`, `encore llm-rules init`, `encore rand uuid/bytes/words`, `encore alpha deploy`, `encore secret delete`.
  - Corrects flags on `run`, `app create`, `app link`, `auth login`, `db reset`, `logs`, and `build docker`.
- **General prose compression** — caveman style (drops articles, filler, hedging). Every code block, command, URL, and file path preserved byte-for-byte.

## Why these specific changes

Content is empirically tuned, not just rewritten. Across the two most recent benchmark batches (`20260519-154806` and `20260520-115208` in the `ai-setup-benchmarks` repo, both `claude-sonnet-4-6`), the `claude-md-improved` setup driven by this content scored **9 / 9 prompts at first pass** with the cleanest run-level quality scores recorded in the project — every `db.query<>` carried a typed row generic, every Pub/Sub-fed audit endpoint ordered by a publish-monotonic key, and the agent reached for the new MCP tools at the right moments.

## Test plan

- [ ] Smoke-check: clone the repo, open both files, scan headings — confirm they read as a single coherent doc per language.
- [ ] Run `encore help` and spot-check the CLI reference section in each file against `encore help <cmd>` output for `run`, `db`, `secret`, `namespace`, `mcp`, `alpha deploy`, `build docker`, `rand`. (Already verified locally.)
- [ ] Sanity-check the MCP tool descriptions against the live tool schemas in `cli/daemon/mcp/mcp.go` (`call_endpoint` + `wait_for_subscription_message`).
- [ ] No CI consumes these `.txt` files for compilation; expect no test failures.