### PR TITLE
daemon: fixes for origin checks

### DIFF
--- a/cli/cmd/encore/daemon/daemon.go
+++ b/cli/cmd/encore/daemon/daemon.go
@@ -286,7 +286,7 @@ func (d *Daemon) serveObjects() {
 func (d *Daemon) serveDash() {
 	log.Info().Stringer("addr", d.Dash.Addr()).Msg("serving dash")
 	srv := dash.NewServer(d.Apps, d.RunMgr, d.NS, d.Trace, d.Dash.Port())
-	d.exit <- http.Serve(d.Dash, httpx.CheckOrigin(httpx.IsLocalOrigin, srv))
+	d.exit <- http.Serve(d.Dash, httpx.CheckOrigin(httpx.IsNotExternalWebsite, srv))
 }
 
 func (d *Daemon) serveDebug() {

--- a/cli/daemon/dash/server.go
+++ b/cli/daemon/dash/server.go
@@ -24,7 +24,7 @@ import (
 )
 
 var upgrader = websocket.Upgrader{
-	CheckOrigin: httpx.IsLocalOrigin,
+	CheckOrigin: httpx.IsNotExternalWebsite,
 }
 
 // NewServer starts a new server and returns it.

--- a/cli/daemon/mcp/mcp.go
+++ b/cli/daemon/mcp/mcp.go
@@ -14,6 +14,7 @@ import (
 	"encr.dev/cli/daemon/objects"
 	"encr.dev/cli/daemon/run"
 	"encr.dev/cli/daemon/sqldb"
+	"encr.dev/pkg/httpx"
 )
 
 // serverInstructions is returned to MCP clients in the `initialize` response.
@@ -117,25 +118,7 @@ func addAppToContext(ctx context.Context, r *http.Request) context.Context {
 }
 
 func (m *Manager) Serve(listener net.Listener) error {
-	return http.Serve(listener, originCheck(m.sse))
-}
-
-// originCheck restricts the MCP server to local code agents (editors, CLI tools),
-// which don't send an Origin header, and rejects browser requests.
-func originCheck(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !allowedOrigin(r) {
-			http.Error(w, "forbidden", http.StatusForbidden)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
-func allowedOrigin(req *http.Request) bool {
-	// The MCP server is only consumed by local code agents, which don't send an
-	// Origin header. Browsers always do, so reject any request that carries one.
-	return req.Header.Get("Origin") == ""
+	return http.Serve(listener, httpx.CheckOrigin(httpx.IsNonBrowser, m.sse))
 }
 
 func (m *Manager) getApp(ctx context.Context) (*apps.Instance, error) {

--- a/cli/daemon/mcp/mcp_test.go
+++ b/cli/daemon/mcp/mcp_test.go
@@ -4,12 +4,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"encr.dev/pkg/httpx"
 )
 
 // TestOriginCheck verifies the MCP listener only serves code agents (no Origin
 // header) and rejects any browser request (which always carries an Origin).
 func TestOriginCheck(t *testing.T) {
-	handler := originCheck(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := httpx.CheckOrigin(httpx.IsNonBrowser, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/pkg/httpx/origin.go
+++ b/pkg/httpx/origin.go
@@ -7,6 +7,18 @@ import (
 	"net/url"
 )
 
+// isNonCrossSite gates browser requests coming from another site that don't
+// get the CORS check-ed. For example, GET sub-resource loads (<img>, <script>, etc.).
+func isNonCrossSite(req *http.Request) bool {
+	return req.Header.Get("Sec-Fetch-Site") != "cross-site"
+}
+
+// IsNotExternalWebsite makes sure request did not come from a browser page that is
+// not a localhost.
+func IsNotExternalWebsite(req *http.Request) bool {
+	return IsLocalOrigin(req) && isNonCrossSite(req)
+}
+
 // IsLocalOrigin gates localhost-bound dev servers so a malicious website can't
 // drive-by request them, while still serving the local dashboard and frontend
 // dev servers (which run on localhost).
@@ -14,13 +26,8 @@ import (
 // Browser requests are allowed only when the Origin's host is loopback or
 // "localhost"; other origins are rejected. Requests without an Origin are
 // allowed, since non-browser clients (the app runtime, CLI tools) don't send
-// one. Browsers also omit Origin on GET sub-resource loads (<img>, <script>),
-// so we additionally reject Sec-Fetch-Site: cross-site to catch those.
+// one.
 func IsLocalOrigin(req *http.Request) bool {
-	if req.Header.Get("Sec-Fetch-Site") == "cross-site" {
-		return false
-	}
-
 	origin := req.Header.Get("Origin")
 	if origin == "" {
 		return true

--- a/pkg/httpx/origin_test.go
+++ b/pkg/httpx/origin_test.go
@@ -6,18 +6,26 @@ import (
 	"testing"
 )
 
-func newReq(origin string) *http.Request {
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/x", nil)
-	if origin != "" {
-		req.Header.Set("Origin", origin)
+func withSecFetchSite(secFetchSite string) func(*http.Request) {
+	return func(req *http.Request) {
+		if secFetchSite != "" {
+			req.Header.Set("Sec-Fetch-Site", secFetchSite)
+		}
 	}
-	return req
 }
 
-func newReqWithFetchSite(origin, fetchSite string) *http.Request {
-	req := newReq(origin)
-	if fetchSite != "" {
-		req.Header.Set("Sec-Fetch-Site", fetchSite)
+func withOrigin(origin string) func(*http.Request) {
+	return func(req *http.Request) {
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+	}
+}
+
+func newReq(opts ...func(*http.Request)) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/x", nil)
+	for _, apply := range opts {
+		apply(req)
 	}
 	return req
 }
@@ -36,13 +44,38 @@ func TestIsLocalOrigin(t *testing.T) {
 		{"://bad", false},
 	}
 	for _, tt := range tests {
-		if got := IsLocalOrigin(newReq(tt.origin)); got != tt.want {
+		if got := IsLocalOrigin(newReq(withOrigin(tt.origin))); got != tt.want {
 			t.Errorf("IsLocalOrigin(%q) = %v, want %v", tt.origin, got, tt.want)
 		}
 	}
 }
 
-func TestIsLocalOriginFetchMetadata(t *testing.T) {
+func TestIsNonBrowser(t *testing.T) {
+	tests := []struct {
+		origin       string
+		secFetchSite string
+		want         bool
+	}{
+		{"", "", true}, // only a missing Origin + Sec-Fetch-Site are allowed
+		// Origin or Sec-Fetch-Site headers are not allowd
+		{"http://localhost:5173", "", false},
+		{"http://localhost:5173", "", false},
+		{"http://127.0.0.1:3000", "", false},
+		{"https://example.com", "", false},
+		{"", "same-site", false},
+		{"", "same-origin", false},
+		{"", "cross-site", false},
+		{"", "none", false},
+		{"http://localhost:3000", "same-site", false},
+	}
+	for _, tt := range tests {
+		if got := IsNonBrowser(newReq(withOrigin(tt.origin), withSecFetchSite(tt.secFetchSite))); got != tt.want {
+			t.Errorf("IsNonBrowser(%q) = %v, want %v", tt.origin, got, tt.want)
+		}
+	}
+}
+
+func TestIsNonExternalWebsite(t *testing.T) {
 	tests := []struct {
 		name      string
 		origin    string
@@ -50,7 +83,7 @@ func TestIsLocalOriginFetchMetadata(t *testing.T) {
 		want      bool
 	}{
 		// A cross-site GET sub-resource load (e.g. <img>) sends no Origin but
-		// still carries Sec-Fetch-Site: cross-site. It must be rejected.
+		// still carries Sec-Fetch-Site: cross-site.
 		{"cross-site no origin", "", "cross-site", false},
 		{"cross-site with origin", "https://example.com", "cross-site", false},
 		// Same-origin/same-site requests from the local dashboard and localhost
@@ -61,47 +94,8 @@ func TestIsLocalOriginFetchMetadata(t *testing.T) {
 		{"user navigation", "", "none", true},
 	}
 	for _, tt := range tests {
-		if got := IsLocalOrigin(newReqWithFetchSite(tt.origin, tt.fetchSite)); got != tt.want {
+		if got := IsNotExternalWebsite(newReq(withOrigin(tt.origin), withSecFetchSite(tt.fetchSite))); got != tt.want {
 			t.Errorf("%s: IsLocalOrigin(origin=%q, sec-fetch-site=%q) = %v, want %v", tt.name, tt.origin, tt.fetchSite, got, tt.want)
-		}
-	}
-}
-
-func TestIsNonBrowser(t *testing.T) {
-	tests := []struct {
-		origin string
-		want   bool
-	}{
-		{"", true}, // only a missing Origin is allowed
-		{"http://localhost:5173", false},
-		{"http://127.0.0.1:3000", false},
-		{"https://example.com", false},
-	}
-	for _, tt := range tests {
-		if got := IsNonBrowser(newReq(tt.origin)); got != tt.want {
-			t.Errorf("IsNonBrowser(%q) = %v, want %v", tt.origin, got, tt.want)
-		}
-	}
-}
-
-func TestIsNonBrowserFetchMetadata(t *testing.T) {
-	tests := []struct {
-		name      string
-		origin    string
-		fetchSite string
-		want      bool
-	}{
-		// go tool pprof / CLIs / the app runtime send neither header.
-		{"non-browser tool", "", "", true},
-		// A browser GET drive-by (e.g. <img src=".../debug/pprof/profile">)
-		// sends no Origin but does send Sec-Fetch-Site. It must be rejected.
-		{"cross-site drive-by", "", "cross-site", false},
-		{"same-origin browser", "", "same-origin", false},
-		{"user navigation", "", "none", false},
-	}
-	for _, tt := range tests {
-		if got := IsNonBrowser(newReqWithFetchSite(tt.origin, tt.fetchSite)); got != tt.want {
-			t.Errorf("%s: IsNonBrowser(origin=%q, sec-fetch-site=%q) = %v, want %v", tt.name, tt.origin, tt.fetchSite, got, tt.want)
 		}
 	}
 }
@@ -112,13 +106,13 @@ func TestCheckOrigin(t *testing.T) {
 	}))
 
 	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, newReq(""))
+	handler.ServeHTTP(rec, newReq())
 	if rec.Code != http.StatusOK {
 		t.Errorf("no-origin request: got %d, want 200", rec.Code)
 	}
 
 	rec = httptest.NewRecorder()
-	handler.ServeHTTP(rec, newReq("https://example.com"))
+	handler.ServeHTTP(rec, newReq(withOrigin("https://example.com")))
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("browser request: got %d, want 403", rec.Code)
 	}


### PR DESCRIPTION
follow-up to 1e683cea1d655f6404401aba9a6c52cca823e982

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644156&installation_model_id=427204&pr_number=2537&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2537&signature=3c066bc359812815c8f94fe458cc6862ab57204ef03ba45c0ea8ac7b80d27673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->