### PR TITLE
docs: fix outdated contribution link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We're so excited that you are interested in contributing to Encore!
 All contributions are welcome, and there are several valuable ways to contribute.
 
 Below is a technical walkthrough of developing the `encore` command for contributing code
-to the Encore project. Head over to the community section for [more ways to contribute](https://encore.dev/docs/community/contribute)!
+to the Encore project. Head over to the community section for [more ways to contribute](https://encore.dev/docs/ts/community/contribute)!
 
 ## GitHub Codespaces / VS Code Remote Containers
 The easiest way to get started with developing Encore is using


### PR DESCRIPTION
## Description

Updates the outdated **"more ways to contribute"** link in `CONTRIBUTING.md`.

The link was pointing to:

`https://encore.dev/docs/community/contribute`

and has been updated to:

`https://encore.dev/docs/ts/community/contribute`

## Related Issue

Fixes #2531

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789213032&installation_model_id=427204&pr_number=2532&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2532&signature=aefe1c18ffc41ec33609bf0033166c0cf389ef7e9a19d494f26a01cb793ba3ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->