### PR TITLE
docs: fix undefined params.ID in errs.Builder example

### DIFF
--- a/docs/go/primitives/api-errors.md
+++ b/docs/go/primitives/api-errors.md
@@ -126,14 +126,14 @@ For example:
 ```go
 func getBoard(ctx context.Context, boardID int64) (*Board, error) {
     // Construct a new error builder with errs.B()
-	eb := errs.B().Meta("board_id", params.ID)
+	eb := errs.B().Meta("board_id", boardID)
 
-	b := &Board{ID: params.ID}
+	b := &Board{ID: boardID}
 	err := sqldb.QueryRow(ctx, `
 		SELECT name, created
 		FROM board
 		WHERE id = $1
-	`, params.ID).Scan(&b.Name, &b.Created)
+	`, boardID).Scan(&b.Name, &b.Created)
 	if errors.Is(err, sqldb.ErrNoRows) {
         // Return a "board not found" error with code == NotFound
 		return nil, eb.Code(errs.NotFound).Msg("board not found").Err()


### PR DESCRIPTION
The `getBoard` example used `params.ID`, which isn't declared in the function. Changed to `boardID`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787496141&installation_model_id=427204&pr_number=2521&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2521&signature=a89a782228cc533d9a4deaf17d7d3e96e504f42274a018722db6cea58e5e8205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->