### PR TITLE
ci: update deprecated GitHub Actions to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
           path: encr.dev
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "encr.dev/go.mod"
           check-latest: true
@@ -48,10 +48,10 @@ jobs:
           path: encr.dev
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "encr.dev/go.mod"
           check-latest: true
@@ -66,7 +66,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
@@ -133,10 +133,10 @@ jobs:
           path: encr.dev
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "encr.dev/go.mod"
           check-latest: true
@@ -151,7 +151,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
@@ -231,7 +231,7 @@ jobs:
           python3 -m pip install --upgrade requests
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           cache: false
@@ -258,7 +258,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |
@@ -284,7 +284,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
       - name: Install deps
@@ -315,7 +315,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         continue-on-error: false
         with:
           path: |

--- a/.github/workflows/release-2.yml
+++ b/.github/workflows/release-2.yml
@@ -30,31 +30,31 @@ jobs:
           go run ./pkg/encorebuild/cmd/make-release/ -dst "${{ github.workspace	}}/build" -v "${{ github.event.inputs.version }}" -publish-npm=true
 
       - name: Publish artifact (darwin_amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-darwin_amd64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-darwin_amd64.tar.gz
 
       - name: Publish artifact (darwin_arm64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-darwin_arm64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-darwin_arm64.tar.gz
 
       - name: Publish artifact (linux_amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-linux_amd64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-linux_amd64.tar.gz
 
       - name: Publish artifact (linux_arm64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-linux_arm64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-linux_arm64.tar.gz
 
       - name: Publish artifact (windows_amd64)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-windows_amd64
           path: ${{ github.workspace }}/build/artifacts/encore-${{ github.event.inputs.version }}-windows_amd64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           path: encr.dev
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "encr.dev/go.mod"
           check-latest: true
@@ -75,7 +75,7 @@ jobs:
       - name: "Tar artifacts"
         run: tar -czvf encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz -C encr.dev/dist/${{ matrix.goos }}_${{ matrix.goarch }} .
       - name: Publish artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}
           path: encore-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
@@ -93,9 +93,10 @@ jobs:
         with:
           sparse-checkout: .github
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: .github/dockerimg/artifacts
+          merge-multiple: true
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -106,7 +107,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
## What

Bumps the GitHub Actions across the CI and release workflows to their current major versions:

- `actions/setup-node@v3 → v4`
- `actions/setup-go@v4 → v5`
- `actions/cache@v3 → v4` (and `@v2 → v4` in `release.yml`)
- `actions/upload-artifact@v3 → v4`
- `actions/download-artifact@v3 → v4`

## Why

- The `@v3` artifact actions were **deprecated and shut down by GitHub** (the v3 artifact backend closed in 2025) — any workflow still on `upload-artifact@v3` / `download-artifact@v3` fails.
- `setup-node@v3`, `setup-go@v4` and `cache@v3` run on the **Node 20 runtime**, which GitHub is migrating off; the current majors keep the runners on a supported runtime.

## Care taken

- `upload-artifact@v4` requires **unique artifact names** within a run. Verified all upload steps (in `release-2.yml` and the matrix build in `release.yml`) already use unique per-OS/arch names — no collisions.
- `download-artifact@v4` changes the default layout when downloading **all** artifacts (one sub-dir per artifact instead of a flat merge). The "Download Artifacts" step in `release.yml` pulls all artifacts into one path for the Docker build, so I added `merge-multiple: true` to preserve the flat structure.

YAML validated locally; no other changes.
