### PR TITLE
fix: Stop a 304 revalidation's Content-Length (often 0) from

### DIFF
--- a/internal/httpcache/httpcache.go
+++ b/internal/httpcache/httpcache.go
@@ -189,6 +189,11 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			// Replace the 304 response with the one from cache, but update with some new headers
 			endToEndHeaders := getEndToEndHeaders(resp.Header)
 			for _, header := range endToEndHeaders {
+				if header == "Content-Length" {
+					// A 304 has no body; its Content-Length does not describe
+					// the cached body and would truncate the replayed response.
+					continue
+				}
 				cachedResp.Header[header] = resp.Header[header]
 			}
 			resp = cachedResp


### PR DESCRIPTION
Fixes #2187.

Stop a 304 revalidation's Content-Length (often 0) from overwriting the cached response's length in internal/httpcache, which truncated replayed dashboard HTML/JS to zero bytes and rendered the dev dashboard as a blank white page.

Files: `internal/httpcache/httpcache.go`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789502864&installation_model_id=427204&pr_number=2536&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2536&signature=7d0500c5c4d59af14b8541179216fdd45d29adf04bcf0390207a27a16c50c0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

**Verification note:** the root cause is mechanism-level — on 304 revalidation the cached response's headers were overwritten with the 304's `Content-Length`, which does not describe the cached body and truncates the replayed response. The full test suite passes with this change, but the reported symptom (white Development Dashboard on Windows) was not reproduced in our environment (macOS), so the fix is verified against the mechanism rather than the reported rendering failure.