### PR TITLE
runtimes/core/sqs_sns: set operation_attempt_timeout to prevent hangs

### DIFF
--- a/runtimes/core/src/pubsub/sqs_sns/mod.rs
+++ b/runtimes/core/src/pubsub/sqs_sns/mod.rs
@@ -10,6 +10,15 @@ mod fetcher;
 mod sub;
 mod topic;
 
+/// Long-poll wait for each SQS ReceiveMessage call. 20s is the AWS SQS maximum.
+const LONG_POLL_WAIT_SECS: u64 = 20;
+
+/// Per-attempt timeout for SQS/SNS API calls. Must exceed [`LONG_POLL_WAIT_SECS`] so
+/// empty long polls don't time out; bounds stalled requests so they fail (and the SDK
+/// retries on a fresh connection) instead of hanging on a silently-dropped connection.
+const OPERATION_ATTEMPT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(LONG_POLL_WAIT_SECS + 10);
+
 #[derive(Debug)]
 pub struct Cluster {
     /// publisher_id is a unique ID for this Encore app instance, used as the Message Group ID
@@ -67,8 +76,15 @@ impl LazyClient {
 
     async fn config(&self) -> aws_config::SdkConfig {
         let provider = aws_config::meta::region::RegionProviderChain::default_provider();
+
+        // See https://github.com/awslabs/aws-sdk-rust/issues/1094#issuecomment-1984587869
+        let timeout_config = aws_smithy_types::timeout::TimeoutConfig::builder()
+            .operation_attempt_timeout(OPERATION_ATTEMPT_TIMEOUT)
+            .build();
+
         aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(provider)
+            .timeout_config(timeout_config)
             .load()
             .await
     }

--- a/runtimes/core/src/pubsub/sqs_sns/sub.rs
+++ b/runtimes/core/src/pubsub/sqs_sns/sub.rs
@@ -128,7 +128,7 @@ impl fetcher::Fetcher for Arc<SqsFetcher> {
                 .queue_url(queue_url)
                 .message_system_attribute_names(MessageSystemAttributeName::ApproximateReceiveCount)
                 .visibility_timeout(ack_deadline.as_secs() as i32)
-                .wait_time_seconds(20) // maximum allowed time
+                .wait_time_seconds(super::LONG_POLL_WAIT_SECS as i32)
                 .max_number_of_messages(max_items as i32)
                 .send()
                 .await;


### PR DESCRIPTION
prevent hangs in fetch, see https://github.com/awslabs/aws-sdk-rust/issues/1094