### PR TITLE
cli: add --autoreload for encore run, deprecate --watch

### DIFF
--- a/cli/cmd/encore/run.go
+++ b/cli/cmd/encore/run.go
@@ -30,9 +30,9 @@ var (
 		Desc:        "Compile for debugging (disables some optimizations)",
 		TypeDesc:    "string",
 	}
-	watch    bool
-	listen   string
-	logLevel = cmdutil.Oneof{
+	autoreload bool
+	listen     string
+	logLevel   = cmdutil.Oneof{
 		Value:     "",
 		Allowed:   []string{"trace", "debug", "info", "warn", "error"},
 		Flag:      "level",
@@ -55,15 +55,16 @@ var (
 
 func init() {
 	runCmd := &cobra.Command{
-		Use:   "run [--debug] [--watch=true] [--level=TRACE] [--port=4000] [--listen=<listen-addr>]",
+		Use:   "run [--debug] [--autoreload=true] [--level=TRACE] [--port=4000] [--listen=<listen-addr>]",
 		Short: "Runs your application",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			appRoot, wd := determineAppRoot()
-			// If the user didn't explicitly set --watch and we're in debug mode, disable watching
-			// as we typically don't want to swap the process when the user is debugging.
-			if !cmd.Flag("watch").Changed && debug.Value != "" {
-				watch = false
+			// If the user didn't explicitly set --autoreload and we're in debug mode,
+			// disable reloading as we typically don't want to swap the process when
+			// the user is debugging.
+			if !cmd.Flag("autoreload").Changed && !cmd.Flag("watch").Changed && debug.Value != "" {
+				autoreload = false
 			}
 			runApp(appRoot, wd)
 		},
@@ -72,7 +73,12 @@ func init() {
 	isTerm := term.IsTerminal(int(os.Stdout.Fd()))
 
 	rootCmd.AddCommand(runCmd)
-	runCmd.Flags().BoolVarP(&watch, "watch", "w", true, "Watch for changes and live-reload")
+	runCmd.Flags().BoolVar(&autoreload, "autoreload", true, "Automatically reload the app on file changes")
+	// Deprecated alias for --autoreload: the app's files are watched for the
+	// duration of the run regardless (to keep generated code fresh), so the
+	// old name suggested a broader effect than the flag ever had.
+	runCmd.Flags().BoolVarP(&autoreload, "watch", "w", true, "Automatically reload the app on file changes")
+	_ = runCmd.Flags().MarkDeprecated("watch", "use --autoreload instead")
 	runCmd.Flags().StringVar(&listen, "listen", "", "Address to listen on (for example \"0.0.0.0:4000\")")
 	runCmd.Flags().UintVarP(&port, "port", "p", 4000, "Port to listen on")
 	runCmd.Flags().BoolVar(&jsonLogs, "json", false, "Display logs in JSON format")
@@ -128,7 +134,7 @@ func runApp(appRoot, wd string) {
 	stream, err := daemon.Run(ctx, &daemonpb.RunRequest{
 		AppRoot:            appRoot,
 		DebugMode:          debugMode,
-		Watch:              watch,
+		Watch:              autoreload,
 		WorkingDir:         wd,
 		ListenAddr:         listenAddr,
 		Environ:            os.Environ(),

--- a/docs/go/cli/cli-reference.md
+++ b/docs/go/cli/cli-reference.md
@@ -13,14 +13,14 @@ lang: go
 Runs your application.
 
 ```shell
-$ encore run [--debug] [--watch=true] [--port=<number>] [--listen=<addr>] [flags]
+$ encore run [--debug] [--autoreload=true] [--port=<number>] [--listen=<addr>] [flags]
 ```
 
 **Flags**
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `-w, --watch` | Watch for changes and live-reload | `true` |
+| `--autoreload` | Automatically reload the app on file changes | `true` |
 | `--listen` | Address to listen on (e.g. `0.0.0.0:4000`) | |
 | `-p, --port` | Port to listen on | `4000` |
 | `--json` | Display logs in JSON format | `false` |

--- a/docs/ts/cli/cli-reference.md
+++ b/docs/ts/cli/cli-reference.md
@@ -13,14 +13,14 @@ lang: ts
 Runs your application.
 
 ```shell
-$ encore run [--debug] [--watch=true] [--port=4000] [--listen=<addr>] [flags]
+$ encore run [--debug] [--autoreload=true] [--port=4000] [--listen=<addr>] [flags]
 ```
 
 **Flags**
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `-w, --watch` | Watch for changes and live-reload | `true` |
+| `--autoreload` | Automatically reload the app on file changes | `true` |
 | `--listen` | Address to listen on (e.g. `0.0.0.0:4000`) | |
 | `-p, --port` | Port to listen on | `4000` |
 | `--json` | Display logs in JSON format | `false` |


### PR DESCRIPTION
Follow-up to #2520, per https://github.com/encoredev/encore/pull/2520#issuecomment-5118319307: since the app's files are watched for the duration of every run regardless of `--watch` - the flag only controls whether the app is automatically reloaded on changes, so its name suggests a broader effect than it has.

- `--autoreload` (default `true`) is the new canonical name, shown in help and docs.
- `--watch` / `-w` keep working as a hidden, deprecated alias: using either prints `Flag --watch has been deprecated, use --autoreload instead` and behaves as before.
- The debug-mode default (`--debug` implies no reload unless the flag was set explicitly) respects both spellings.
- CLI reference docs updated for Go and TS.

No daemon/proto changes - the `RunRequest.Watch` field is untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788361653&installation_model_id=427204&pr_number=2524&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2524&signature=b3ab8cc7eaada87e7a6e072993131c3e63f8a0d8b01a96d7d7151514a140fc24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
