### PR TITLE
[daemon] Fix unbounded memory/fd growth from eager watching, codegen-regen, and leaked runs

### DIFF
--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -244,9 +244,10 @@ func (mgr *Manager) resolve(appRoot string) (*Instance, error) {
 	i := NewInstance(appRoot, man.LocalID, platformID)
 	i.tutorial = man.Tutorial
 	i.mgr = mgr
-	if err := i.beginWatch(); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		log.Error().Err(err).Str("id", i.PlatformOrLocalID()).Msg("unable to begin watching app")
-	}
+	// Note: we deliberately don't start the file watcher here. Watching is
+	// lazy, started only via Watch() (i.e. only for apps actually running
+	// with live-reload enabled), so that commands like `encore check` and
+	// `encore run --watch=false` never hold a recursive fsnotify watch open.
 	mgr.instances[appRoot] = i
 
 	// Notify any listeners about the new app

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -174,7 +174,7 @@ func (mgr *Manager) listRoots() ([]string, error) {
 }
 
 // RegisterAppListener registers a callback that gets invoked every time
-// an app is tracked.
+// an app starts being actively watched (i.e. run with live-reload enabled).
 func (mgr *Manager) RegisterAppListener(fn func(*Instance)) {
 	mgr.instanceMu.Lock()
 	defer mgr.instanceMu.Unlock()
@@ -183,9 +183,22 @@ func (mgr *Manager) RegisterAppListener(fn func(*Instance)) {
 	mgr.appListeners = append(mgr.appListeners, fn)
 	mgr.appRegMu.Unlock()
 
-	// Call the handler for all existing apps
+	// Call the handler for all apps that are already being watched.
 	for _, inst := range mgr.instances {
-		fn(inst)
+		if inst.watcher != nil {
+			fn(inst)
+		}
+	}
+}
+
+// notifyAppListeners invokes all registered app listeners for i.
+func (mgr *Manager) notifyAppListeners(i *Instance) {
+	mgr.appRegMu.Lock()
+	listeners := mgr.appListeners
+	mgr.appRegMu.Unlock()
+
+	for _, fn := range listeners {
+		fn(i)
 	}
 }
 
@@ -244,16 +257,13 @@ func (mgr *Manager) resolve(appRoot string) (*Instance, error) {
 	i := NewInstance(appRoot, man.LocalID, platformID)
 	i.tutorial = man.Tutorial
 	i.mgr = mgr
-	// Note: we deliberately don't start the file watcher here. Watching is
-	// lazy, started only via Watch() (i.e. only for apps actually running
-	// with live-reload enabled), so that commands like `encore check` and
-	// `encore run --watch=false` never hold a recursive fsnotify watch open.
+	// Note: we deliberately don't start the file watcher (or notify app
+	// listeners) here. Both are lazy, triggered only via Watch() (i.e. only
+	// for apps actually running with live-reload enabled), so that commands
+	// like `encore check` and `encore run --watch=false` never hold a
+	// recursive fsnotify watch open, and never trigger a codegen-regen parse
+	// for apps that aren't being actively developed against.
 	mgr.instances[appRoot] = i
-
-	// Notify any listeners about the new app
-	for _, fn := range mgr.appListeners {
-		fn(i)
-	}
 
 	return i, nil
 }
@@ -481,6 +491,13 @@ func (i *Instance) beginWatch() error {
 				}
 			}
 		}()
