### PR TITLE
runtimes/core: avoid exit-time teardown race on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ dependencies = [
  "indexmap 2.7.0",
  "insta",
  "jsonwebtoken",
+ "libc",
  "log",
  "malachite",
  "matchit",

--- a/runtimes/core/Cargo.toml
+++ b/runtimes/core/Cargo.toml
@@ -57,6 +57,7 @@ mime = "0.3.17"
 futures = "0.3.30"
 native-tls = "0.2.11"
 postgres-native-tls = "0.5.0"
+libc = "0.2"
 reqwest = { version = "0.12.4", features = ["stream", "json"] }
 url = "2.5.0"
 futures-core = { version = "0.3.30", features = [] }

--- a/runtimes/core/src/lib.rs
+++ b/runtimes/core/src/lib.rs
@@ -568,14 +568,19 @@ impl Runtime {
             // Exit. We can't just return here because the tokio runtime
             // (and the orchestrator's force-exit task) is kept alive by Arc<Runtime>
             // in the JS layer's static OnceLock.
+            //
+            // Use force_exit (libc `_exit`), not `std::process::exit`: running
+            // libc exit's atexit/teardown chain from this background thread
+            // races the still-live Node/V8/worker threads and segfaults. See
+            // shutdown::force_exit for the full story.
             match serve_result {
                 Ok(()) => {
                     ::log::info!("shutdown complete");
-                    std::process::exit(0);
+                    shutdown::force_exit(0);
                 }
                 Err(err) => {
                     ::log::error!("server failed: {:?}", err);
-                    std::process::exit(1);
+                    shutdown::force_exit(1);
                 }
             }
         });

--- a/runtimes/core/src/lib.rs
+++ b/runtimes/core/src/lib.rs
@@ -219,6 +219,7 @@ pub struct Runtime {
     runtime_config: runtime_config::RuntimeConfig,
     shutdown_config: shutdown::ShutdownConfig,
     tracer_flush: std::sync::Mutex<Option<trace::TracerFlush>>,
+    exit: Arc<shutdown::ExitCell>,
 }
 
 impl Runtime {
@@ -468,6 +469,7 @@ impl Runtime {
             runtime_config,
             shutdown_config,
             tracer_flush: std::sync::Mutex::new(tracer_flush),
+            exit: Arc::new(shutdown::ExitCell::new()),
         })
     }
 
@@ -521,21 +523,46 @@ impl Runtime {
         self.runtime.handle()
     }
 
-    /// Runs the runtime until graceful shutdown completes, then returns the
-    /// process exit code (0 on clean shutdown, 1 on serve failure).
+    /// Runs the runtime until graceful shutdown completes, requesting the
+    /// process exit code (0 on clean shutdown, 1 on serve failure or panic)
+    /// and returning it.
     ///
     /// This deliberately does NOT exit the process: the runtime is embedded in
     /// Node via a NAPI addon, and exiting from this background thread runs
     /// exit-time teardown concurrently with Node's live threads (see
