### PR TITLE
fix: stop leaking unexported Go types into generated API specs

### DIFF
--- a/pkg/clientgen/testdata/goapp/expected_golang.go
+++ b/pkg/clientgen/testdata/goapp/expected_golang.go
@@ -291,6 +291,13 @@ type SvcResponseWithSingleSetCookie struct {
 	SetCookie string `header:"set-cookie"` // single set-cookie header value
 }
 
+// StatusResponse tests that unexported types in exported struct fields
+// are resolved inline rather than leaked as named schema components.
+type SvcStatusResponse struct {
+	Status  int
+	Message string
+}
+
 // Tuple is a generic type which allows us to
 // return two values of two different types
 type SvcTuple[A any, B any] struct {
@@ -320,6 +327,7 @@ type SvcClient interface {
 	FallbackPath(ctx context.Context, a string, b []string) error
 	Get(ctx context.Context, params SvcGetRequest) error
 	GetRequestWithAllInputTypes(ctx context.Context, params SvcAllInputTypes[int]) (SvcHeaderOnlyStruct, error)
+	GetStatus(ctx context.Context) (SvcStatusResponse, error)
 	HeaderOnlyRequest(ctx context.Context, params SvcHeaderOnlyStruct) error
 	Nested(ctx context.Context, params SvcWithNested) (SvcWithNested, error)
 	RESTPath(ctx context.Context, a string, b int) error
@@ -446,6 +454,16 @@ func (c *svcClient) GetRequestWithAllInputTypes(ctx context.Context, params SvcA
 
 	if respDecoder.LastError != nil {
 		err = fmt.Errorf("unable to unmarshal headers: %w", respDecoder.LastError)
+		return
+	}
+
+	return
+}
+
+func (c *svcClient) GetStatus(ctx context.Context) (resp SvcStatusResponse, err error) {
+	// Now make the actual call to the API
+	_, err = callAPI(ctx, c.base, "GET", "/svc.GetStatus", nil, nil, &resp)
+	if err != nil {
 		return
 	}
 

--- a/pkg/clientgen/testdata/goapp/expected_javascript.js
+++ b/pkg/clientgen/testdata/goapp/expected_javascript.js
@@ -105,6 +105,7 @@ class SvcServiceClient {
         this.FallbackPath = this.FallbackPath.bind(this)
         this.Get = this.Get.bind(this)
         this.GetRequestWithAllInputTypes = this.GetRequestWithAllInputTypes.bind(this)
+        this.GetStatus = this.GetStatus.bind(this)
         this.HeaderOnlyRequest = this.HeaderOnlyRequest.bind(this)
         this.Nested = this.Nested.bind(this)
         this.RESTPath = this.RESTPath.bind(this)
@@ -191,6 +192,12 @@ class SvcServiceClient {
         rtn.UserID = mustBeSet("Header `x-user-id`", resp.headers.get("x-user-id"))
         rtn.Optional = resp.headers.get("x-optional")
         return rtn
+    }
+
+    async GetStatus() {
+        // Now make the actual call to the API
+        const resp = await this.baseClient.callTypedAPI("GET", `/svc.GetStatus`)
+        return await resp.json()
     }
 
     async HeaderOnlyRequest(params) {

--- a/pkg/clientgen/testdata/goapp/expected_openapi.json
+++ b/pkg/clientgen/testdata/goapp/expected_openapi.json
@@ -926,6 +926,39 @@
         }
       }
     },
+    "/svc.GetStatus": {
+      "get": {
+        "operationId": "GET:svc.GetStatus",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "Message": {
+                      "type": "string"
+                    },
+                    "Status": {
+                      "format": "int64",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "Status",
+                    "Message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success response"
+          },
+          "default": {
+            "$ref": "#/components/responses/APIError"
+          }
+        }
+      }
+    },
     "/svc.HeaderOnlyRequest": {
       "get": {
         "operationId": "GET:svc.HeaderOnlyRequest",

--- a/pkg/clientgen/testdata/goapp/expected_typescript.ts
+++ b/pkg/clientgen/testdata/goapp/expected_typescript.ts
@@ -330,6 +330,15 @@ export namespace svc {
     }
 
     /**
+     * StatusResponse tests that unexported types in exported struct fields
+     * are resolved inline rather than leaked as named schema components.
+     */
+    export interface StatusResponse {
+        Status: number
+        Message: string
+    }
+
+    /**
      * Tuple is a generic type which allows us to
      * return two values of two different types
      */
@@ -358,6 +367,7 @@ export namespace svc {
             this.FallbackPath = this.FallbackPath.bind(this)
             this.Get = this.Get.bind(this)
             this.GetRequestWithAllInputTypes = this.GetRequestWithAllInputTypes.bind(this)
+            this.GetStatus = this.GetStatus.bind(this)
             this.HeaderOnlyRequest = this.HeaderOnlyRequest.bind(this)
             this.Nested = this.Nested.bind(this)
             this.RESTPath = this.RESTPath.bind(this)
@@ -444,6 +454,12 @@ export namespace svc {
             rtn.UserID = mustBeSet("Header `x-user-id`", resp.headers.get("x-user-id"))
             rtn.Optional = mustBeSet("Header `x-optional`", resp.headers.get("x-optional"))
             return rtn
+        }
+
+        public async GetStatus(): Promise<StatusResponse> {
+            // Now make the actual call to the API
+            const resp = await this.baseClient.callTypedAPI("GET", `/svc.GetStatus`)
+            return await resp.json() as StatusResponse
         }
 
         public async HeaderOnlyRequest(params: HeaderOnlyStruct): Promise<void> {

--- a/pkg/clientgen/testdata/goapp/input.go
+++ b/pkg/clientgen/testdata/goapp/input.go
@@ -130,6 +130,22 @@ type Recursive struct {
     MapOfOptional map[string]option.Option[*Recursive]
 }
 
+// internalStatus is an unexported type used in exported struct fields.
+// It should NOT appear in the generated OpenAPI spec.
+type internalStatus int
+
+const (
+	statusOK    internalStatus = iota
+	statusError
+)
+
+// StatusResponse tests that unexported types in exported struct fields
+// are resolved inline rather than leaked as named schema components.
+type StatusResponse struct {
+	Status  internalStatus
+	Message string
+}
+
 -- svc/api.go --
 package svc
 
@@ -214,6 +230,11 @@ func Rec(ctx context.Context, req *Recursive) (*Recursive, error) {
 //encore:api public method=POST
 func CreateDocumentedOrder(ctx context.Context, req *DocumentedOrder) (*DocumentedOrder, error) {
     return req, nil
+}
+
+//encore:api public method=GET
+func GetStatus(ctx context.Context) (*StatusResponse, error) {
+    return &StatusResponse{Status: statusOK, Message: "ok"}, nil
 }
 -- svc/nested/nested.go --
 package nested

--- a/v2/app/legacymeta/schema.go
+++ b/v2/app/legacymeta/schema.go
@@ -76,6 +76,12 @@ func (b *builder) schemaType(typ schemav2.Type) *schema.Type {
 		if typ.DeclInfo.File.Pkg.ImportPath == "encore.dev/config" {
 			return b.configValue(typ)
 		}
+		// If the named type is unexported, resolve to its underlying type
+		// instead of exposing it as a named declaration.
+		if !ast.IsExported(typ.DeclInfo.Name) {
+			resolved := schemautil.ConcretizeWithTypeArgs(b.errs, typ.Decl().Type, typ.TypeArgs)
+			return b.schemaType(resolved)
+		}
 		return &schema.Type{Typ: &schema.Type_Named{
 			Named: &schema.Named{
 				Id:            b.decl(typ.Decl()),
@@ -86,13 +92,11 @@ func (b *builder) schemaType(typ schemav2.Type) *schema.Type {
 	case schemav2.StructType:
 		var fields []*schema.Field
 		for _, f := range typ.Fields {
-			if f.IsAnonymous() {
-				continue // not supported by meta
+			if f.IsAnonymous() || !f.IsExported() {
+				continue // not supported by meta, or unexported
 			}
 			field := b.structField(f)
-			if f.IsExported() { // to match legacy meta behavior
-				fields = append(fields, field)
-			}
+			fields = append(fields, field)
 		}
 
 		return &schema.Type{Typ: &schema.Type_Struct{


### PR DESCRIPTION
Stop leaking unexported Go types into OpenAPI and client specs. Unexported Go types (lowercase names) are package-private and not part of any API contract, yet the schema builder was registering them in the declarations map whenever they appeared in exported struct fields. The fix skips the type-walk for unexported struct fields entirely, and resolves unexported named types inline to their underlying type instead of exposing them as named schema components.