### PR TITLE
dockerbuild: exclude volatile pnpm metadata from the deps layer

### DIFF
--- a/pkg/dockerbuild/dockerbuild_test.go
+++ b/pkg/dockerbuild/dockerbuild_test.go
@@ -24,6 +24,11 @@ func testImageConfig(c *qt.C) (DescribeConfig, HostPath) {
 		"entrypoint":       "echo hello",
 		"package.json":     `{"name": "package/name"}`,
 		"node_modules/foo": "foo",
+		// pnpm bookkeeping files that must be excluded from the deps layer so
+		// its digest stays stable across installs. See pnpm#9474.
+		"node_modules/.modules.yaml":                 "prunedAt: Mon, 01 Jan 2024 00:00:00 GMT\n",
+		"node_modules/.pnpm-workspace-state.json":    `{"lastValidatedTimestamp":1}`,
+		"node_modules/.pnpm-workspace-state-v1.json": `{"lastValidatedTimestamp":1}`,
 	})
 	runtimes := paths.FS(c.TempDir())
 	writeFiles(c, runtimes, map[string]string{
@@ -144,6 +149,54 @@ func TestBuildImage_ReproducibleLayers(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(secondDigest, qt.Equals, firstDigest, qt.Commentf("layer %d digest differs", i))
 	}
+}
+
+// TestBuildImage_DeterministicDepsLayerAcrossInstalls verifies that two installs
+// producing identical dependencies but a different pnpm prunedAt timestamp in
+// node_modules/.modules.yaml yield the same dependency-layer digest, so the
+// (largest) node_modules layer is not needlessly re-pushed and re-pulled on every
+// deploy. See https://github.com/pnpm/pnpm/issues/9474.
+func TestBuildImage_DeterministicDepsLayerAcrossInstalls(t *testing.T) {
+	c := qt.New(t)
+	cfg, supervisorPath := testImageConfig(c)
+
+	source, ok := cfg.BundleSource.Get()
+	c.Assert(ok, qt.IsTrue)
+	modulesYAML := filepath.Join(string(source.Source), "node_modules", ".modules.yaml")
+
+	ctx := context.Background()
+	depsDigest := func() string {
+		spec, err := describe(cfg)
+		c.Assert(err, qt.IsNil)
+		img, err := BuildImage(ctx, spec, ImageBuildConfig{
+			BuildTime:      time.Unix(1234567890, 0),
+			SupervisorPath: option.Some(supervisorPath),
+		})
+		c.Assert(err, qt.IsNil)
+		layers, err := img.Layers()
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(layers), qt.Equals, 4)
+
+		// Layer index 1 is the dependency (node_modules) layer; the volatile
+		// bookkeeping files must be excluded from it.
+		deps := layers[1]
+		c.Assert(layerEntryNames(c, deps), qt.DeepEquals, []string{
+			"workspace/",
+			"workspace/node_modules/",
+			"workspace/node_modules/foo",
+		})
+		digest, err := deps.Digest()
+		c.Assert(err, qt.IsNil)
+		return digest.String()
+	}
+
+	c.Assert(os.WriteFile(modulesYAML, []byte("prunedAt: Mon, 01 Jan 2024 00:00:00 GMT\n"), 0644), qt.IsNil)
+	first := depsDigest()
+
+	c.Assert(os.WriteFile(modulesYAML, []byte("prunedAt: Tue, 02 Jul 2030 12:34:56 GMT\n"), 0644), qt.IsNil)
+	second := depsDigest()
+
+	c.Assert(second, qt.Equals, first, qt.Commentf("deps layer digest changed when only .modules.yaml content changed"))
 }
 
 func layerEntryNames(c *qt.C, layer v1.Layer) []string {

--- a/pkg/dockerbuild/dockerbuild_test.go
+++ b/pkg/dockerbuild/dockerbuild_test.go
@@ -24,8 +24,7 @@ func testImageConfig(c *qt.C) (DescribeConfig, HostPath) {
 		"entrypoint":       "echo hello",
 		"package.json":     `{"name": "package/name"}`,
 		"node_modules/foo": "foo",
-		// pnpm bookkeeping files that must be excluded from the deps layer so
-		// its digest stays stable across installs. See pnpm#9474.
+		// Volatile pnpm bookkeeping files; must not end up in any layer.
 		"node_modules/.modules.yaml":                 "prunedAt: Mon, 01 Jan 2024 00:00:00 GMT\n",
 		"node_modules/.pnpm-workspace-state.json":    `{"lastValidatedTimestamp":1}`,
 		"node_modules/.pnpm-workspace-state-v1.json": `{"lastValidatedTimestamp":1}`,
@@ -149,54 +148,6 @@ func TestBuildImage_ReproducibleLayers(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(secondDigest, qt.Equals, firstDigest, qt.Commentf("layer %d digest differs", i))
 	}
-}
-
-// TestBuildImage_DeterministicDepsLayerAcrossInstalls verifies that two installs
-// producing identical dependencies but a different pnpm prunedAt timestamp in
-// node_modules/.modules.yaml yield the same dependency-layer digest, so the
-// (largest) node_modules layer is not needlessly re-pushed and re-pulled on every
-// deploy. See https://github.com/pnpm/pnpm/issues/9474.
-func TestBuildImage_DeterministicDepsLayerAcrossInstalls(t *testing.T) {
-	c := qt.New(t)
-	cfg, supervisorPath := testImageConfig(c)
-
-	source, ok := cfg.BundleSource.Get()
-	c.Assert(ok, qt.IsTrue)
-	modulesYAML := filepath.Join(string(source.Source), "node_modules", ".modules.yaml")
-
-	ctx := context.Background()
-	depsDigest := func() string {
-		spec, err := describe(cfg)
-		c.Assert(err, qt.IsNil)
-		img, err := BuildImage(ctx, spec, ImageBuildConfig{
-			BuildTime:      time.Unix(1234567890, 0),
-			SupervisorPath: option.Some(supervisorPath),
-		})
-		c.Assert(err, qt.IsNil)
-		layers, err := img.Layers()
-		c.Assert(err, qt.IsNil)
-		c.Assert(len(layers), qt.Equals, 4)
-
-		// Layer index 1 is the dependency (node_modules) layer; the volatile
-		// bookkeeping files must be excluded from it.
-		deps := layers[1]
-		c.Assert(layerEntryNames(c, deps), qt.DeepEquals, []string{
-			"workspace/",
-			"workspace/node_modules/",
-			"workspace/node_modules/foo",
-		})
-		digest, err := deps.Digest()
-		c.Assert(err, qt.IsNil)
-		return digest.String()
-	}
-
-	c.Assert(os.WriteFile(modulesYAML, []byte("prunedAt: Mon, 01 Jan 2024 00:00:00 GMT\n"), 0644), qt.IsNil)
-	first := depsDigest()
-
-	c.Assert(os.WriteFile(modulesYAML, []byte("prunedAt: Tue, 02 Jul 2030 12:34:56 GMT\n"), 0644), qt.IsNil)
-	second := depsDigest()
-
-	c.Assert(second, qt.Equals, first, qt.Commentf("deps layer digest changed when only .modules.yaml content changed"))
 }
 
 func layerEntryNames(c *qt.C, layer v1.Layer) []string {

--- a/pkg/dockerbuild/tarcopy.go
+++ b/pkg/dockerbuild/tarcopy.go
@@ -208,6 +208,32 @@ func nodeModulesPath(relPath HostPath) (within, isRoot bool) {
 	return false, false
 }
 
+// volatilePnpmMetadata are pnpm bookkeeping files written directly inside a
+// node_modules directory whose contents change on every install even when the
+// installed dependencies are identical: pnpm records a prunedAt timestamp in
+// .modules.yaml and a lastValidatedTimestamp in .pnpm-workspace-state-v1.json.
+// They are not read at runtime, and including them gives the dependency layer a
+// new digest each build. That defeats layer caching, so the whole node_modules
+// layer is re-pushed and re-pulled on every deploy.
+// See https://github.com/pnpm/pnpm/issues/9474.
+var volatilePnpmMetadata = map[string]bool{
+	".modules.yaml":                 true, // volatile prunedAt + machine-specific storeDir
+	".pnpm-workspace-state.json":    true, // older pnpm: lastValidatedTimestamp
+	".pnpm-workspace-state-v1.json": true, // current pnpm: lastValidatedTimestamp
+}
+
+// isVolatilePnpmMetadata reports whether relPath is a volatilePnpmMetadata file
+// located directly inside a node_modules directory (so a coincidentally-named
+// file shipped deep inside a package is not skipped).
+func isVolatilePnpmMetadata(relPath HostPath) bool {
+	components := strings.Split(string(relPath.ToUnix()), "/")
+	n := len(components)
+	if n < 2 {
+		return false
+	}
+	return components[n-2] == "node_modules" && volatilePnpmMetadata[components[n-1]]
+}
+
 // shouldInclude returns true if the path should be included in the tar.
 func shouldInclude(desc *dirCopyDesc, path HostPath) bool {
 	for _, include := range desc.IncludeSrcPaths {
@@ -256,6 +282,14 @@ func (tc *tarCopier) CopyDir(desc *dirCopyDesc) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+
+		// Skip volatile pnpm bookkeeping files so the dependency layer digest
+		// stays stable across installs. See volatilePnpmMetadata and
+		// https://github.com/pnpm/pnpm/issues/9474.
+		if !d.IsDir() && isVolatilePnpmMetadata(relPath) {
+			return nil
+		}
+
 		dstPath := desc.DstPath.Join(string(relPath.ToImage()))
 
 		// Route node_modules trees to the dependency layer's copier, if configured.

--- a/pkg/dockerbuild/tarcopy.go
+++ b/pkg/dockerbuild/tarcopy.go
@@ -209,29 +209,22 @@ func nodeModulesPath(relPath HostPath) (within, isRoot bool) {
 }
 
 // volatilePnpmMetadata are pnpm bookkeeping files written directly inside a
-// node_modules directory whose contents change on every install even when the
-// installed dependencies are identical: pnpm records a prunedAt timestamp in
-// .modules.yaml and a lastValidatedTimestamp in .pnpm-workspace-state-v1.json.
-// They are not read at runtime, and including them gives the dependency layer a
-// new digest each build. That defeats layer caching, so the whole node_modules
-// layer is re-pushed and re-pulled on every deploy.
+// node_modules directory. pnpm records timestamps in them, so their contents
+// change on every install even when the dependencies are identical, giving the
+// dependency layer a new digest on every build. They aren't read at runtime.
 // See https://github.com/pnpm/pnpm/issues/9474.
 var volatilePnpmMetadata = map[string]bool{
-	".modules.yaml":                 true, // volatile prunedAt + machine-specific storeDir
-	".pnpm-workspace-state.json":    true, // older pnpm: lastValidatedTimestamp
-	".pnpm-workspace-state-v1.json": true, // current pnpm: lastValidatedTimestamp
+	".modules.yaml":                 true,
+	".pnpm-workspace-state.json":    true, // older pnpm
+	".pnpm-workspace-state-v1.json": true,
 }
 
 // isVolatilePnpmMetadata reports whether relPath is a volatilePnpmMetadata file
-// located directly inside a node_modules directory (so a coincidentally-named
-// file shipped deep inside a package is not skipped).
+// directly inside a node_modules directory, so a coincidentally-named file
+// shipped deep inside a package isn't skipped.
 func isVolatilePnpmMetadata(relPath HostPath) bool {
-	components := strings.Split(string(relPath.ToUnix()), "/")
-	n := len(components)
-	if n < 2 {
-		return false
-	}
-	return components[n-2] == "node_modules" && volatilePnpmMetadata[components[n-1]]
+	s := string(relPath)
+	return volatilePnpmMetadata[filepath.Base(s)] && filepath.Base(filepath.Dir(s)) == "node_modules"
 }
 
 // shouldInclude returns true if the path should be included in the tar.
@@ -283,9 +276,7 @@ func (tc *tarCopier) CopyDir(desc *dirCopyDesc) error {
 			return errors.WithStack(err)
 		}
 
-		// Skip volatile pnpm bookkeeping files so the dependency layer digest
-		// stays stable across installs. See volatilePnpmMetadata and
-		// https://github.com/pnpm/pnpm/issues/9474.
+		// Skip volatile pnpm bookkeeping files; see volatilePnpmMetadata.
 		if !d.IsDir() && isVolatilePnpmMetadata(relPath) {
 			return nil
 		}

--- a/pkg/dockerbuild/tarcopy_test.go
+++ b/pkg/dockerbuild/tarcopy_test.go
@@ -116,6 +116,39 @@ func TestNodeModulesPath(t *testing.T) {
 	}
 }
 
+func TestIsVolatilePnpmMetadata(t *testing.T) {
+	tests := []struct {
+		path HostPath
+		want bool
+	}{
+		// Volatile pnpm bookkeeping files directly inside a node_modules dir.
+		{"node_modules/.modules.yaml", true},
+		{"node_modules/.pnpm-workspace-state.json", true},
+		{"node_modules/.pnpm-workspace-state-v1.json", true},
+		{"app/node_modules/.modules.yaml", true},
+		// Nested node_modules roots (e.g. pnpm virtual store) are still caught.
+		{"node_modules/.pnpm/pkg@1.0.0/node_modules/.modules.yaml", true},
+		// Not directly under node_modules -> a package may legitimately ship
+		// a coincidentally-named file deep inside it; must not be skipped.
+		{"node_modules/pkg/fixtures/.modules.yaml", false},
+		{"node_modules/pkg/.modules.yaml", false},
+		// At the workspace root (no node_modules parent) -> keep.
+		{".modules.yaml", false},
+		// Regular dependency files -> keep.
+		{"node_modules/foo", false},
+		{"node_modules/pkg/index.js", false},
+		// Not in the denylist -> keep.
+		{"node_modules/package.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.path), func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(isVolatilePnpmMetadata(tt.path), qt.Equals, tt.want)
+		})
+	}
+}
+
 func TestMkdirAll_OrderingInvariant(t *testing.T) {
 	c := qt.New(t)
 	tc := newTarCopier()

--- a/pkg/dockerbuild/tarcopy_test.go
+++ b/pkg/dockerbuild/tarcopy_test.go
@@ -121,23 +121,18 @@ func TestIsVolatilePnpmMetadata(t *testing.T) {
 		path HostPath
 		want bool
 	}{
-		// Volatile pnpm bookkeeping files directly inside a node_modules dir.
+		// Directly inside a node_modules dir, including nested ones.
 		{"node_modules/.modules.yaml", true},
 		{"node_modules/.pnpm-workspace-state.json", true},
 		{"node_modules/.pnpm-workspace-state-v1.json", true},
 		{"app/node_modules/.modules.yaml", true},
-		// Nested node_modules roots (e.g. pnpm virtual store) are still caught.
 		{"node_modules/.pnpm/pkg@1.0.0/node_modules/.modules.yaml", true},
-		// Not directly under node_modules -> a package may legitimately ship
-		// a coincidentally-named file deep inside it; must not be skipped.
+		// A package may legitimately ship a coincidentally-named file.
 		{"node_modules/pkg/fixtures/.modules.yaml", false},
 		{"node_modules/pkg/.modules.yaml", false},
-		// At the workspace root (no node_modules parent) -> keep.
 		{".modules.yaml", false},
-		// Regular dependency files -> keep.
 		{"node_modules/foo", false},
 		{"node_modules/pkg/index.js", false},
-		// Not in the denylist -> keep.
 		{"node_modules/package.json", false},
 	}
 


### PR DESCRIPTION
## What

pnpm writes bookkeeping files into `node_modules` whose contents change on every install even when the installed dependency set is identical:

- `node_modules/.modules.yaml` records a `prunedAt` timestamp (and a machine-specific `storeDir`)
- `node_modules/.pnpm-workspace-state-v1.json` records a `lastValidatedTimestamp`

This change skips those files when building the image so the dependency layer's digest stays stable across installs.

## Why

Since #2483 the image is split into layers by change frequency, with `node_modules` in its own dependency layer so that "unchanged layers keep identical digests across builds and can be skipped when pushing and pulling images". For pnpm apps that benefit never materialises: because `.modules.yaml` changes on every install, the dependency layer gets a new digest on every build, so the whole `node_modules` layer is re-uploaded on `--push` and re-pulled on deploy even when nothing changed. For large pnpm trees this dominates deploy time.

These files are written directly inside a `node_modules` directory and are only consumed by the package manager during a later install; nothing reads them at runtime. Dropping them from the image makes the dependency layer reproducible across installs without affecting the running app, which is the same rationale as the existing always-on `.git` exclusion.

## How

`CopyDir` skips a small denylist of pnpm metadata files, matched only when they sit directly inside a `node_modules` directory, so a coincidentally-named file shipped deep inside a package is left untouched:

- `.modules.yaml`, `.pnpm-workspace-state.json`, `.pnpm-workspace-state-v1.json`

## Tests

- `TestBuildImage` fixture now includes the pnpm metadata files and asserts they are absent from the dependency layer.
- `TestBuildImage_DeterministicDepsLayerAcrossInstalls` builds twice with differing `.modules.yaml` content and asserts the dependency layer digest is identical. It extends `TestBuildImage_ReproducibleLayers`, which only varied the build time.
- `TestIsVolatilePnpmMetadata` covers the path matching, including the immediate-parent guard.

Context: https://github.com/pnpm/pnpm/issues/9474, https://github.com/pnpm/pnpm/issues/11669
