### PR TITLE
parser: batch module directory resolution into a single go list

### DIFF
--- a/v2/internals/pkginfo/loader.go
+++ b/v2/internals/pkginfo/loader.go
@@ -41,6 +41,12 @@ type Loader struct {
 	modulesMu sync.Mutex
 	modules   map[paths.Mod]*Module
 
+	// moduleDirs holds the on-disk directory of every module the app depends
+	// on, populated once by loadModuleDirs. sortedModulePaths is its keys, sorted.
+	moduleDirsOnce    sync.Once
+	moduleDirs        map[paths.Mod]string
+	sortedModulePaths []paths.Mod
+
 	// parsed is a cache of parse results, guarded by parsedMu.
 	parsedMu sync.Mutex
 	parsed   map[paths.Pkg]*parseResult // importPath -> result

--- a/v2/internals/pkginfo/modresolve.go
+++ b/v2/internals/pkginfo/modresolve.go
@@ -1,10 +1,13 @@
 package pkginfo
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"go/token"
 	"io/fs"
 	"os"
+	"os/exec"
 	"slices"
 
 	"golang.org/x/mod/modfile"
@@ -73,6 +76,67 @@ func (l *Loader) loadModuleFromDisk(rootDir paths.FS, fallbackModPath paths.Mod)
 	slices.Sort(m.sortedOtherDeps)
 
 	return m
+}
+
+// buildListModuleDir returns the module that pkgPath belongs to, and that
+// module's directory on disk, looked up from the batched module list.
+func (l *Loader) buildListModuleDir(pkgPath paths.Pkg) (modPath paths.Mod, dir string, ok bool) {
+	l.moduleDirsOnce.Do(l.loadModuleDirs)
+	modPath, ok = findModule(l.sortedModulePaths, pkgPath)
+	if !ok {
+		return "", "", false
+	}
+	dir = l.moduleDirs[modPath]
+	return modPath, dir, dir != ""
+}
+
+// loadModuleDirs finds the directory of every module the app depends on,
+// using one `go list -m -e -json all` invocation.
+func (l *Loader) loadModuleDirs() {
+	l.moduleDirs = make(map[paths.Mod]string)
+
+	// -e makes go list report broken modules in its output
+	// instead of failing the whole command.
+	goBin := l.c.Build.GOROOT.Join("bin", "go").ToIO()
+	cmd := exec.CommandContext(l.c.Ctx, goBin, "list", "-m", "-e", "-json", "all")
+	cmd.Dir = l.packagesConfig.Dir
+	cmd.Env = l.packagesConfig.Env
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// Non-fatal: resolveModuleForPkg falls back to per-module packages.Load.
+		l.c.Log.Warn().Err(err).Str("stderr", stderr.String()).
+			Msg("go list -m -e -json all failed; falling back to per-module resolution")
+		return
+	}
+
+	type modError struct{ Err string }
+	type modJSON struct {
+		Path  string
+		Dir   string
+		Error *modError
+	}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var m modJSON
+		if err := dec.Decode(&m); err != nil {
+			// Keep whatever decoded cleanly.
+			l.c.Log.Warn().Err(err).Msg("failed to decode go list module output; using partial module list")
+			break
+		}
+		// Skip errored modules and any without a resolved directory.
+		if m.Error != nil || m.Path == "" || m.Dir == "" || !paths.ValidModPath(m.Path) {
+			continue
+		}
+		l.moduleDirs[paths.MustModPath(m.Path)] = m.Dir
+	}
+
+	l.sortedModulePaths = make([]paths.Mod, 0, len(l.moduleDirs))
+	for modPath := range l.moduleDirs {
+		l.sortedModulePaths = append(l.sortedModulePaths, modPath)
+	}
+	slices.Sort(l.sortedModulePaths)
 }
 
 var stdModule = paths.StdlibMod()
