### PR TITLE
mcp: Remove source tools

### DIFF
--- a/cli/daemon/mcp/src_tools.go
+++ b/cli/daemon/mcp/src_tools.go
@@ -2,10 +2,7 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -16,16 +13,6 @@ func (m *Manager) registerSrcTools() {
 	m.server.AddTool(mcp.NewTool("get_metadata",
 		mcp.WithDescription("Retrieve the complete application metadata, including service definitions, database schemas, API endpoints, and other infrastructure components. This tool provides a comprehensive view of the application's architecture and configuration."),
 	), m.getMetadata)
-
-	// Add tool handlers
-	m.server.AddTool(mcp.NewTool("get_src_files",
-		mcp.WithDescription("Retrieve the contents of one or more source files from the application. This tool is useful for examining specific parts of the codebase or understanding implementation details."),
-		mcp.WithArray("files", mcp.Items(map[string]any{
-			"type":        "string",
-			"description": "List of file paths to retrieve, relative to the application root. Each path should point to a valid source file in the project.",
-		})),
-	), m.getSrcFiles)
-
 }
 
 func (m *Manager) getMetadata(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -40,34 +27,4 @@ func (m *Manager) getMetadata(ctx context.Context, request mcp.CallToolRequest) 
 	data, err := protojson.Marshal(md)
 
 	return mcp.NewToolResultText(string(data)), nil
-}
-
-func (m *Manager) getSrcFiles(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-
-	inst, err := m.getApp(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get app: %w", err)
-	}
-
-	files, ok := request.Params.Arguments["files"].([]any)
-	if !ok || len(files) == 0 {
-		return nil, fmt.Errorf("no files provided")
-	}
-
-	rtn := map[string]string{}
-	for _, file := range files {
-		fileStr := file.(string)
-		content, err := os.ReadFile(filepath.Join(inst.Root(), fileStr))
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file: %w", err)
-		}
-		rtn[fileStr] = string(content)
-	}
-
-	jsonData, err := json.Marshal(rtn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal json: %w", err)
-	}
-
-	return mcp.NewToolResultText(string(jsonData)), nil
 }


### PR DESCRIPTION
The get_src_files tool confuses agents into using it instead of their native more efficient file access tools (which can do partial reads, greps, etc.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787246022&installation_model_id=427204&pr_number=2519&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2519&signature=2f57fde37d293aa365b4930cda973684b79e6ec6bffa645433fed4e0ccc5af65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->