### PR TITLE
feat(sqldb): make Postgres Docker image configurable via environment …

### DIFF
--- a/cli/cmd/encore/db.go
+++ b/cli/cmd/encore/db.go
@@ -159,7 +159,7 @@ when using tools like Prisma.
 				}
 			}
 
-			cmd = exec.Command("docker", "run", "-it", "--rm", "--network=host", docker.Image, "psql", dsn)
+			cmd = exec.Command("docker", "run", "-it", "--rm", "--network=host", docker.GetPostgresImage(), "psql", dsn)
 		}
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/cli/daemon/sqldb/docker/docker.go
+++ b/cli/daemon/sqldb/docker/docker.go
@@ -144,7 +144,7 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 		if p.Memfs {
 			args = append(args,
 				"--mount", "type=tmpfs,destination="+defaultDataDir,
-				Image,
+				GetPostgresImage(),
 				"-c", "fsync=off",
 			)
 		} else {
@@ -154,7 +154,7 @@ func (d *Driver) CreateCluster(ctx context.Context, p *sqldb.CreateParams, log z
 			}
 			args = append(args,
 				"-v", fmt.Sprintf("%s:%s", volumeName, defaultDataDir),
-				Image)
+				GetPostgresImage())
 		}
 
 		cmd := exec.CommandContext(ctx, "docker", args...)
@@ -361,7 +361,7 @@ func containerNames(id sqldb.ClusterID) []string {
 
 // ImageExists reports whether the docker image exists.
 func ImageExists(ctx context.Context) (ok bool, err error) {
-	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", Image).CombinedOutput()
+	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", GetPostgresImage()).CombinedOutput()
 	switch {
 	case err == nil:
 		return true, nil
@@ -371,19 +371,25 @@ func ImageExists(ctx context.Context) (ok bool, err error) {
 	case bytes.Contains(out, []byte("failed to find image")):
 		return false, nil
 	default:
-		return false, errors.WithStack(errors.Wrapf(err, "docker image inspect failed: %s", Image))
+		return false, errors.WithStack(errors.Wrapf(err, "docker image inspect failed: %s", GetPostgresImage()))
 	}
 }
 
 // PullImage pulls the image.
 func PullImage(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "docker", "pull", Image)
+	cmd := exec.CommandContext(ctx, "docker", "pull", GetPostgresImage())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
-const Image = "encoredotdev/postgres:18"
+func GetPostgresImage() string {
+	image := os.Getenv("ENCORE_POSTGRES_IMAGE")
+	if image == "" {
+		image = "encoredotdev/postgres:18"
+	}
+	return image
+}
 
 func isDockerRunning(ctx context.Context) bool {
 	err := exec.CommandContext(ctx, "docker", "info").Run()


### PR DESCRIPTION
…variable

Previously, the Postgres Docker image used for local development was hardcoded as a constant:

    const Image = "encoredotdev/postgres:18"

This meant developers had no way to match their local Postgres version to their production environment, which could cause subtle bugs that only appear in production.

This change replaces the constant with a function GetPostgresImage() that reads from the ENCORE_POSTGRES_IMAGE environment variable, falling back to the default image if not set.

Usage:
    ENCORE_POSTGRES_IMAGE=encoredotdev/postgres:17 encore run

If the environment variable is not set, behaviour is unchanged and the default image encoredotdev/postgres:18 is used.

Fixes #2212

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787757223&installation_model_id=427204&pr_number=2522&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2522&signature=54b767f321f52497404c65139ca94223ee95e339b6c3feb2e7ee9d579d8f4145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->