### PR TITLE
fix(db): clarify error message when invalid environment name is passed to db shell

### DIFF
--- a/cli/cmd/encore/db.go
+++ b/cli/cmd/encore/db.go
@@ -138,8 +138,15 @@ when using tools like Prisma.
 			Namespace:   nonZeroPtr(nsName),
 			Role:        getDBRole(),
 		})
-		if err != nil {
-			fatalf("could not connect to db  %s: %v", dbName, err)
+		if err != nil { // if there is an error
+			st , ok :=status.FromError(err) // we check the error statud what kind of erro and where is it coming from
+			if ok && st.Code()== codes.NotFound{ // IF THE gRPC daemon status (st) is equals to NOT FOUND and 
+			// the ok (boolean) returns true
+			fatalf("Environment %q not found you can check your environment name and try again ",dbEnv) 
+			// now it shows where the exact error is coming from instead of wrongly pointing to the databse 
+
+			}
+			fatalf("could not connect to database %q in environment %q: %v", dbName, dbEnv, err) //HEY 
 		}
 
 		// If we have the psql binary, use that.


### PR DESCRIPTION
## Problem
When an incorrect environment name is passed via `--env` to `encore db shell`, 
the CLI returns a misleading error message blaming the database name instead of 
the environment name.

For example, passing `--env stagng` (typo) would produce:
    could not connect to db myapp: environment not found

This incorrectly implies the database is missing when the real problem 
is the environment name.

## Fix
Check the gRPC status code returned by the daemon. When `codes.NotFound` 
is returned, report that the environment name was not found instead of 
the database, and suggest the correct usage.

The fallback error message now also includes both the database name and 
environment name for full context.

Fixes #2252