### PR TITLE
object explorer: fix prefix rollup

### DIFF
--- a/cli/daemon/dash/bucketbrowser.go
+++ b/cli/daemon/dash/bucketbrowser.go
@@ -119,6 +119,9 @@ type bucketSearchRequest struct {
 }
 
 type bucketSearchResponse struct {
+	// Prefixes holds the sub-paths a non-recursive search matched below, the way Cloud
+	// Storage reports them. A recursive or glob search rolls nothing up, so it's empty.
+	Prefixes      []string       `json:"prefixes"`
 	Objects       []bucketObject `json:"objects"`
 	NextPageToken string         `json:"next_page_token"`
 }
@@ -214,14 +217,8 @@ func (t *bucketTarget) List(ctx context.Context, req bucketListRequest) (*bucket
 		return nil, err
 	}
 
-	// The dashboard distinguishes "no sub-paths" from "field absent", so never return null.
-	prefixes := objs.Prefixes
-	if prefixes == nil {
-		prefixes = []string{}
-	}
-
 	return &bucketListResponse{
-		Prefixes:      prefixes,
+		Prefixes:      bucketPrefixes(objs),
 		Objects:       t.objects(objs),
 		NextPageToken: objs.NextPageToken,
 	}, nil
@@ -266,6 +263,7 @@ func (t *bucketTarget) Search(ctx context.Context, req bucketSearchRequest) (*bu
 	}
 
 	return &bucketSearchResponse{
+		Prefixes:      bucketPrefixes(objs),
 		Objects:       t.objects(objs),
 		NextPageToken: objs.NextPageToken,
 	}, nil
@@ -570,6 +568,15 @@ func (t *bucketTarget) list(ctx context.Context, opts gcsemu.ListOptions, pageTo
 		return nil, errors.Wrap(err, "list objects")
 	}
 	return objs, nil
+}
+
+// bucketPrefixes returns the rolled-up sub-paths of a listing, never null: the
+// dashboard distinguishes "no sub-paths" from "field absent".
+func bucketPrefixes(objs *storage.Objects) []string {
+	if objs.Prefixes == nil {
+		return []string{}
+	}
+	return objs.Prefixes
 }
 
 // objects converts emulator objects to their dashboard representation.

