### PR TITLE
Improve local dashboard handling of Git worktrees

### DIFF
--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -227,6 +227,15 @@ func (mgr *Manager) resolve(appRoot string) (*Instance, error) {
 	defer mgr.instanceMu.Unlock()
 
 	if existing, ok := mgr.instances[appRoot]; ok {
+		if _, err := os.Stat(filepath.Join(appRoot, appfile.Name)); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				delete(mgr.instances, appRoot)
+				if closeErr := existing.Close(); closeErr != nil {
+					log.Error().Err(closeErr).Str("root", appRoot).Msg("unable to close missing app instance")
+				}
+			}
+			return nil, err
+		}
 		return existing, nil
 	}
 

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -282,10 +282,11 @@ func (mgr *Manager) Close() error {
 
 // Instance describes an app instance known by the Encore daemon.
 type Instance struct {
-	root       string
-	localID    string
-	platformID *goldfish.Cache[string]
-	tutorial   string
+	root          string
+	localID       string
+	platformID    *goldfish.Cache[string]
+	workspaceName string
+	tutorial      string
 
 	// mgr is a reference to the manager that created it.
 	// It may be nil if an instance was created without a manager.
@@ -303,9 +304,10 @@ type Instance struct {
 
 func NewInstance(root, localID, platformID string) *Instance {
 	i := &Instance{
-		root:     root,
-		localID:  localID,
-		watchers: make(map[WatchSubscriptionID]*watchSubscription),
+		root:          root,
+		localID:       localID,
+		workspaceName: findWorkspaceName(root),
+		watchers:      make(map[WatchSubscriptionID]*watchSubscription),
 	}
 	i.platformID = goldfish.New[string](1*time.Second, i.fetchPlatformID)
 	if platformID != "" {
@@ -321,6 +323,10 @@ func (i *Instance) Tutorial() string {
 // Root returns the filesystem path for the app root.
 // It always returns a non-empty string.
 func (i *Instance) Root() string { return i.root }
+
+// WorkspaceName returns "primary" for a repository's primary checkout and
+// the worktree directory name for a linked Git worktree.
+func (i *Instance) WorkspaceName() string { return i.workspaceName }
 
 // LocalID reports a local, random id unique for this app,
 // as persisted in the .encore/manifest.json file.
@@ -350,6 +356,24 @@ func (i *Instance) Name() string {
 	}
 
 	return filepath.Base(i.root)
+}
+
+func findWorkspaceName(appRoot string) string {
+	dir := filepath.Clean(appRoot)
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			if info.IsDir() {
+				return "primary"
+			}
+			return filepath.Base(dir)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return filepath.Base(appRoot)
+		}
+		dir = parent
+	}
 }
 
 func (i *Instance) fetchPlatformID() (string, error) {

--- a/cli/daemon/apps/apps_test.go
+++ b/cli/daemon/apps/apps_test.go
@@ -1,0 +1,141 @@
+package apps
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"encr.dev/pkg/appfile"
+)
+
+func TestListEvictsMissingAppInstances(t *testing.T) {
+	tests := []struct {
+		name   string
+		remove func(t *testing.T, root string)
+	}{
+		{
+			name: "missing app root",
+			remove: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.RemoveAll(root); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "missing encore.app",
+			remove: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(root, appfile.Name)); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db := newTestDB(t)
+			mgr := NewManager(db)
+			t.Cleanup(func() {
+				if err := mgr.Close(); err != nil {
+					t.Errorf("close manager: %v", err)
+				}
+			})
+
+			root := t.TempDir()
+			writeTestAppFile(t, root)
+
+			instance, err := mgr.Track(root)
+			if err != nil {
+				t.Fatalf("track app: %v", err)
+			}
+			if instance.watcher == nil {
+				t.Fatal("expected app instance to have a watcher")
+			}
+
+			test.remove(t, root)
+
+			got, err := mgr.List()
+			if err != nil {
+				t.Fatalf("list apps: %v", err)
+			}
+			if len(got) != 0 {
+				t.Fatalf("got %d apps, want none", len(got))
+			}
+
+			var count int
+			if err := db.QueryRow(`SELECT COUNT(*) FROM app WHERE root = ?`, root).Scan(&count); err != nil {
+				t.Fatalf("count app rows: %v", err)
+			}
+			if count != 0 {
+				t.Fatalf("got %d persisted app rows, want none", count)
+			}
+
+			mgr.instanceMu.Lock()
+			_, cached := mgr.instances[root]
+			mgr.instanceMu.Unlock()
+			if cached {
+				t.Fatal("missing app instance remains cached")
+			}
+
+			select {
+			case <-instance.watcher.Done():
+			default:
+				t.Fatal("missing app instance watcher remains open")
+			}
+
+			writeTestAppFile(t, root)
+			retracked, err := mgr.Track(root)
+			if err != nil {
+				t.Fatalf("retrack app: %v", err)
+			}
+			if retracked == instance {
+				t.Fatal("retracked app reused evicted instance")
+			}
+		})
+	}
+}
+
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close database: %v", err)
+		}
+	})
+
+	_, err = db.Exec(`
+		CREATE TABLE app (
+			root TEXT PRIMARY KEY,
+			local_id TEXT NOT NULL,
+			platform_id TEXT NULL,
+			updated_at TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create app table: %v", err)
+	}
+
+	return db
+}
+
+func writeTestAppFile(t *testing.T, root string) {
+	t.Helper()
+
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatalf("create app root: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, appfile.Name), []byte(`{"id":"test-app"}`), 0644); err != nil {
+		t.Fatalf("write encore.app: %v", err)
+	}
+}

--- a/cli/daemon/dash/dash.go
+++ b/cli/daemon/dash/dash.go
@@ -43,6 +43,33 @@ type handler struct {
 	tr   trace2.Store
 }
 
+// appDisplayNames adds the workspace name to apps that otherwise have the same
+// display name. This commonly happens when the same linked app is used from
+// multiple Git worktrees.
+func appDisplayNames(instances []*apps.Instance) map[*apps.Instance]string {
+	nameCounts := make(map[string]int)
+	workspaceCounts := make(map[string]int)
+	for _, instance := range instances {
+		name := instance.Name()
+		nameCounts[name]++
+		workspaceCounts[name+"\x00"+instance.WorkspaceName()]++
+	}
+
+	displayNames := make(map[*apps.Instance]string, len(instances))
+	for _, instance := range instances {
+		name := instance.Name()
+		if nameCounts[name] > 1 {
+			workspaceName := instance.WorkspaceName()
+			if workspaceCounts[name+"\x00"+workspaceName] > 1 {
+				workspaceName = instance.Root()
+			}
+			name = fmt.Sprintf("%s (%s)", name, workspaceName)
+		}
+		displayNames[instance] = name
+	}
+	return displayNames
+}
+
 func (h *handler) GetMeta(appID string) (*meta.Data, error) {
 	runInstance := h.run.FindRunByAppID(appID)
 	var md *meta.Data
@@ -181,10 +208,11 @@ func (h *handler) Handle(ctx context.Context, reply jsonrpc2.Replier, r jsonrpc2
 		if err != nil {
 			return reply(ctx, nil, err)
 		}
+		displayNames := appDisplayNames(allApp)
 		for _, instance := range allApp {
 			data := app{
 				ID:      instance.PlatformOrLocalID(),
-				Name:    instance.Name(),
+				Name:    displayNames[instance],
 				AppRoot: instance.Root(),
 				Offline: true,
 			}

--- a/cli/daemon/dash/dash_test.go
+++ b/cli/daemon/dash/dash_test.go
@@ -1,11 +1,66 @@
 package dash
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	"encr.dev/cli/daemon/apps"
 	meta "encr.dev/proto/encore/parser/meta/v1"
 )
+
+func TestAppDisplayNamesDistinguishesWorktrees(t *testing.T) {
+	root := t.TempDir()
+	primaryRoot := filepath.Join(root, "project", "apps", "backend")
+	worktreeRoot := filepath.Join(root, "worktrees", "DRE-103", "apps", "backend")
+	if err := os.MkdirAll(filepath.Join(root, "project", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "worktrees", "DRE-103", ".git"), []byte("gitdir: /tmp/repo/.git/worktrees/DRE-103\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := apps.NewInstance(primaryRoot, "primary-local", "linked-app")
+	worktree := apps.NewInstance(worktreeRoot, "worktree-local", "linked-app")
+	other := apps.NewInstance(primaryRoot, "other-local", "other-app")
+	got := appDisplayNames([]*apps.Instance{primary, worktree, other})
+
+	if got[primary] != "linked-app (primary)" {
+		t.Errorf("primary display name = %q, want %q", got[primary], "linked-app (primary)")
+	}
+	if got[worktree] != "linked-app (DRE-103)" {
+		t.Errorf("worktree display name = %q, want %q", got[worktree], "linked-app (DRE-103)")
+	}
+	if got[other] != "other-app" {
+		t.Errorf("unique display name = %q, want %q", got[other], "other-app")
+	}
+}
+
+func TestAppDisplayNamesFallsBackToRoot(t *testing.T) {
+	root := t.TempDir()
+	firstRoot := filepath.Join(root, "first", "project", "apps", "backend")
+	secondRoot := filepath.Join(root, "second", "project", "apps", "backend")
+	for _, appRoot := range []string{firstRoot, secondRoot} {
+		if err := os.MkdirAll(filepath.Join(appRoot, "..", "..", ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first := apps.NewInstance(firstRoot, "first-local", "linked-app")
+	second := apps.NewInstance(secondRoot, "second-local", "linked-app")
+	got := appDisplayNames([]*apps.Instance{first, second})
+
+	if got[first] != "linked-app ("+firstRoot+")" {
+		t.Errorf("first display name = %q, want root qualifier", got[first])
+	}
+	if got[second] != "linked-app ("+secondRoot+")" {
+		t.Errorf("second display name = %q, want root qualifier", got[second])
+	}
+}
 
 func TestBuildMigrationHistory(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What

- validate cached app roots before returning them and close the watcher when encore.app has disappeared
- let the existing list cleanup remove the stale SQLite row without restarting the daemon
- disambiguate duplicate dashboard names with the nearest Git workspace, for example linked-app (primary) and linked-app (DRE-103)
- fall back to the full app root when workspace qualifiers still collide

## Why

Tracking the same linked Encore app from multiple Git worktrees creates identical entries in the local dashboard. After a worktree is deleted, Manager.List intends to prune the missing root, but resolve returns its cached instance before checking the filesystem, so the entry remains until the daemon restarts.

The shipped dashboard already renders the name returned by list-apps, so server-side qualifiers make duplicate worktree entries understandable without a frontend change.

## Example

With the same linked app tracked from a primary checkout and a DRE-103 worktree:

| Workspace | Before | After |
| --- | --- | --- |
| Primary checkout | linked-app | linked-app (primary) |
| DRE-103 worktree | linked-app | linked-app (DRE-103) |

If the DRE-103 worktree is then deleted, the next dashboard refresh removes its stale entry. With only one copy left, the remaining label returns to linked-app without a suffix.

## Validation

- go test -short -tags=dev_build ./cli/daemon/apps ./cli/daemon/dash
- go test -race ./cli/daemon/apps
- go test -tags=dev_build ./cli/daemon/...
- go vet -tags=dev_build ./cli/daemon/apps ./cli/daemon/dash

## Scope

This PR improves cleanup and visible labels. Dashboard routes still use the shared platform app ID, so reliably targeting two simultaneously running worktrees would require a separate app-instance identity and frontend change.