@@ -170,6 +234,26 @@ func (l *Loader) resolveModuleForPkg(cause token.Pos, pkgPath paths.Pkg) (result
 
 	tr := l.c.Trace("resolve module for package", "pkgPath", pkgPath)
 	defer tr.Done("result", result)
+
+	// Fast path: look up the module's directory in the batched module list
+	// instead of spawning a `go list` subprocess per module.
+	// realMod can differ from the modPath guess above: if modPath is "foo" but
+	// the package actually lives in a separate nested module "foo/bar", realMod
+	// is "foo/bar". Cache under realMod, the module the package belongs to.
+	if realMod, dir, ok := l.buildListModuleDir(pkgPath); ok {
+		l.modulesMu.Lock()
+		if cached, ok := l.modules[realMod]; ok {
+			l.modulesMu.Unlock()
+			return cached
+		}
+		l.modulesMu.Unlock()
+
+		result = l.loadModuleFromDisk(paths.RootedFSPath(dir, "."), realMod)
+		l.modulesMu.Lock()
+		defer l.modulesMu.Unlock()
+		l.modules[realMod] = result
+		return result
+	}
 
 	pkgs, err := packages.Load(l.packagesConfig, "pattern="+string(pkgPath))
 	l.c.Errs.AssertStd(err)


### PR DESCRIPTION
## Problem

On large apps, the "Building Encore application graph" phase dominates every `encore run` / `encore test` / `encore check` / `encore gen`. Profiling an app with ~1,000 Go packages showed a ~15s parse, of which **~13s went to figuring out which directory each imported module lives in**.

The parser resolves that in `(*Loader).resolveModuleForPkg` (`v2/internals/pkginfo/modresolve.go`) with one `packages.Load` call per module. Each call spawns a `go list` subprocess, and each subprocess independently reloads the entire module graph — on this app, 71 subprocesses at ~185ms each. The only thing actually consumed from each result is the module's on-disk directory (`pkg.Module.Dir`); all other module metadata is re-derived from its `go.mod` by `loadModuleFromDisk`.

The cost is also paid continuously: the daemon's file watcher re-runs the parse on every save, so background re-parses contend with whatever command is currently running.

## Fix

Fetch every build-list module's directory up front with a single `go list -m -json all`, and answer the per-module lookups from that map. The existing per-module `packages.Load` stays as a fallback for anything the batched list doesn't cover.

Measured on the same ~1,000-package app:

| | before | after |
|---|---:|---:|
| `go list` subprocesses during parse | 71 | 1 |
| time in module resolution | ~13.1s | ~0.14s |
| **total `Parser.Parse()`** | **~15.3s** | **~1.5s** |

End-to-end (fresh daemon, warm Go build cache, watcher on), the same app's `encore run` to a healthy server dropped from ~120s to ~15s, and `encore test` / `encore check` improved roughly 8–9×. A big part of the end-to-end win is reduced watcher contention: each background re-parse drops from ~13s to ~3s, so it stops colliding with the command you're actually running.

## Correctness / safety

- **Picks the same module `go list` would.** The fast path selects the providing module by Go's own rule — the build-list module with the longest path that is a prefix of the import path — using the loader's existing `findModule` helper over the *full* build list from `go list -m all`. That includes nested modules that only appear as transitive requirements, which the main module's `require` list alone wouldn't reveal. The resolved directory then feeds the unchanged `loadModuleFromDisk`, so module metadata is derived exactly as before.
- **Same environment.** The batched command runs with the same `Dir` and `Env` as the existing `packagesConfig`, so it sees identical `GOOS`/`GOARCH`/`GOFLAGS` and `replace` directives — it reports the replacement directory for `replace` targets just like `packages.Load` did (verified for both local-path and version replacements).
- **Degrades to the old behaviour, never breaks.** The command runs with `-e`, so one errored module doesn't discard the directories of the others; errored or dir-less entries are skipped and those imports fall back to the per-module `packages.Load`. If the command itself fails (stderr is logged) or its output can't be decoded, the whole fast path is skipped and behaviour is exactly as before.
- **Cancellation & concurrency.** The subprocess uses `exec.CommandContext`, so it's torn down with the parse; population is guarded by `sync.Once`, and module caching keeps using the existing `modulesMu`.

No change to which packages get parsed or how module metadata is read — only how a module's directory is discovered. Genuine module errors still surface at the subsequent `go build` step, as before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786877973&installation_id=146362377&pr_number=2516&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2516&signature=d753a1b4e6e347f9c2e3528f16a71a4bbb610ea1028aafbb15becbf808aa1495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->