-    /// `shutdown::force_exit`). Instead the caller propagates the code to the
-    /// JS layer, which calls `process.exit(code)` on Node's main thread so the
-    /// host exits through its own orderly teardown. The force-exit watchdog
-    /// (`shutdown::run`) remains the `_exit` backstop if that path wedges.
-    #[inline]
+    /// `shutdown::force_exit`). Instead the exit code is delivered through the
+    /// runtime's exit cell — the JS layer awaits it (`wait_for_exit_code`) and
+    /// calls `process.exit(code)` on Node's main thread so the host exits
+    /// through its own orderly teardown. The watchdog (`shutdown::run`)
+    /// requests an exit through the same cell at the shutdown deadline, and
+    /// every exit request arms a `_exit` backstop in case the host can't
+    /// exit at all.
+    ///
+    /// Panics during serving or shutdown are caught and converted into exit
+    /// code 1, so every caller (production and test mode alike) is guaranteed
+    /// both a return value and an exit-cell request.
     pub fn run_blocking(&self) -> i32 {
+        let code = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            self.run_blocking_inner()
+        }))
+        .unwrap_or_else(|_| {
+            ::log::error!("runtime panicked while serving or shutting down");
+            1
+        });
+
+        // Request the exit (first request wins against the watchdog's
+        // deadline request; arms the force-exit backstop). The tokio runtime
+        // stays alive (Arc<Runtime> in the JS layer's static OnceLock), which
+        // also keeps the watchdog task running until the process exits.
+        self.exit.request(code);
+        code
+    }
+
+    fn run_blocking_inner(&self) -> i32 {
         self.runtime.block_on(async move {
             // Start the shutdown orchestrator (waits for signal in background).
-            let shutdown = shutdown::run(self.shutdown_config.clone()).await;
+            let shutdown =
+                shutdown::run(self.shutdown_config.clone(), self.exit.clone()).await;
 
             // Start the API server with the shutdown handle.
             let api_handle = self.api().start_serving(shutdown.clone());
@@ -575,10 +602,8 @@ impl Runtime {
                 flush.flush().await;
             }
 
-            // Return the exit code rather than exiting; see the doc comment.
-            // The tokio runtime stays alive (Arc<Runtime> in the JS layer's
-            // static OnceLock), which also keeps the force-exit watchdog
-            // task running until the process exits.
+            // Return the exit code rather than exiting; run_blocking requests
+            // it through the exit cell (see its doc comment).
             match serve_result {
                 Ok(()) => {
                     ::log::info!("shutdown complete");
@@ -590,6 +615,20 @@ impl Runtime {
                 }
             }
         })
+    }
+
+    /// Requests that the process exit with the given code. The first request
+    /// (graceful completion, the watchdog deadline, or the host layer) wins.
+    pub fn request_exit(&self, code: i32) {
+        self.exit.request(code);
+    }
+
+    /// Resolves once a process exit code has been requested — either by
+    /// graceful shutdown completing ([`run_blocking`](Self::run_blocking)
+    /// finishing) or by the force-exit watchdog reaching its deadline with
+    /// the shutdown still in progress.
+    pub async fn wait_for_exit_code(&self) -> i32 {
+        self.exit.wait().await
     }
 
     #[inline]

--- a/runtimes/core/src/lib.rs
+++ b/runtimes/core/src/lib.rs
@@ -521,8 +521,18 @@ impl Runtime {
         self.runtime.handle()
     }
 
+    /// Runs the runtime until graceful shutdown completes, then returns the
+    /// process exit code (0 on clean shutdown, 1 on serve failure).
+    ///
+    /// This deliberately does NOT exit the process: the runtime is embedded in
+    /// Node via a NAPI addon, and exiting from this background thread runs
+    /// exit-time teardown concurrently with Node's live threads (see
+    /// `shutdown::force_exit`). Instead the caller propagates the code to the
+    /// JS layer, which calls `process.exit(code)` on Node's main thread so the
+    /// host exits through its own orderly teardown. The force-exit watchdog
+    /// (`shutdown::run`) remains the `_exit` backstop if that path wedges.
     #[inline]
-    pub fn run_blocking(&self) {
+    pub fn run_blocking(&self) -> i32 {
         self.runtime.block_on(async move {
             // Start the shutdown orchestrator (waits for signal in background).
             let shutdown = shutdown::run(self.shutdown_config.clone()).await;
@@ -565,25 +575,21 @@ impl Runtime {
                 flush.flush().await;
             }
 
-            // Exit. We can't just return here because the tokio runtime
-            // (and the orchestrator's force-exit task) is kept alive by Arc<Runtime>
-            // in the JS layer's static OnceLock.
-            //
-            // Use force_exit (libc `_exit`), not `std::process::exit`: running
-            // libc exit's atexit/teardown chain from this background thread
-            // races the still-live Node/V8/worker threads and segfaults. See
-            // shutdown::force_exit for the full story.
+            // Return the exit code rather than exiting; see the doc comment.
+            // The tokio runtime stays alive (Arc<Runtime> in the JS layer's
+            // static OnceLock), which also keeps the force-exit watchdog
+            // task running until the process exits.
             match serve_result {
                 Ok(()) => {
                     ::log::info!("shutdown complete");
-                    shutdown::force_exit(0);
+                    0
                 }
                 Err(err) => {
                     ::log::error!("server failed: {:?}", err);
-                    shutdown::force_exit(1);
+                    1
                 }
             }
-        });
+        })
     }
 
     #[inline]