--- a/cli/daemon/dash/bucketbrowser_test.go
+++ b/cli/daemon/dash/bucketbrowser_test.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -197,16 +198,14 @@ func TestListPagination(t *testing.T) {
 
 // TestListPaginationWithPrefixRollup covers a page that fills up entirely with
 // rolled-up sub-paths: it still has to hand back a token, or the dashboard stops
-// early and silently hides the remaining folders.
-//
-// A prefix may be reported on more than one page, which the dashboard deduplicates,
-// so this only checks that every folder is eventually seen.
+// early and silently hides the remaining folders. Each folder is reported once, on
+// one page, so the dashboard can append pages as they arrive.
 func TestListPaginationWithPrefixRollup(t *testing.T) {
 	ctx := context.Background()
 	target := newTestTarget(t, &meta.Bucket{Name: testBucket})
 	seed(t, target, "a/1.txt", "b/1.txt", "c/1.txt", "d/1.txt")
 
-	seen := make(map[string]bool)
+	var got []string
 	pageToken := ""
 	for i := 0; ; i++ {
 		if i > 10 {
@@ -216,18 +215,44 @@ func TestListPaginationWithPrefixRollup(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, prefix := range res.Prefixes {
-			seen[prefix] = true
-		}
+		got = append(got, res.Prefixes...)
 		if res.NextPageToken == "" {
 			break
 		}
 		pageToken = res.NextPageToken
 	}
 
-	want := map[string]bool{"a/": true, "b/": true, "c/": true, "d/": true}
-	if !reflect.DeepEqual(seen, want) {
-		t.Errorf("prefixes seen = %v, want %v", seen, want)
+	if want := []string{"a/", "b/", "c/", "d/"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("paging through the folders gave %v, want %v", got, want)
+	}
+}
+
+// TestListLargeFolder pins that how big a folder is doesn't affect how many pages it
+// takes to browse the folder it sits in: it is one row in the dashboard however many
+// objects are below it, so it costs one result of the page reporting it.
+func TestListLargeFolder(t *testing.T) {
+	ctx := context.Background()
+	target := newTestTarget(t, &meta.Bucket{Name: testBucket})
+
+	keys := make([]string, 0, 201)
+	for i := range 200 {
+		keys = append(keys, fmt.Sprintf("holiday/%03d.jpg", i))
+	}
+	keys = append(keys, "readme.txt")
+	seed(t, target, keys...)
+
+	res, err := target.List(ctx, bucketListRequest{Delimiter: "/", PageSize: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"holiday/"}; !reflect.DeepEqual(res.Prefixes, want) {
+		t.Errorf("prefixes = %v, want %v", res.Prefixes, want)
+	}
+	if want := []string{"readme.txt"}; !reflect.DeepEqual(keysOf(res.Objects), want) {
+		t.Errorf("objects = %v, want %v", keysOf(res.Objects), want)
+	}
+	if res.NextPageToken != "" {
+		t.Error("got a page token, want the whole folder view on one page")
 	}
 }
 
@@ -245,9 +270,10 @@ func TestSearch(t *testing.T) {
 	seed(t, target, "report.pdf", "reports/q1.pdf", "2024/annual-report.pdf", "notes.txt")
 
 	tests := []struct {
-		name string
-		req  bucketSearchRequest
-		want []string
+		name         string
+		req          bucketSearchRequest
+		want         []string
+		wantPrefixes []string
 	}{
 		{
 			name: "prefix search is anchored at the start of the key",
@@ -255,9 +281,11 @@ func TestSearch(t *testing.T) {
 			want: []string{"report.pdf", "reports/q1.pdf"},
 		},
 		{
-			name: "non-recursive prefix search does not descend",
-			req:  bucketSearchRequest{Query: "report"},
-			want: []string{"report.pdf"},
+			// As Cloud Storage does with a delimiter set.
+			name:         "non-recursive prefix search rolls matches below a sub-path up",
+			req:          bucketSearchRequest{Query: "report"},
+			want:         []string{"report.pdf"},
+			wantPrefixes: []string{"reports/"},
 		},
 		{
 			name: "glob search matches anywhere in the key",
@@ -291,7 +319,50 @@ func TestSearch(t *testing.T) {
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("objects = %v, want %v", got, test.want)
 			}
+			wantPrefixes := test.wantPrefixes
+			if wantPrefixes == nil {
+				wantPrefixes = []string{}
+			}
+			if !reflect.DeepEqual(res.Prefixes, wantPrefixes) {
+				t.Errorf("prefixes = %v, want %v", res.Prefixes, wantPrefixes)
+			}
 		})
+	}
+}
+
+// TestSearchPaginationWithPrefixRollup pins that a non-recursive search spends its pages
+// the way a delimited listing does, rather than charging the page for objects a sub-path
+// stands for and then not reporting them.
+func TestSearchPaginationWithPrefixRollup(t *testing.T) {
+	ctx := context.Background()
+	target := newTestTarget(t, &meta.Bucket{Name: testBucket})
+	seed(t, target, "report-2024/q1.pdf", "report-2024/q2.pdf", "report-2024/q3.pdf",
+		"report-2025/q1.pdf", "report.pdf", "notes.txt")
+
+	res, err := target.Search(ctx, bucketSearchRequest{Query: "report", PageSize: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"report-2024/", "report-2025/"}; !reflect.DeepEqual(res.Prefixes, want) {
+		t.Errorf("prefixes = %v, want %v", res.Prefixes, want)
+	}
+	if want := []string{"report.pdf"}; !reflect.DeepEqual(keysOf(res.Objects), want) {
+		t.Errorf("objects = %v, want %v", keysOf(res.Objects), want)
+	}
+	if res.NextPageToken != "" {
+		t.Error("got a page token, want every match on one page")
+	}
+
+	// A glob search rolls nothing up, so it reports the objects themselves.
+	res, err = target.Search(ctx, bucketSearchRequest{Query: "report**", Mode: string(searchModeGlob)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Prefixes) != 0 {
+		t.Errorf("prefixes = %v, want none for a glob search", res.Prefixes)
+	}
+	if got := len(res.Objects); got != 5 {
+		t.Errorf("objects = %v, want all 5 matches", keysOf(res.Objects))
 	}
 }
 

--- a/pkg/emulators/storage/gcsemu/walk.go
+++ b/pkg/emulators/storage/gcsemu/walk.go
@@ -37,7 +37,8 @@ type ListOptions struct {
 	// matches the given glob pattern. See compileGlob for the supported syntax.
 	MatchGlob string
 
-	// MaxResults caps the number of objects and rolled-up prefixes returned.
+	// MaxResults caps the combined number of objects and rolled-up prefixes returned,
+	// counting each prefix once however many objects it stands for.
 	// If <= 0 or above MaxResults, MaxResults is used.
 	MaxResults int
 }
@@ -84,11 +85,19 @@ func (g *GcsEmu) ListObjects(ctx context.Context, baseUrl HttpBaseUrl, bucket st
 		}
 	}
 
-	// lastMatch is the name of the last object accepted by the filters, whether it was
-	// returned as an object or rolled up into a prefix. It seeds the next page token.
+	// lastMatch is the name of the last object this page reported, either in its own
+	// right or as the first object seen below a prefix. It seeds the next page token.
 	var lastMatch string
 	moreResults := false
 	count := 0
+
+	// A prefix is reported the first time an object below it is seen, so a cursor that
+	// rolls up names an object below a sub-path an earlier page of this listing already
+	// reported: everything else below it is a duplicate, and can be skipped in one step
+	// rather than walked (and, on a filesystem, stat'ed) object by object on every page.
+	// Like Cloud Storage, a page token belongs to the listing it came from; carrying one
+	// over to a different delimiter or prefix is undefined.
+	cursorPrefix := rollupPrefix(opts.Cursor, opts.Prefix, opts.Delimiter)
 	err := g.store.Walk(ctx, bucket, func(ctx context.Context, filename string, fInfo os.FileInfo) error {
 		dbgWalk("walk: %s", filename)
 
@@ -113,6 +122,11 @@ func (g *GcsEmu) ListObjects(ctx context.Context, baseUrl HttpBaseUrl, bucket st
 				dbgWalk("%q < prefix=%q skip dir", filename, opts.Prefix)
 				return filepath.SkipDir
 			}
+			// Everything below this directory was reported as a prefix already.
+			if cursorPrefix != "" && strings.HasPrefix(filename+"/", cursorPrefix) {
+				dbgWalk("%q below reported prefix=%q skip dir", filename, cursorPrefix)
+				return filepath.SkipDir
+			}
 			// Directories are not objects, so they are never reported. A folder that
 			// was explicitly created has a placeholder object inside it, which the
 			// store reports under the folder's own name.
@@ -128,11 +142,35 @@ func (g *GcsEmu) ListObjects(ctx context.Context, baseUrl HttpBaseUrl, bucket st
 			dbgWalk("%q < prefix=%q skipping", filename, opts.Prefix)
 			return nil
 		}
+		if cursorPrefix != "" && strings.HasPrefix(filename, cursorPrefix) {
+			dbgWalk("%q below reported prefix=%q skipping", filename, cursorPrefix)
+			return nil
+		}
 
 		// Non-matching objects don't consume the page budget, so that a sparse
 		// glob still fills a page instead of returning mostly-empty ones.
 		if glob != nil && !glob.MatchString(filename) {
 			dbgWalk("%q does not match glob=%q skipping", filename, opts.MatchGlob)
+			return nil
+		}
+
+		// An object below a sub-path is reported as that sub-path, and only the first
+		// one is: the rest are already covered by the prefix it produced. Those don't
+		// consume the page budget either, or a folder holding a thousand objects would
+		// fill a page of a thousand with one repeated sub-path.
+		if itemPrefix := rollupPrefix(filename, opts.Prefix, opts.Delimiter); itemPrefix != "" {
+			if seenPrefixes[itemPrefix] {
+				dbgWalk("%q already covered by prefix=%q skipping", filename, itemPrefix)
+				return nil
+			}
+			if count >= maxResults {
+				moreResults = true
+				return errAbort
+			}
+			count++
+			lastMatch = filename
+			seenPrefixes[itemPrefix] = true
+			prefixes = append(prefixes, itemPrefix)
 			return nil
 		}
 
@@ -142,22 +180,6 @@ func (g *GcsEmu) ListObjects(ctx context.Context, baseUrl HttpBaseUrl, bucket st
 		}
 		count++
 		lastMatch = filename
-
-		if opts.Delimiter != "" {
-			// See if the filename (beyond the prefix) contains delimiter, if it does, don't record the item,
-			// instead record the prefix (including the delimiter).
-			withoutPrefix := strings.TrimPrefix(filename, opts.Prefix)
-			delimiterPos := strings.Index(withoutPrefix, opts.Delimiter)
-			if delimiterPos >= 0 {
-				// Got a hit, reconstruct the item's prefix, including the trailing delimiter
-				itemPrefix := filename[:len(opts.Prefix)+delimiterPos+len(opts.Delimiter)]
-				if !seenPrefixes[itemPrefix] {
-					seenPrefixes[itemPrefix] = true
-					prefixes = append(prefixes, itemPrefix)
-				}
-				return nil
-			}
-		}
 
 		found = append(found, item{
 			filename: filename,
@@ -194,6 +216,19 @@ func (g *GcsEmu) ListObjects(ctx context.Context, baseUrl HttpBaseUrl, bucket st
 		Items:         items,
 		Prefixes:      prefixes,
 	}, nil
+}
+
+// rollupPrefix returns the sub-path name is reported as when listing below prefix with
+// the given delimiter, including the trailing delimiter, or "" if name doesn't roll up.
+func rollupPrefix(name string, prefix string, delimiter string) string {
+	if delimiter == "" || !strings.HasPrefix(name, prefix) {
+		return ""
+	}
+	delimiterPos := strings.Index(name[len(prefix):], delimiter)
+	if delimiterPos < 0 {
+		return ""
+	}
+	return name[:len(prefix)+delimiterPos+len(delimiter)]
 }
 
 // Iterate over the file system to serve a GCS list-bucket request.

--- a/pkg/emulators/storage/gcsemu/walk_test.go
+++ b/pkg/emulators/storage/gcsemu/walk_test.go
@@ -300,6 +300,147 @@ func TestListObjectsPagesEveryObject(t *testing.T) {
 	}
 }
 
+// TestListObjectsPagesEveryPrefixOnce pins how a delimited listing spends a page: on
+// results the caller hasn't seen. A sub-path counts once however many objects it stands
+// for — Cloud Storage's maxResults is the "maximum combined number of entries in items[]
+// and prefixes[]" — so a folder holding more objects than fit in a page is still one
+// prefix on one page, rather than a run of pages repeating the same sub-path.
+func TestListObjectsPagesEveryPrefixOnce(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(t.TempDir())
+	emu := NewGcsEmu(Options{Store: store})
+
+	var wantPrefixes []string
+	for folder := range 5 {
+		wantPrefixes = append(wantPrefixes, fmt.Sprintf("f%d/", folder))
+		for i := range 50 {
+			key := fmt.Sprintf("f%d/%03d.txt", folder, i)
+			if err := store.Add("bkt", key, []byte("x"), &storage.Object{}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	wantItems := []string{"g.txt", "h.txt"} // objects of the root's own, sorting last
+	for _, key := range wantItems {
+		if err := store.Add("bkt", key, []byte("x"), &storage.Object{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, maxResults := range []int{1, 2, 3, 7, 100} {
+		var gotPrefixes, gotItems []string
+		pages := 0
+		opts := ListOptions{Delimiter: "/", MaxResults: maxResults}
+		for {
+			if pages > 20 {
+				t.Fatalf("maxResults=%d: pagination did not terminate", maxResults)
+			}
+			objs, err := emu.ListObjects(ctx, "", "bkt", opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pages++
+			if got := len(objs.Items) + len(objs.Prefixes); got > maxResults {
+				t.Errorf("maxResults=%d: page held %d results", maxResults, got)
+			} else if got == 0 {
+				t.Errorf("maxResults=%d: page %d held no results at all", maxResults, pages)
+			}
+			gotPrefixes = append(gotPrefixes, objs.Prefixes...)
+			gotItems = append(gotItems, names(objs)...)
+			if objs.NextPageToken == "" {
+				break
+			}
+			cursor, err := gcsutil.DecodePageToken(objs.NextPageToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+			opts.Cursor = cursor
+		}
+
+		// Every sub-path exactly once, in order, however small the pages are.
+		if !reflect.DeepEqual(gotPrefixes, wantPrefixes) {
+			t.Errorf("maxResults=%d: paged through prefixes %v, want %v", maxResults, gotPrefixes, wantPrefixes)
+		}
+		if !reflect.DeepEqual(gotItems, wantItems) {
+			t.Errorf("maxResults=%d: paged through items %v, want %v", maxResults, gotItems, wantItems)
+		}
+		// ceil(results/n) pages exactly: nothing but a result was ever charged for.
+		if want := (len(wantPrefixes) + len(wantItems) + maxResults - 1) / maxResults; pages != want {
+			t.Errorf("maxResults=%d: took %d pages, want %d", maxResults, pages, want)
+		}
+	}
+}
+
+// TestListObjectsSkipsReportedPrefix pins that paging past a reported sub-path doesn't
+// walk what's below it again. Those objects can only roll up into the same prefix and be
+// dropped, so revisiting them costs a stat apiece for nothing — which is what made paging
+// a large folder take time quadratic in its size.
+func TestListObjectsSkipsReportedPrefix(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(t.TempDir())
+	counting := &countingStore{Store: store}
+	emu := NewGcsEmu(Options{Store: counting})
+
+	for i := range 200 {
+		if err := store.Add("bkt", fmt.Sprintf("big/%03d.txt", i), []byte("x"), &storage.Object{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, key := range []string{"y.txt", "z.txt"} {
+		if err := store.Add("bkt", key, []byte("x"), &storage.Object{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The first page reports "big/" off its first object; the pages after it must
+	// not look at the other 199.
+	opts := ListOptions{Delimiter: "/", MaxResults: 1}
+	var visited []int
+	for pages := 0; ; pages++ {
+		if pages > 5 {
+			t.Fatal("pagination did not terminate")
+		}
+		counting.walked = 0
+		objs, err := emu.ListObjects(ctx, "", "bkt", opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		visited = append(visited, counting.walked)
+		if objs.NextPageToken == "" {
+			break
+		}
+		cursor, err := gcsutil.DecodePageToken(objs.NextPageToken)
+		if err != nil {
+			t.Fatal(err)
+		}
+		opts.Cursor = cursor
+	}
+
+	if len(visited) != 3 {
+		t.Fatalf("took %d pages, want 3 (big/, y.txt, z.txt)", len(visited))
+	}
+	for _, walked := range visited[1:] {
+		// A handful covers the root and what the page reports; the point is that it
+		// isn't the 200 objects below "big/".
+		if walked > 10 {
+			t.Errorf("pages walked %v names, want the pages after the first to skip the folder", visited)
+		}
+	}
+}
+
+// countingStore counts the names a listing walks past.
+type countingStore struct {
+	Store
+	walked int
+}
+
+func (s *countingStore) Walk(ctx context.Context, bucket string, cb func(ctx context.Context, filename string, fInfo os.FileInfo) error) error {
+	return s.Store.Walk(ctx, bucket, func(ctx context.Context, filename string, fInfo os.FileInfo) error {
+		s.walked++
+		return cb(ctx, filename, fInfo)
+	})
+}
+
 // TestListObjectsClampsMaxResults pins that a caller can't ask for a bigger page than
 // Cloud Storage would give: "The service will use this parameter or 1,000 items,
 // whichever is smaller." An over-large request is capped, not rejected.


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789222151&installation_model_id=427204&pr_number=2534&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2534&signature=67b545e06f32105931895d800d8e43d233ab7cafbaaaf86a9f7e6f012f7d8adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->