### PR TITLE
fix(compiler): use CommandContext and guard CGO cross-compilation in …fix(compiler): use CommandContext and guard CGO cross-compilation in buildMain

### DIFF
--- a/v2/compiler/build/build.go
+++ b/v2/compiler/build/build.go
@@ -190,7 +190,7 @@ func (b *builder) writeModFile() {
 
 			build := b.cfg.Ctx.Build
 			goroot := build.GOROOT
-			cmd := exec.Command(goroot.Join("bin", "go"+b.exe()).ToIO(),
+			cmd := exec.CommandContext(b.ctx, goroot.Join("bin", "go"+b.exe()).ToIO(),
 				"mod", "tidy",
 				"-overlay="+overlayPath.ToIO(),
 				"-modfile="+gomodpath.ToIO(),
@@ -280,9 +280,9 @@ func (b *builder) buildMain() {
 		}
 
 		args = append(args, b.cfg.MainPkg.String())
-		
+
 		goroot := build.GOROOT
-		cmd := exec.Command(goroot.Join("bin", "go"+b.exe()).ToIO(), args...)
+		cmd := exec.CommandContext(b.ctx, goroot.Join("bin", "go"+b.exe()).ToIO(), args...)
 
 		// Copy the env before we add additional env vars
 		// to avoid accidentally sharing the same backing array.
@@ -302,6 +302,28 @@ func (b *builder) buildMain() {
 		}
 		if !build.CgoEnabled {
 			env = append(env, "CGO_ENABLED=0")
+		} else {
+			hostOS := runtime.GOOS
+			hostArch := runtime.GOARCH
+			targetOS := build.GOOS
+			targetArch := build.GOARCH
+			if targetOS == "" {
+				targetOS = hostOS
+			}
+			if targetArch == "" {
+				targetArch = hostArch
+			}
+			isCrossBuild := targetOS != hostOS || targetArch != hostArch
+			if isCrossBuild {
+				cc := cCrossCompilerName(targetOS, targetArch)
+				if _, err := exec.LookPath(cc); err != nil {
+					b.errs.Addf(token.NoPos,
+						"CGO is enabled but no C cross-compiler found for %s/%s.\n"+
+							"Install %q or disable CGO to build for this target.",
+						targetOS, targetArch, cc)
+					return
+				}
+			}
 		}
 		cmd.Env = append(os.Environ(), env...)
 		cmd.Dir = b.cfg.Ctx.MainModuleDir.ToIO()
@@ -478,4 +500,19 @@ func (b *builder) prepareWorkDir() (workdir paths.FS, temporary bool) {
 	}
 
 	return paths.RootedFSPath(work, "."), isTemp
+}
+
+// cCrossCompilerName returns the expected C cross-compiler binary name
+// for the given target OS and architecture.
+func cCrossCompilerName(goos, goarch string) string {
+	switch goos + "/" + goarch {
+	case "linux/amd64":
+		return "x86_64-linux-gnu-gcc"
+	case "linux/arm64":
+		return "aarch64-linux-gnu-gcc"
+	case "linux/arm":
+		return "arm-linux-gnueabihf-gcc"
+	default:
+		return "gcc"
+	}
 }


### PR DESCRIPTION
## Problem
When `bundle_source: true` is set in encore.app and `encore build docker` 
is run targeting a different OS/arch than the host machine, the build 
hangs indefinitely at:

    INF compiling Encore application for linux/arm64

No output, no error, no progress. The user has to wait 10+ minutes 
before killing the process manually.

Two bugs cause this:

1. `exec.Command` was used to spawn the `go build` and `go mod tidy` 
subprocesses with no context attached. This means Ctrl+C does not kill 
the subprocess — it keeps running silently regardless of cancellation.

2. When CGO is enabled during cross-compilation, `go build` needs a C 
cross-compiler for the target platform(for that specific operating system). If one (a Golang C cross compiler) is not installed on the 
host machine, `go build` hangs silently inside `cmd.CombinedOutput()` 
waiting for a tool that will never come. There was no upfront check for 
this situation.

## Fix
- Replaced `exec.Command` with `exec.CommandContext` in both `buildMain` 
and the `go mod tidy` block so context cancellation kills subprocesses 
immediately.

- Added a cross-compilation guard in `buildMain`: when CGO is enabled 
and the target OS/arch differs from the host, the required C 
cross-compiler is verified via `exec.LookPath` before `go build` is 
spawned. If not found, the build fails immediately with a clear message:

      CGO is enabled but no C cross-compiler found for linux/arm64.
      Install "aarch64-linux-gnu-gcc" or disable CGO to build for this target.

- Added `cCrossCompilerName` helper to map target OS/arch to the 
expected C cross-compiler binary name.

Fixes #2214

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787156447&installation_model_id=427204&pr_number=2517&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2517&signature=e7650cc4151cafab93266fba49132b4d9bee875be5472190f69f3416261c981b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->