--- a/runtimes/core/src/lib.rs
+++ b/runtimes/core/src/lib.rs
@@ -542,13 +542,12 @@ impl Runtime {
     /// code 1, so every caller (production and test mode alike) is guaranteed
     /// both a return value and an exit-cell request.
     pub fn run_blocking(&self) -> i32 {
-        let code = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            self.run_blocking_inner()
-        }))
-        .unwrap_or_else(|_| {
-            ::log::error!("runtime panicked while serving or shutting down");
-            1
-        });
+        let code =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.run_blocking_inner()))
+                .unwrap_or_else(|_| {
+                    ::log::error!("runtime panicked while serving or shutting down");
+                    1
+                });
 
         // Request the exit (first request wins against the watchdog's
         // deadline request; arms the force-exit backstop). The tokio runtime
@@ -561,8 +560,7 @@ impl Runtime {
     fn run_blocking_inner(&self) -> i32 {
         self.runtime.block_on(async move {
             // Start the shutdown orchestrator (waits for signal in background).
-            let shutdown =
-                shutdown::run(self.shutdown_config.clone(), self.exit.clone()).await;
+            let shutdown = shutdown::run(self.shutdown_config.clone(), self.exit.clone()).await;
 
             // Start the API server with the shutdown handle.
             let api_handle = self.api().start_serving(shutdown.clone());

--- a/runtimes/core/src/shutdown.rs
+++ b/runtimes/core/src/shutdown.rs
@@ -75,6 +75,47 @@ fn parse_k8s_grace_period(total: Duration) -> Duration {
     k8s_grace.saturating_sub(total)
 }
 
+/// Terminates the process immediately without running C `atexit` handlers or
+/// C++ static destructors.
+///
+/// We must NOT use `std::process::exit` (which calls libc `exit`) here. The
+/// runtime is embedded in Node via a NAPI addon, and the exit is driven from a
+/// background thread while Node's event loop, V8, libuv, and worker threads are
+/// all still live. libc `exit` runs the global teardown chain on the calling
+/// thread — Node/V8 platform teardown and OpenSSL's `OPENSSL_cleanup` (Node
+/// registers it via `atexit`; it frees process-global crypto state) — while
+/// those other threads keep using that very state. That data race crashes the
+/// majority of shutdowns under load (SIGSEGV/SIGABRT).
+///
+/// `_exit` terminates the process immediately (`exit_group(2)` on Linux) with
+/// no handlers and no destructors — exactly what we want when force-terminating
+/// with live threads. All observability data is already flushed by this point
+/// (see `run_blocking`). Known tradeoff: log lines emitted immediately before
+/// this call go through the async log writer thread (`log::writers`) and may
+/// not reach stderr before termination; the process exit code remains the
+/// authoritative shutdown signal.
+#[cfg(unix)]
+pub(crate) fn force_exit(code: i32) -> ! {
+    use std::io::Write;
+
+    // Best-effort flush of Rust's stdio buffers (stderr is unbuffered; the
+    // runtime doesn't write Rust stdout, so this is insurance for stray
+    // debug output).
+    let _ = std::io::stdout().flush();
+    let _ = std::io::stderr().flush();
+    // SAFETY: `_exit` has no preconditions and is safe to call from any
+    // thread; it never returns.
+    unsafe { libc::_exit(code) }
+}
+
+/// On non-unix platforms we keep the standard exit. The crash this guards
+/// against is specific to the Linux/glibc + Node + OpenSSL teardown chain that
+/// production deployments run on, and `_exit` semantics differ on Windows.
+#[cfg(not(unix))]
+pub(crate) fn force_exit(code: i32) -> ! {
+    std::process::exit(code)
+}
+
 /// Handle used by components to observe when shutdown has been initiated.
 ///
 /// When a SIGINT/SIGTERM signal is received, the handle fires, signaling
@@ -160,7 +201,7 @@ pub async fn run(config: ShutdownConfig) -> ShutdownHandle {
         ::log::warn!("graceful shutdown deadline reached, forcing exit");
         tokio::time::sleep(FORCE_EXIT_GRACE).await;
         ::log::error!("force shutdown grace period exceeded, exiting");
-        std::process::exit(1);
+        force_exit(1);
     });
 
     handle

--- a/runtimes/core/src/shutdown.rs
+++ b/runtimes/core/src/shutdown.rs
@@ -1,3 +1,4 @@
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
@@ -7,8 +8,10 @@ use crate::encore::runtime::v1 as runtimepb;
 /// Default total shutdown time.
 const DEFAULT_TOTAL: Duration = Duration::from_secs(5);
 
-/// Default grace period after force shutdown before process exit.
-const FORCE_EXIT_GRACE: Duration = Duration::from_secs(1);
+/// Grace period after an exit has been requested before the process is
+/// force-terminated with `force_exit`. Must be generous enough to cover the
+/// host's orderly exit path (worker-thread termination plus Node teardown).
+const FORCE_EXIT_GRACE: Duration = Duration::from_secs(3);
 
 /// Configuration for graceful shutdown timings.
 #[derive(Debug, Clone)]
@@ -75,6 +78,77 @@ fn parse_k8s_grace_period(total: Duration) -> Duration {
     k8s_grace.saturating_sub(total)
 }
 
+/// Coordinates the process exit code between the graceful-shutdown path, the
+/// force-exit watchdog, and the host-language layer that performs the actual
+/// exit (e.g. `process.exit(code)` on Node's main thread).
+///
+/// The first request wins; later requests are ignored. This makes the
+/// graceful path and the watchdog race-safe: whoever reaches their exit
+/// condition first decides the code, and the host observes a single value.
+pub(crate) struct ExitCell {
+    code: Mutex<Option<i32>>,
+    notify: tokio::sync::Notify,
+}
+
+impl ExitCell {
+    pub(crate) fn new() -> Self {
+        Self {
+            code: Mutex::new(None),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Requests that the process exit with the given code.
+    /// The first request wins; subsequent requests are no-ops.
+    ///
+    /// Once an exit has been requested the process must terminate, so the
+    /// first request also arms a backstop that force-exits (with the same
+    /// code) if the host's exit path hasn't terminated the process within
+    /// the grace period — e.g. a wedged event loop, or a worker thread stuck
+    /// in native code during `worker.terminate()`. This covers every exit
+    /// origin (graceful completion, the watchdog deadline, and panic
+    /// recovery) without depending on a signal having been received.
+    pub(crate) fn request(&self, code: i32) {
+        {
+            let mut guard = self.code.lock().expect("exit cell lock poisoned");
+            if guard.is_some() {
+                return;
+            }
+            *guard = Some(code);
+            self.notify.notify_waiters();
+        }
+
+        let spawned = std::thread::Builder::new()
+            .name("encore-exit-backstop".into())
+            .spawn(move || {
+                std::thread::sleep(FORCE_EXIT_GRACE);
+                ::log::error!(
+                    "process still alive {FORCE_EXIT_GRACE:?} after exit was requested, force-exiting"
+                );
+                force_exit(code);
+            });
+        if let Err(err) = spawned {
+            // Extremely unlikely (thread exhaustion). The exit code is already
+            // recorded and waiters notified, so the normal exit path still
+            // works — we just lose the wedge protection.
+            ::log::error!("failed to spawn exit backstop thread: {err}");
+        }
+    }
+
+    /// Resolves once an exit code has been requested.
+    pub(crate) async fn wait(&self) -> i32 {
+        loop {
+            // Register interest before checking the state so a request
+            // between the check and the await can't be missed.
+            let notified = self.notify.notified();
+            if let Some(code) = *self.code.lock().expect("exit cell lock poisoned") {
+                return code;
+            }
+            notified.await;
+        }
+    }
+}
+
 /// Terminates the process immediately without running C `atexit` handlers or
 /// C++ static destructors.
 ///
@@ -89,12 +163,12 @@ fn parse_k8s_grace_period(total: Duration) -> Duration {
 ///
 /// `_exit` terminates the process immediately (`exit_group(2)` on Linux) with
 /// no handlers and no destructors — exactly what we want when force-terminating
-/// with live threads. On the normal path observability data is flushed before
-/// this is reached (see `run_blocking`); when the force-exit watchdog fires,
-/// shutdown is past its deadline and immediate termination takes priority.
-/// Known tradeoff: log lines emitted immediately before this call go through
-/// the async log writer thread (`log::writers`) and may not reach stderr
-/// before termination; the process exit code remains the authoritative
+/// with live threads. It is reached only from the exit backstop (the host
+/// failed to exit within the grace period after an exit was requested; see
+/// [`ExitCell::request`]) and from test mode, where nothing awaits the exit
+/// code. Known tradeoff: log lines emitted immediately before this call go
+/// through the async log writer thread (`log::writers`) and may not reach
+/// stderr before termination; the process exit code remains the authoritative
 /// shutdown signal.
 #[cfg(unix)]
 pub fn force_exit(code: i32) -> ! {
@@ -178,13 +252,16 @@ async fn wait_for_signal() {
 /// This function:
 /// 1. Waits for a shutdown signal (SIGINT/SIGTERM) in a background task
 /// 2. Initiates graceful shutdown (components stop accepting new work)
-/// 3. Force-exits the process if the total deadline is exceeded
+/// 3. If the total deadline is exceeded, requests a process exit (code 1)
+///    through the host's normal exit path
 ///
-/// The force exit is a safety net — normally `run_blocking` returns before
-/// the deadline and the JS layer exits the process cleanly from Node's main
-/// thread. The watchdog covers the cases where that path never runs: a wedged
-/// drain, a stuck event loop, or a worker that won't terminate.
-pub async fn run(config: ShutdownConfig) -> ShutdownHandle {
+/// The watchdog is a safety net — normally `run_blocking` finishes before the
+/// deadline and the JS layer exits the process cleanly from Node's main
+/// thread. The deadline request covers a wedged drain (the host is healthy,
+/// so it can still exit normally); a host that can't exit at all (wedged
+/// event loop, stuck worker termination) is covered by the force-exit
+/// backstop that arming any exit request starts (see [`ExitCell::request`]).
+pub(crate) async fn run(config: ShutdownConfig, exit: Arc<ExitCell>) -> ShutdownHandle {
     let initiated = CancellationToken::new();
     let handle = ShutdownHandle {
         initiated: initiated.clone(),
@@ -197,15 +274,15 @@ pub async fn run(config: ShutdownConfig) -> ShutdownHandle {
         // Initiate shutdown — components stop accepting new work.
         initiated.cancel();
 
-        // Safety net: force-exit the process if shutdown takes too long.
-        // The deadline includes the keep_accepting grace period (K8s LB propagation)
-        // plus the total drain/flush time.
-        // Normally the JS layer has exited the process well before this.
+        // When the deadline is reached, request a process exit through the
+        // host's normal exit path — the same mechanism graceful completion
+        // uses (first request wins). The deadline includes the keep_accepting
+        // grace period (K8s LB propagation) plus the total drain/flush time.
+        // Normally the process has exited well before this and this request
+        // is never made.
         tokio::time::sleep(config.keep_accepting + config.total).await;
-        ::log::warn!("graceful shutdown deadline reached, forcing exit");
-        tokio::time::sleep(FORCE_EXIT_GRACE).await;
-        ::log::error!("force shutdown grace period exceeded, exiting");
-        force_exit(1);
+        ::log::warn!("graceful shutdown deadline reached, requesting process exit");
+        exit.request(1);
     });
 
     handle

--- a/runtimes/core/src/shutdown.rs
+++ b/runtimes/core/src/shutdown.rs
@@ -89,13 +89,15 @@ fn parse_k8s_grace_period(total: Duration) -> Duration {
 ///
 /// `_exit` terminates the process immediately (`exit_group(2)` on Linux) with
 /// no handlers and no destructors — exactly what we want when force-terminating
-/// with live threads. All observability data is already flushed by this point
-/// (see `run_blocking`). Known tradeoff: log lines emitted immediately before
-/// this call go through the async log writer thread (`log::writers`) and may
-/// not reach stderr before termination; the process exit code remains the
-/// authoritative shutdown signal.
+/// with live threads. On the normal path observability data is flushed before
+/// this is reached (see `run_blocking`); when the force-exit watchdog fires,
+/// shutdown is past its deadline and immediate termination takes priority.
+/// Known tradeoff: log lines emitted immediately before this call go through
+/// the async log writer thread (`log::writers`) and may not reach stderr
+/// before termination; the process exit code remains the authoritative
+/// shutdown signal.
 #[cfg(unix)]
-pub(crate) fn force_exit(code: i32) -> ! {
+pub fn force_exit(code: i32) -> ! {
     use std::io::Write;
 
     // Best-effort flush of Rust's stdio buffers (stderr is unbuffered; the
@@ -112,7 +114,7 @@ pub(crate) fn force_exit(code: i32) -> ! {
 /// against is specific to the Linux/glibc + Node + OpenSSL teardown chain that
 /// production deployments run on, and `_exit` semantics differ on Windows.
 #[cfg(not(unix))]
-pub(crate) fn force_exit(code: i32) -> ! {
+pub fn force_exit(code: i32) -> ! {
     std::process::exit(code)
 }
 
@@ -179,7 +181,9 @@ async fn wait_for_signal() {
 /// 3. Force-exits the process if the total deadline is exceeded
 ///
 /// The force exit is a safety net — normally `run_blocking` returns before
-/// the deadline, and the process exits cleanly when the tokio runtime drops.
+/// the deadline and the JS layer exits the process cleanly from Node's main
+/// thread. The watchdog covers the cases where that path never runs: a wedged
+/// drain, a stuck event loop, or a worker that won't terminate.
 pub async fn run(config: ShutdownConfig) -> ShutdownHandle {
     let initiated = CancellationToken::new();
     let handle = ShutdownHandle {
@@ -196,7 +200,7 @@ pub async fn run(config: ShutdownConfig) -> ShutdownHandle {
         // Safety net: force-exit the process if shutdown takes too long.
         // The deadline includes the keep_accepting grace period (K8s LB propagation)
         // plus the total drain/flush time.
-        // Normally run_blocking calls process::exit(0) well before this.
+        // Normally the JS layer has exited the process well before this.
         tokio::time::sleep(config.keep_accepting + config.total).await;
         ::log::warn!("graceful shutdown deadline reached, forcing exit");
         tokio::time::sleep(FORCE_EXIT_GRACE).await;

--- a/runtimes/js/encore.dev/internal/appinit/mod.ts
+++ b/runtimes/js/encore.dev/internal/appinit/mod.ts
@@ -46,17 +46,32 @@ export async function run(entrypoint: string) {
     }
 
     const metricsBuffer = initGlobalMetricsBuffer();
+    const workers: Worker[] = [];
     const extraWorkers = runtime.RT.numWorkerThreads() - 1;
     if (extraWorkers > 0) {
       const path = fileURLToPath(entrypoint);
       for (let i = 0; i < extraWorkers; i++) {
-        new Worker(path, {
-          workerData: { metricsBuffer }
-        });
+        workers.push(
+          new Worker(path, {
+            workerData: { metricsBuffer }
+          })
+        );
       }
     }
 
-    return runtime.RT.runForever();
+    // Resolves once the Rust runtime has completed graceful shutdown
+    // (drained requests and pubsub, flushed traces/metrics), with the
+    // process exit code.
+    const exitCode = await runtime.RT.runForever();
+
+    // Exit from the main thread so Node tears down through its own orderly
+    // path (stdio flush, 'exit' handlers, env teardown). Exiting from a
+    // background thread instead runs exit-time teardown concurrently with
+    // live JS threads, which segfaults. Stop worker threads first so none
+    // of them executes JS while the process exits; if a worker is wedged,
+    // the Rust-side force-exit watchdog still terminates the process.
+    await Promise.allSettled(workers.map((w) => w.terminate()));
+    process.exit(exitCode);
   }
 
   // Worker thread: set metrics buffer from workerData

--- a/runtimes/js/encore.dev/internal/appinit/mod.ts
+++ b/runtimes/js/encore.dev/internal/appinit/mod.ts
@@ -59,17 +59,25 @@ export async function run(entrypoint: string) {
       }
     }
 
-    // Resolves once the Rust runtime has completed graceful shutdown
-    // (drained requests and pubsub, flushed traces/metrics), with the
-    // process exit code.
-    const exitCode = await runtime.RT.runForever();
+    // Resolves once the Rust runtime has requested a process exit: graceful
+    // shutdown completed (drained requests and pubsub, flushed traces and
+    // metrics), the shutdown deadline was exceeded, or the runtime crashed.
+    let exitCode: number;
+    try {
+      exitCode = await runtime.RT.runForever();
+    } catch (err) {
+      console.error("encore: runtime failed while awaiting shutdown:", err);
+      exitCode = 1;
+    }
 
     // Exit from the main thread so Node tears down through its own orderly
     // path (stdio flush, 'exit' handlers, env teardown). Exiting from a
     // background thread instead runs exit-time teardown concurrently with
     // live JS threads, which segfaults. Stop worker threads first so none
-    // of them executes JS while the process exits; if a worker is wedged,
-    // the Rust-side force-exit watchdog still terminates the process.
+    // of them executes JS while the process exits; if a worker is wedged
+    // (e.g. stuck in native code, so terminate() never settles), the
+    // Rust-side backstop that armed when the exit was requested still
+    // force-terminates the process.
     await Promise.allSettled(workers.map((w) => w.terminate()));
     process.exit(exitCode);
   }

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -99,10 +99,13 @@ impl Runtime {
 
             // If we're running tests, there's no specific entrypoint so
             // start the runtime in the background immediately.
+            // Nothing awaits the exit code in test mode, so exit directly
+            // when shutdown completes (force_exit: see its docs).
             {
                 let rt = runtime.clone();
                 thread::spawn(move || {
-                    rt.run_blocking();
+                    let code = rt.run_blocking();
+                    encore_runtime_core::shutdown::force_exit(code);
                 });
             }
 
@@ -116,15 +119,24 @@ impl Runtime {
         Ok(Self { runtime })
     }
 
+    /// Runs the runtime until graceful shutdown completes, resolving with the
+    /// process exit code. The JS caller is expected to then exit the process
+    /// from Node's main thread (`process.exit(code)`), so that exit-time
+    /// teardown runs through Node's own orderly path instead of from a
+    /// background thread (which races live JS threads and segfaults; see
+    /// `shutdown::force_exit` in encore-runtime-core).
     #[napi]
-    pub async fn run_forever(&self) {
+    pub async fn run_forever(&self) -> i32 {
         let runtime = self.runtime.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
         thread::spawn(move || {
-            runtime.run_blocking();
+            let code = runtime.run_blocking();
+            let _ = tx.send(code);
         });
 
-        // Block the async function forever.
-        futures::future::pending::<()>().await;
+        // Resolves only when graceful shutdown has completed. If the runtime
+        // thread panicked (sender dropped), report failure.
+        rx.await.unwrap_or(1)
     }
 
     #[napi]

--- a/runtimes/js/src/runtime.rs
+++ b/runtimes/js/src/runtime.rs
@@ -119,24 +119,23 @@ impl Runtime {
         Ok(Self { runtime })
     }
 
-    /// Runs the runtime until graceful shutdown completes, resolving with the
-    /// process exit code. The JS caller is expected to then exit the process
-    /// from Node's main thread (`process.exit(code)`), so that exit-time
-    /// teardown runs through Node's own orderly path instead of from a
-    /// background thread (which races live JS threads and segfaults; see
-    /// `shutdown::force_exit` in encore-runtime-core).
+    /// Runs the runtime until a process exit code is requested — by graceful
+    /// shutdown completing, or by the force-exit watchdog reaching its
+    /// deadline with shutdown still in progress. The JS caller is expected to
+    /// then exit the process from Node's main thread (`process.exit(code)`),
+    /// so that exit-time teardown runs through Node's own orderly path
+    /// instead of from a background thread (which races live JS threads and
+    /// segfaults; see `shutdown::force_exit` in encore-runtime-core).
     #[napi]
     pub async fn run_forever(&self) -> i32 {
         let runtime = self.runtime.clone();
-        let (tx, rx) = tokio::sync::oneshot::channel::<i32>();
         thread::spawn(move || {
-            let code = runtime.run_blocking();
-            let _ = tx.send(code);
+            // Requests the exit code on completion, converting panics to
+            // exit code 1, so wait_for_exit_code below always resolves.
+            let _ = runtime.run_blocking();
         });
 
-        // Resolves only when graceful shutdown has completed. If the runtime
-        // thread panicked (sender dropped), report failure.
-        rx.await.unwrap_or(1)
+        self.runtime.wait_for_exit_code().await
     }
 
     #[napi]


### PR DESCRIPTION
The runtime ended graceful shutdown by calling exit() from a background thread, running the atexit/teardown chain (Node's OPENSSL_cleanup, V8 teardown) while Node's threads were still live crashing most shutdowns under load. The runtime now hands the exit code to JS, which exits from Node's main thread through its orderly teardown. Any exit request also arms a libc _exit backstop so a wedged drain, event loop, or worker can never keep the process alive past the shutdown deadline.