+
+		// Now that this app is actively watched (i.e. running with
+		// live-reload), notify listeners so they can e.g. regenerate
+		// user-facing codegen and keep it fresh as files change.
+		if i.mgr != nil {
+			i.mgr.notifyAppListeners(i)
+		}
 
 		return nil
 	})

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -205,7 +205,8 @@ func (mgr *Manager) notifyAppListeners(i *Instance) {
 // WatchFunc is the signature of functions registered as app watchers.
 type WatchFunc func(*Instance, []watcher.Event)
 
-// WatchAll watches all apps for changes.
+// WatchAll registers fn to receive change events from every app that is
+// being actively watched, now or in the future.
 func (mgr *Manager) WatchAll(fn WatchFunc) error {
 	err := mgr.setupWatch.Do(func() error {
 		// Begin tracking all known apps by calling List (since it calls resolve).

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -185,7 +185,7 @@ func (mgr *Manager) RegisterAppListener(fn func(*Instance)) {
 
 	// Call the handler for all apps that are already being watched.
 	for _, inst := range mgr.instances {
-		if inst.watcher != nil {
+		if inst.isWatching() {
 			fn(inst)
 		}
 	}
@@ -291,19 +291,14 @@ type Instance struct {
 
 	// mgr is a reference to the manager that created it.
 	// It may be nil if an instance was created without a manager.
-	mgr     *Manager
-	watcher *watcher.Watcher
+	mgr *Manager
 
-	// watchStateMu guards watcher and watchRefs, controlling the lifetime of
-	// the underlying file watcher: it starts on the first beginWatch() call
-	// and stops once the matching number of endWatch() calls brings the
-	// refcount back to zero, so it can be started and stopped repeatedly
-	// over the instance's lifetime (e.g. once per `encore run` invocation),
-	// rather than running forever once started.
-	watchStateMu sync.Mutex
-	watchRefs    int
-
+	// watchMu guards the fields below. The file watcher runs exactly while
+	// watchers is non-empty: the first Watch starts it and the last Unwatch
+	// stops it, so it can start and stop repeatedly over the instance's
+	// lifetime (e.g. once per `encore run` invocation).
 	watchMu     sync.Mutex
+	watcher     *watcher.Watcher
 	nextWatchID WatchSubscriptionID
 	watchers    map[WatchSubscriptionID]*watchSubscription
 
@@ -440,48 +435,62 @@ func (i *Instance) GlobalCORS() (appfile.CORS, error) {
 }
 
 func (i *Instance) Watch(fn WatchFunc) (WatchSubscriptionID, error) {
-	if err := i.beginWatch(); err != nil {
-		return 0, err
-	}
-
 	i.watchMu.Lock()
+	started := false
+	if len(i.watchers) == 0 {
+		if err := i.startWatching(); err != nil {
+			i.watchMu.Unlock()
+			return 0, err
+		}
+		started = true
+	}
 	i.nextWatchID++
 	id := i.nextWatchID
 	i.watchers[id] = &watchSubscription{id, fn}
 	i.watchMu.Unlock()
+
+	if started && i.mgr != nil {
+		// Now that this app is being watched, notify listeners so they can
+		// e.g. regenerate user-facing codegen and keep it fresh as files
+		// change. Done outside the lock: listeners parse the app and write
+		// generated files into the watched tree, which is slow and produces
+		// events whose delivery needs the lock.
+		i.mgr.notifyAppListeners(i)
+	}
 	return id, nil
 }
 
 func (i *Instance) Unwatch(id WatchSubscriptionID) {
 	i.watchMu.Lock()
+	if _, ok := i.watchers[id]; !ok {
+		// Unknown or already-removed id; it must not affect the watcher
+		// or other subscriptions.
+		i.watchMu.Unlock()
+		return
+	}
 	delete(i.watchers, id)
+	var w *watcher.Watcher
+	if len(i.watchers) == 0 {
+		w = i.watcher
+		i.watcher = nil
+	}
 	i.watchMu.Unlock()
-	i.endWatch()
+
+	if w != nil {
+		_ = w.Close()
+	}
 }
 
-// beginWatch takes a reference on the app's file watcher, starting it if
-// this is the first reference. It must be paired with a call to endWatch
-// once the caller no longer needs the app watched (e.g. Unwatch does this
-// automatically for callers that went through Watch).
-func (i *Instance) beginWatch() error {
-	i.watchStateMu.Lock()
-	defer i.watchStateMu.Unlock()
-
-	i.watchRefs++
-	if i.watchRefs > 1 {
-		// Already watching; nothing more to do.
-		return nil
-	}
-
+// startWatching starts the app's file watcher and the goroutine delivering
+// its events to subscribers. i.watchMu must be held.
+func (i *Instance) startWatching() error {
 	watch, err := watcher.New(i.PlatformOrLocalID())
 	if err != nil {
-		i.watchRefs--
 		return errors.Wrap(err, "unable to create watcher")
 	}
-	i.watcher = watch
 
-	if err := i.watcher.RecursivelyWatch(i.root); err != nil {
-		i.watchRefs--
+	if err := watch.RecursivelyWatch(i.root); err != nil {
+		_ = watch.Close()
 		return errors.Wrap(err, "unable to watch app")
 	}
 
@@ -489,59 +498,52 @@ func (i *Instance) beginWatch() error {
 	// too, so we can develop changes to the runtime without
 	// needing to restart the application.
 	if conf.DevDaemon {
-		if err := i.watcher.RecursivelyWatch(env.EncoreRuntimesPath()); err != nil {
-			i.watchRefs--
+		if err := watch.RecursivelyWatch(env.EncoreRuntimesPath()); err != nil {
+			_ = watch.Close()
 			return errors.Wrap(err, "unable to watch runtime")
 		}
 	}
 
+	i.watcher = watch
+
 	go func() {
 		for {
-			events, ok := i.watcher.WaitForEvents()
+			events, ok := watch.WaitForEvents()
 			if !ok {
 				// We're done watching.
 				return
 			}
 
+			i.watchMu.Lock()
+			if i.watcher != watch {
+				// This watcher was stopped while the batch was in flight;
+				// the events must not reach subscribers of a newer one.
+				i.watchMu.Unlock()
+				return
+			}
+			subs := make([]*watchSubscription, 0, len(i.watchers))
+			for _, sub := range i.watchers {
+				subs = append(subs, sub)
+			}
+			i.watchMu.Unlock()
+
 			if i.mgr != nil {
 				i.mgr.onWatchEvent(i, events)
 			}
-
-			i.watchMu.Lock()
-			watchers := i.watchers
-			i.watchMu.Unlock()
-			for _, sub := range watchers {
+			for _, sub := range subs {
 				sub.f(i, events)
 			}
 		}
 	}()
 
-	// Now that this app is being watched, notify listeners so they can
-	// e.g. regenerate user-facing codegen and keep it fresh as files
-	// change.
-	if i.mgr != nil {
-		i.mgr.notifyAppListeners(i)
-	}
-
 	return nil
 }
 
-// endWatch releases one reference on the app's file watcher, closing the
-// underlying watcher once the last reference has been released. Safe to
-// call even if beginWatch never succeeded.
-func (i *Instance) endWatch() {
-	i.watchStateMu.Lock()
-	defer i.watchStateMu.Unlock()
-
-	if i.watchRefs == 0 {
-		return
-	}
-	i.watchRefs--
-	if i.watchRefs > 0 || i.watcher == nil {
-		return
-	}
-	i.watcher.Close()
-	i.watcher = nil
+// isWatching reports whether the app's file watcher is currently running.
+func (i *Instance) isWatching() bool {
+	i.watchMu.Lock()
+	defer i.watchMu.Unlock()
+	return i.watcher != nil
 }
 
 // CachePath returns the path to the cache directory for this app.
@@ -619,8 +621,16 @@ func (i *Instance) CachedMetadata() (*meta.Data, error) {
 }
 
 func (i *Instance) Close() error {
-	if i.watcher != nil {
-		return i.watcher.Close()
+	i.watchMu.Lock()
+	w := i.watcher
+	i.watcher = nil
+	// Clear the subscriptions so an Unwatch arriving after shutdown
+	// (e.g. from a run exiting) is a no-op.
+	clear(i.watchers)
+	i.watchMu.Unlock()
+
+	if w != nil {
+		return w.Close()
 	}
 	return nil
 }

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -294,7 +294,15 @@ type Instance struct {
 	mgr     *Manager
 	watcher *watcher.Watcher
 
-	setupWatch  syncutil.Once
+	// watchStateMu guards watcher and watchRefs, controlling the lifetime of
+	// the underlying file watcher: it starts on the first beginWatch() call
+	// and stops once the matching number of endWatch() calls brings the
+	// refcount back to zero, so it can be started and stopped repeatedly
+	// over the instance's lifetime (e.g. once per `encore run` invocation),
+	// rather than running forever once started.
+	watchStateMu sync.Mutex
+	watchRefs    int
+
 	watchMu     sync.Mutex
 	nextWatchID WatchSubscriptionID
 	watchers    map[WatchSubscriptionID]*watchSubscription
@@ -448,59 +456,92 @@ func (i *Instance) Unwatch(id WatchSubscriptionID) {
 	i.watchMu.Lock()
 	delete(i.watchers, id)
 	i.watchMu.Unlock()
+	i.endWatch()
 }
 
+// beginWatch takes a reference on the app's file watcher, starting it if
+// this is the first reference. It must be paired with a call to endWatch
+// once the caller no longer needs the app watched (e.g. Unwatch does this
+// automatically for callers that went through Watch).
 func (i *Instance) beginWatch() error {
-	return i.setupWatch.Do(func() error {
-		watch, err := watcher.New(i.PlatformOrLocalID())
-		if err != nil {
-			return errors.Wrap(err, "unable to create watcher")
-		}
-		i.watcher = watch
+	i.watchStateMu.Lock()
+	defer i.watchStateMu.Unlock()
 
-		if err := i.watcher.RecursivelyWatch(i.root); err != nil {
-			return errors.Wrap(err, "unable to watch app")
-		}
-
-		// If we're in dev mode, we want to watch the runtime
-		// too, so we can develop changes to the runtime without
-		// needing to restart the application.
-		if conf.DevDaemon {
-			if err := i.watcher.RecursivelyWatch(env.EncoreRuntimesPath()); err != nil {
-				return errors.Wrap(err, "unable to watch runtime")
-			}
-		}
-
-		go func() {
-			for {
-				events, ok := i.watcher.WaitForEvents()
-				if !ok {
-					// We're done watching.
-					return
-				}
-
-				if i.mgr != nil {
-					i.mgr.onWatchEvent(i, events)
-				}
-
-				i.watchMu.Lock()
-				watchers := i.watchers
-				i.watchMu.Unlock()
-				for _, sub := range watchers {
-					sub.f(i, events)
-				}
-			}
-		}()
-
-		// Now that this app is actively watched (i.e. running with
-		// live-reload), notify listeners so they can e.g. regenerate
-		// user-facing codegen and keep it fresh as files change.
-		if i.mgr != nil {
-			i.mgr.notifyAppListeners(i)
-		}
-
+	i.watchRefs++
+	if i.watchRefs > 1 {
+		// Already watching; nothing more to do.
 		return nil
-	})
+	}
+
+	watch, err := watcher.New(i.PlatformOrLocalID())
+	if err != nil {
+		i.watchRefs--
+		return errors.Wrap(err, "unable to create watcher")
+	}
+	i.watcher = watch
+
+	if err := i.watcher.RecursivelyWatch(i.root); err != nil {
+		i.watchRefs--
+		return errors.Wrap(err, "unable to watch app")
+	}
+
+	// If we're in dev mode, we want to watch the runtime
+	// too, so we can develop changes to the runtime without
+	// needing to restart the application.
+	if conf.DevDaemon {
+		if err := i.watcher.RecursivelyWatch(env.EncoreRuntimesPath()); err != nil {
+			i.watchRefs--
+			return errors.Wrap(err, "unable to watch runtime")
+		}
+	}
+
+	go func() {
+		for {
+			events, ok := i.watcher.WaitForEvents()
+			if !ok {
+				// We're done watching.
+				return
+			}
+
+			if i.mgr != nil {
+				i.mgr.onWatchEvent(i, events)
+			}
+
+			i.watchMu.Lock()
+			watchers := i.watchers
+			i.watchMu.Unlock()
+			for _, sub := range watchers {
+				sub.f(i, events)
+			}
+		}
+	}()
+
+	// Now that this app is being watched, notify listeners so they can
+	// e.g. regenerate user-facing codegen and keep it fresh as files
+	// change.
+	if i.mgr != nil {
+		i.mgr.notifyAppListeners(i)
+	}
+
+	return nil
+}
+
+// endWatch releases one reference on the app's file watcher, closing the
+// underlying watcher once the last reference has been released. Safe to
+// call even if beginWatch never succeeded.
+func (i *Instance) endWatch() {
+	i.watchStateMu.Lock()
+	defer i.watchStateMu.Unlock()
+
+	if i.watchRefs == 0 {
+		return
+	}
+	i.watchRefs--
+	if i.watchRefs > 0 || i.watcher == nil {
+		return
+	}
+	i.watcher.Close()
+	i.watcher = nil
 }
 
 // CachePath returns the path to the cache directory for this app.

--- a/cli/daemon/apps/apps.go
+++ b/cli/daemon/apps/apps.go
@@ -174,7 +174,7 @@ func (mgr *Manager) listRoots() ([]string, error) {
 }
 
 // RegisterAppListener registers a callback that gets invoked every time
-// an app starts being actively watched (i.e. run with live-reload enabled).
+// an app starts being actively watched (i.e. an `encore run` for it starts).
 func (mgr *Manager) RegisterAppListener(fn func(*Instance)) {
 	mgr.instanceMu.Lock()
 	defer mgr.instanceMu.Unlock()
@@ -259,10 +259,11 @@ func (mgr *Manager) resolve(appRoot string) (*Instance, error) {
 	i.mgr = mgr
 	// Note: we deliberately don't start the file watcher (or notify app
 	// listeners) here. Both are lazy, triggered only via Watch() (i.e. only
-	// for apps actually running with live-reload enabled), so that commands
-	// like `encore check` and `encore run --watch=false` never hold a
-	// recursive fsnotify watch open, and never trigger a codegen-regen parse
-	// for apps that aren't being actively developed against.
+	// while an `encore run` is alive), so that resolving an app - e.g. for
+	// `encore check`, or on daemon boot for every app ever tracked - never
+	// holds a recursive fsnotify watch open, and never triggers a
+	// codegen-regen parse for apps that aren't being actively developed
+	// against.
 	mgr.instances[appRoot] = i
 
 	return i, nil

--- a/cli/daemon/apps/apps_test.go
+++ b/cli/daemon/apps/apps_test.go
@@ -1,0 +1,116 @@
+package apps
+
+import (
+	"path/filepath"
+	"testing"
+
+	"encr.dev/internal/conf"
+	"encr.dev/pkg/watcher"
+)
+
+func newTestInstance(t *testing.T) *Instance {
+	t.Helper()
+	// Force off so the watcher doesn't also watch the runtime source tree,
+	// which may not exist in the test environment.
+	prev := conf.DevDaemon
+	conf.DevDaemon = false
+	t.Cleanup(func() { conf.DevDaemon = prev })
+
+	i := NewInstance(t.TempDir(), "test-local-id", "")
+	t.Cleanup(func() { _ = i.Close() })
+	return i
+}
+
+func noopWatch(*Instance, []watcher.Event) {}
+
+// TestUnwatchUnknownID verifies that Unwatch calls without a matching live
+// subscription (double-unwatch, never-issued id) don't affect the watcher
+// or other subscriptions.
+func TestUnwatchUnknownID(t *testing.T) {
+	i := newTestInstance(t)
+
+	id1, err := i.Watch(noopWatch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := i.Watch(noopWatch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i.Unwatch(id1)
+	i.Unwatch(id1)   // double-unwatch
+	i.Unwatch(99999) // never issued
+	if !i.isWatching() {
+		t.Fatal("watcher stopped while a subscription was still active")
+	}
+
+	i.Unwatch(id2)
+	if i.isWatching() {
+		t.Fatal("watcher still running after the last subscription was removed")
+	}
+}
+
+// TestWatcherRestarts verifies the watcher can start and stop repeatedly,
+// e.g. across successive `encore run` invocations.
+func TestWatcherRestarts(t *testing.T) {
+	i := newTestInstance(t)
+
+	for n := 0; n < 3; n++ {
+		id, err := i.Watch(noopWatch)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !i.isWatching() {
+			t.Fatalf("cycle %d: watcher not running after Watch", n)
+		}
+		i.Unwatch(id)
+		if i.isWatching() {
+			t.Fatalf("cycle %d: watcher still running after Unwatch", n)
+		}
+	}
+}
+
+// TestCloseWithActiveSubscriptions verifies Close stops the watcher and that
+// late Unwatch calls for subscriptions it cleared are no-ops.
+func TestCloseWithActiveSubscriptions(t *testing.T) {
+	i := newTestInstance(t)
+
+	id1, err := i.Watch(noopWatch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := i.Watch(noopWatch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := i.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if i.isWatching() {
+		t.Fatal("watcher still running after Close")
+	}
+
+	i.Unwatch(id1)
+	i.Unwatch(id2)
+	if i.isWatching() {
+		t.Fatal("watcher running after Unwatch of closed subscriptions")
+	}
+}
+
+// TestWatchFailure verifies a failed Watch leaves no subscription and no
+// running watcher behind.
+func TestWatchFailure(t *testing.T) {
+	i := newTestInstance(t)
+	i.root = filepath.Join(i.root, "does-not-exist")
+
+	for n := 0; n < 2; n++ {
+		if _, err := i.Watch(noopWatch); err == nil {
+			t.Fatalf("attempt %d: Watch succeeded on a nonexistent root", n)
+		}
+		if i.isWatching() {
+			t.Fatalf("attempt %d: watcher running after failed Watch", n)
+		}
+	}
+}

--- a/cli/daemon/run/manager.go
+++ b/cli/daemon/run/manager.go
@@ -85,6 +85,16 @@ func (mgr *Manager) FindRunByAppID(appID string) *Run {
 	return nil
 }
 
+// removeRun removes a run from the set of tracked runs once it has exited.
+// Without this, mgr.runs grows without bound for the lifetime of the daemon:
+// every run's Builder (and the AST/type-checking data cached inside it) stays
+// reachable through the map long after the run's own process has exited.
+func (mgr *Manager) removeRun(id string) {
+	mgr.mu.Lock()
+	delete(mgr.runs, id)
+	mgr.mu.Unlock()
+}
+
 // ListRuns provides a snapshot of all runs.
 func (mgr *Manager) ListRuns() []*Run {
 	mgr.mu.Lock()

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -283,6 +283,7 @@ func (r *Run) start(ln net.Listener, tracker *optracker.OpTracker) (err error) {
 			// so handle the other cases.
 			close(r.started)
 			close(r.exited)
+			r.Mgr.removeRun(r.ID)
 		}
 	}()
 
@@ -332,6 +333,7 @@ func (r *Run) start(ln net.Listener, tracker *optracker.OpTracker) (err error) {
 					ln.OnStop(r)
 				}
 				close(r.exited)
+				r.Mgr.removeRun(r.ID)
 				return
 			}
 		}

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -208,10 +208,12 @@ func (mgr *Manager) Start(ctx context.Context, params StartParams) (run *Run, er
 		return nil, err
 	}
 
-	if params.Watch {
-		if err := mgr.watch(run); err != nil {
-			return nil, err
-		}
+	// Keep the app watched for as long as it's running, regardless of
+	// params.Watch: that flag only controls whether we live-reload the app
+	// on changes, not whether we watch its files at all, so that generated
+	// code doesn't go stale for the duration of `encore run --watch=false`.
+	if err := mgr.watch(run, params.Watch); err != nil {
+		return nil, err
 	}
 
 	return run, nil

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -86,6 +86,12 @@ type StartParams struct {
 	// Watch enables watching for code changes for live reloading.
 	Watch bool
 
+	// SkipFileWatch disables file watching entirely for this run.
+	// Interactive runs are watched even with Watch=false so generated code
+	// stays fresh while they're up; for short-lived runs (like `encore
+	// check` booting the app) that's pure overhead.
+	SkipFileWatch bool
+
 	Listener   net.Listener // listener to use
 	ListenAddr string       // address we're listening on
 
@@ -212,8 +218,10 @@ func (mgr *Manager) Start(ctx context.Context, params StartParams) (run *Run, er
 	// params.Watch: that flag only controls whether we live-reload the app
 	// on changes, not whether we watch its files at all, so that generated
 	// code doesn't go stale for the duration of `encore run --watch=false`.
-	if err := mgr.watch(run, params.Watch); err != nil {
-		return nil, err
+	if !params.SkipFileWatch {
+		if err := mgr.watch(run, params.Watch); err != nil {
+			return nil, err
+		}
 	}
 
 	return run, nil

--- a/cli/daemon/run/watch.go
+++ b/cli/daemon/run/watch.go
@@ -8,11 +8,15 @@ import (
 	"encr.dev/pkg/watcher"
 )
 
-// watch watches the given app for changes, and reports
-// them on c.
-func (mgr *Manager) watch(run *Run) error {
+// watch watches the given app for changes, keeping generated code fresh for
+// as long as run is alive. liveReload controls whether we additionally
+// reload the running app on changes - this is what `--watch=false` disables;
+// it doesn't stop us from watching altogether, since the app's files should
+// stay watched regardless so codegen doesn't go stale while `encore run` is
+// up.
+func (mgr *Manager) watch(run *Run, liveReload bool) error {
 	sub, err := run.App.Watch(func(i *apps.Instance, event []watcher.Event) {
-		if IgnoreEvents(event) {
+		if !liveReload || IgnoreEvents(event) {
 			return
 		}
 

--- a/cli/daemon/run_spec.go
+++ b/cli/daemon/run_spec.go
@@ -99,10 +99,13 @@ func (s *Server) RunSpec(req *daemonpb.RunSpecRequest, stream daemonpb.Daemon_Ru
 		Listener:   ln,
 		ListenAddr: listenAddr,
 		Watch:      false,
-		Environ:    req.Environ,
-		OpsTracker: ops,
-		Browser:    run.BrowserModeNever,
-		Debug:      builder.DebugModeDisabled,
+		// The run only lives for the duration of the spec commands;
+		// watching its files would be pure overhead.
+		SkipFileWatch: true,
+		Environ:       req.Environ,
+		OpsTracker:    ops,
+		Browser:       run.BrowserModeNever,
+		Debug:         builder.DebugModeDisabled,
 	})
 	if err != nil {
 		// Forward errlist details (compile errors, parse errors) as plain text

--- a/cli/daemon/watch.go
+++ b/cli/daemon/watch.go
@@ -31,9 +31,9 @@ func (s *Server) watchApps() {
 		}
 	})
 	if err := s.apps.WatchAll(s.onWatchEvent); err != nil {
-		log.Error().Err(err).Msg("unable to set up app watchers")
+		log.Error().Err(err).Msg("unable to register app watch listener")
 	} else {
-		log.Info().Msg("successfully set up file watchers")
+		log.Info().Msg("registered app watch listener")
 	}
 }
 

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -28,6 +28,7 @@ type Watcher struct {
 	directories map[string]struct{}
 	stop        chan struct{}
 	closeOnce   sync.Once
+	closed      bool // guarded by mutex
 }
 
 func New(appID string) (*Watcher, error) {
@@ -69,6 +70,10 @@ func (w *Watcher) RecursivelyWatch(folder string) error {
 
 			// Track the fact we're watching this directory
 			w.mutex.Lock()
+			if w.closed {
+				w.mutex.Unlock()
+				return filepath.SkipAll
+			}
 			if _, found := w.directories[folder]; found {
 				w.mutex.Unlock()
 				return filepath.SkipDir
@@ -77,8 +82,24 @@ func (w *Watcher) RecursivelyWatch(folder string) error {
 			w.mutex.Unlock() // unlock here to prevent reentrant locks during recursion
 
 			// Now start watching this folder
-			if err := w.watcher.Add(folder); err != nil {
-				return eerror.Wrap(err, "watcher", "unable to add folder to watch", map[string]any{"folder": folder})
+			addErr := w.watcher.Add(folder)
+
+			// Close may have run its removal sweep while the add was in
+			// flight, in which case this watch missed it and must be
+			// dropped here instead.
+			w.mutex.Lock()
+			stale := w.closed || addErr != nil
+			if stale {
+				delete(w.directories, folder)
+			}
+			w.mutex.Unlock()
+
+			if stale {
+				_ = w.watcher.Remove(folder)
+				if addErr != nil {
+					return eerror.Wrap(addErr, "watcher", "unable to add folder to watch", map[string]any{"folder": folder})
+				}
+				return filepath.SkipAll
 			}
 		}
 
@@ -204,6 +225,9 @@ func (w *Watcher) Close() error {
 		// on the goroutine that delivers events, which may itself be
 		// waiting on the mutex.
 		w.mutex.Lock()
+		// Stops RecursivelyWatch from registering new watches after the
+		// sweep below, which would leak them.
+		w.closed = true
 		folders := make([]string, 0, len(w.directories))
 		for folder := range w.directories {
 			folders = append(folders, folder)

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -176,15 +176,18 @@ func (w *Watcher) WaitForEvents() (events []Event, ok bool) {
 			return nil, false
 
 		default:
-			if w.events == nil || len(w.events.latestEvents) == 0 {
-				w.eventCond.Wait()
-			}
-			// Post-condition: we have at least one event.
-
-			events := w.events.Events()
-			w.events = newEventBatch()
-			return events, true
 		}
+
+		if w.events == nil || len(w.events.latestEvents) == 0 {
+			// A wakeup doesn't guarantee events: Close broadcasts too,
+			// so re-check both the stop channel and the batch.
+			w.eventCond.Wait()
+			continue
+		}
+
+		events := w.events.Events()
+		w.events = newEventBatch()
+		return events, true
 	}
 }
 
@@ -196,14 +199,31 @@ func (w *Watcher) Close() error {
 		// and each watched file and directory leaks its file descriptor.
 		// Removing them here, while the watcher is still open, actually
 		// releases them.
+		//
+		// Remove without holding the mutex: on some backends Remove waits
+		// on the goroutine that delivers events, which may itself be
+		// waiting on the mutex.
 		w.mutex.Lock()
+		folders := make([]string, 0, len(w.directories))
 		for folder := range w.directories {
-			_ = w.watcher.Remove(folder)
-			delete(w.directories, folder)
+			folders = append(folders, folder)
 		}
+		clear(w.directories)
 		w.mutex.Unlock()
 
+		for _, folder := range folders {
+			_ = w.watcher.Remove(folder)
+		}
+
+		// Close under the mutex guarding the condition, so a WaitForEvents
+		// caller cannot check w.stop, miss the broadcast below, and then
+		// park on the condition forever.
+		w.mutex.Lock()
 		close(w.stop)
+		w.mutex.Unlock()
+
+		// Wake anyone parked in WaitForEvents so they observe the close.
+		w.eventCond.Broadcast()
 	})
 	return nil
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -27,6 +27,7 @@ type Watcher struct {
 	watcher     *fsnotify.Watcher
 	directories map[string]struct{}
 	stop        chan struct{}
+	closeOnce   sync.Once
 }
 
 func New(appID string) (*Watcher, error) {
@@ -188,7 +189,22 @@ func (w *Watcher) WaitForEvents() (events []Event, ok bool) {
 }
 
 func (w *Watcher) Close() error {
-	close(w.stop)
+	w.closeOnce.Do(func() {
+		// Drop the watches ourselves before closing. fsnotify's kqueue
+		// backend (macOS/BSD) marks the watcher closed before removing its
+		// own watches, so every Remove it performs during Close is a no-op
+		// and each watched file and directory leaks its file descriptor.
+		// Removing them here, while the watcher is still open, actually
+		// releases them.
+		w.mutex.Lock()
+		for folder := range w.directories {
+			_ = w.watcher.Remove(folder)
+			delete(w.directories, folder)
+		}
+		w.mutex.Unlock()
+
+		close(w.stop)
+	})
 	return nil
 }
 

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,65 @@
+package watcher
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCloseWakesWaitForEvents verifies that Close releases a caller parked
+// in WaitForEvents, rather than leaving it asleep on the condition forever.
+func TestCloseWakesWaitForEvents(t *testing.T) {
+	w, err := New("test-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.RecursivelyWatch(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	done := make(chan bool, 1)
+	go func() {
+		_, ok := w.WaitForEvents()
+		done <- ok
+	}()
+
+	// Wait until the caller is genuinely parked on the condition, so the
+	// test can't pass merely by observing an already-closed watcher. There
+	// is no hook between WaitForEvents' stop-check and its Wait, so stack
+	// inspection is the only way to detect this.
+	waitUntilParked(t)
+
+	_ = w.Close()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("WaitForEvents reported events after Close, want ok=false")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForEvents did not return after Close; its caller is leaked")
+	}
+}
+
+// waitUntilParked blocks until a goroutine is parked on the condition from
+// inside WaitForEvents. It matches both frames in the same goroutine's
+// stack, so an unrelated goroutine waiting on some other condition doesn't
+// count.
+func waitUntilParked(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	buf := make([]byte, 1<<20)
+	for time.Now().Before(deadline) {
+		n := runtime.Stack(buf, true)
+		for _, g := range strings.Split(string(buf[:n]), "\n\n") {
+			if strings.Contains(g, "sync.(*Cond).Wait") &&
+				strings.Contains(g, "(*Watcher).WaitForEvents") {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for a caller to park in WaitForEvents")
+}


### PR DESCRIPTION
## Problem

Running `encore` locally against a large monorepo (~200 services, multiple git
worktrees checked out alongside the main clone) causes the daemon
(`encore daemon`) to leak memory and file descriptors without bound over the
life of the process:

- RAM usage climbing to **25-50GB+**, forcing macOS into heavy swap
- File descriptor exhaustion (`too many open files`) even when running
  `encore run --watch=false` and `encore check`/`encore test` - commands that
  shouldn't need to watch anything, also causing  `read tcp: connection reset by peer` errors everywhere
- None of this recovers by restarting the daemon: the very next boot
  reproduces the same cost, because the set of app roots the daemon considers
  "known" is persisted in sqlite (`~/Library/Application Support/encore/encore.db`,
  table `app`) and survives across restarts.

We profiled the daemon live (`pprof` on the `debug` HTTP endpoint) against a
real large monorepo and traced this to three separate, compounding causes.

## Root causes

**1. File watching was eager, not lazy.**
`apps.Manager.resolve()` called `Instance.beginWatch()` unconditionally for
every app root it resolved - for *any* command, not just `encore run`. Since
resolved instances are cached for the daemon's entire lifetime, every git
worktree ever `encore check`ed or `encore test`ed accumulated a permanent
recursive fsnotify watch that was never released. `encore run --watch=false`
didn't help either: that flag only ever gated the live-reload subscription
(`Manager.watch(run)`), not the underlying watch itself, which the daemon
starts unconditionally as soon as an app is resolved.

**2. Codegen regeneration ran for every app root the daemon has ever seen, on every boot.**
`Server.watchApps()` (run once at daemon startup) calls `WatchAll`, which
calls `Manager.List()` - which iterates *every app root in the sqlite `app`
table* and resolves each one. Each resolution fires an `appListeners`
callback (`regenerateUserCode`) that does a full parse of the app to
regenerate `encore.gen.go` and update `.gitignore`. With 14 worktrees/
workspaces tracked from past sessions, every single daemon boot triggered 14
full monorepo parses before a single user command ran - each costing
multiple GB.

**3. `run.Manager.runs` never released exited runs.**
Every `encore run` invocation adds a `*Run` entry to `mgr.runs`, keyed by a
unique ID. Nothing ever removed an entry once its process exited - confirmed
by the fact that every consumer of the map (`FindRunByAppID`) has to manually
skip over dead entries via a `select { case <-run.Done(): }` check, rather
than the map only containing live runs. Each `*Run` holds its own `Builder`,
whose internal `pkginfo.Loader` package cache stays reachable for as long as
the entry survives. Restarting the same app 5 times grew daemon memory
linearly and permanently (~1.5GB per restart, ~7.7GB total, never released).

## Fix

Three commits, each addressing one of the above:

- **`daemon: make file watching lazy, only for apps running with live-reload`**
  Removed the eager `beginWatch()` call from `resolve()`. `beginWatch()` is
  now reachable only through `Instance.Watch()`, which is only called via
  `Manager.watch(run)`, which is only invoked when `Params.Watch` is true
  (i.e. `encore run` without `--watch=false`). `encore check`, `encore test`,
  and `encore run --watch=false` now never hold a watch open.

- **`daemon: gate codegen-regen behind active Watch(), matching file-watching`**
  Moved the `appListeners` notification (which triggers `regenerateUserCode`)
  from `resolve()` into `beginWatch()`, so it fires under the exact same
  condition as file-watching. Apps that are only ever checked/tested no
  longer trigger a background parse at all, and the startup `WatchAll` pass
  no longer reparses every historically-tracked app root - only apps actively
  being run with live-reload do.

  Verified this doesn't affect correctness: `encore check`/`encore run` never
  read the codegen-regen output back (`bld.Parse()` is always called fresh);
  the only consumers of the underlying metadata cache are the MCP server
  tools and the local dev dashboard, which we confirmed via a full grep of
  all callers.

- **`daemon: return parse garbage to the OS, and stop leaking exited runs`**
  Two independent fixes: (a) `debug.FreeOSMemory()` after the parse/compile
  pass completes in both `run.go`'s `buildAndStart` and `check.go`'s `Check`,
  so the large amount of short-lived AST/type-checking data is returned to
  the OS immediately rather than waiting on the background scavenger -
  relevant on macOS, where pages the scavenger hasn't reclaimed yet still
  count against the process's reported memory footprint (and system memory
  pressure, i.e. what actually pushed us into swap). (b) Added
  `Manager.removeRun`, called at both points a run's `exited` channel closes,
  so `mgr.runs` no longer accumulates dead entries forever.

## Testing

All measurements taken against our actual monorepo (~200 services), using
`footprint` (macOS's `phys_footprint`, the same metric Activity Monitor
reports) rather than `ps`'s RSS, since Go's scavenger on Darwin uses
`madvise(MADV_FREE)`, which `ps` stops counting as resident before the kernel
has actually reclaimed the pages, but which `phys_footprint` (correctly)
still charges to the process.

Each fix targets a separate, non-overlapping code path, so we could isolate
and verify each one independently by measuring with only the relevant fix(es)
applied. The table below reports each root cause's own before/after in
isolation - these numbers are **not cumulative with each other** (e.g. the
codegen-regen row and the leaked-runs row were measured at different points
in the rollout, so don't add them together):

| Root cause | Before | After |
|---|---|---|
| #1: fsnotify watch held for every resolved app root | dozens+ watch fds per worktree, growing forever | 1 fd, held only while an app is actively `run` with live-reload |
| #2: codegen-regen for every tracked app root, on every daemon boot | 6-9GB at every boot (14 tracked roots) | 209MB |
| #3: `mgr.runs` never releasing exited runs | ~1.5GB per restart, unbounded (7.7GB after 5 restarts of the same app) | ~1.4GB regardless of restart count |

<img width="1314" height="142" alt="Screenshot 2026-07-24 at 08 18 12" src="https://github.com/user-attachments/assets/b56ae2d5-49dc-4bf9-b67b-bfcd825d4332" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787492088&installation_model_id=427204&pr_number=2520&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2520&signature=0b662fd968e48c424e4e68fef7f008bc27cb29e1474f8d129da5b4807c4f559c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->