### PR TITLE
docs: describe handling PostgreSQL database errors

### DIFF
--- a/docs/go/primitives/api-errors.md
+++ b/docs/go/primitives/api-errors.md
@@ -1,5 +1,5 @@
 ---
-seotitle: API Errors 鈥?Types, Wrappers, and Codes
+seotitle: API Errors – Types, Wrappers, and Codes
 seodesc: See how to return structured error information from your APIs using Encore's errs package, and how to build precise error messages for complex business logic.
 title: API Errors
 subtitle: Returning structured error information from your APIs

--- a/docs/go/primitives/api-errors.md
+++ b/docs/go/primitives/api-errors.md
@@ -1,5 +1,5 @@
 ---
-seotitle: API Errors - Types, Wrappers, and Codes
+seotitle: API Errors 鈥?Types, Wrappers, and Codes
 seodesc: See how to return structured error information from your APIs using Encore's errs package, and how to build precise error messages for complex business logic.
 title: API Errors
 subtitle: Returning structured error information from your APIs
@@ -26,7 +26,8 @@ type Error struct {
 	Message string `json:"message"`
 	// Details are user-defined additional details.
 	Details ErrDetails `json:"details"`
-	// Meta are arbitrary key-value pairs for use within the Encore application. They are not exposed to external clients.
+	// Meta are arbitrary key-value pairs for use within
+	// the Encore application. They are not exposed to external clients.
 	Meta Metadata `json:"-"`
 }
 ```
@@ -134,7 +135,6 @@ if errors.As(err, &dbErr) {
 ```
 
 Use `sqldb.ErrCode(err)` when only the general database error code is needed. It returns `sqlerr.Other` for errors that are not database errors.
-
 ## Error Building
 
 In cases where you have complex business logic, or multiple error returns,

--- a/docs/go/primitives/api-errors.md
+++ b/docs/go/primitives/api-errors.md
@@ -1,5 +1,5 @@
 ---
-seotitle: API Errors – Types, Wrappers, and Codes
+seotitle: API Errors - Types, Wrappers, and Codes
 seodesc: See how to return structured error information from your APIs using Encore's errs package, and how to build precise error messages for complex business logic.
 title: API Errors
 subtitle: Returning structured error information from your APIs
@@ -26,8 +26,7 @@ type Error struct {
 	Message string `json:"message"`
 	// Details are user-defined additional details.
 	Details ErrDetails `json:"details"`
-	// Meta are arbitrary key-value pairs for use within
-	// the Encore application. They are not exposed to external clients.
+	// Meta are arbitrary key-value pairs for use within the Encore application. They are not exposed to external clients.
 	Meta Metadata `json:"-"`
 }
 ```
@@ -109,6 +108,31 @@ You can find additional documentation about when to use them in the
 | `Unavailable`        | `"unavailable"`         | 503 Unavailable           |
 | `DataLoss`           | `"data_loss"`           | 500 Internal Server Error |
 | `Unauthenticated`    | `"unauthenticated"`     | 401 Unauthorized          |
+
+## Database Errors
+
+Database operations can return `*sqldb.Error` when PostgreSQL reports an error. Use `errors.As` to inspect the error's general Encore code and PostgreSQL-specific `DatabaseCode`:
+
+```go
+import (
+	"errors"
+
+	"encore.dev/storage/sqldb"
+	"encore.dev/storage/sqldb/sqlerr"
+)
+
+err := db.Exec(ctx, "INSERT INTO user (email) VALUES ($1)", email)
+var dbErr *sqldb.Error
+if errors.As(err, &dbErr) {
+	if dbErr.Code == sqlerr.UniqueViolation {
+		return nil, errs.B().Code(errs.AlreadyExists).Msg("email already exists").Err()
+	}
+	// DatabaseCode contains the PostgreSQL SQLSTATE, such as "23505".
+	log.Error("database query failed", "sqlstate", dbErr.DatabaseCode)
+}
+```
+
+Use `sqldb.ErrCode(err)` when only the general database error code is needed. It returns `sqlerr.Other` for errors that are not database errors.
 
 ## Error Building
 

--- a/docs/go/primitives/api-errors.md
+++ b/docs/go/primitives/api-errors.md
@@ -112,12 +112,13 @@ You can find additional documentation about when to use them in the
 
 ## Database Errors
 
-Database operations can return `*sqldb.Error` when PostgreSQL reports an error. Use `errors.As` to inspect the error's general Encore code and PostgreSQL-specific `DatabaseCode`:
+Database operations may return errors that wrap `*sqldb.Error` when PostgreSQL reports an error. Use `errors.As` to inspect the database error class (`sqlerr.Code`) and the PostgreSQL SQLSTATE (`DatabaseCode`):
 
 ```go
 import (
 	"errors"
 
+	"encore.dev/beta/errs"
 	"encore.dev/storage/sqldb"
 	"encore.dev/storage/sqldb/sqlerr"
 )

--- a/docs/go/primitives/api-errors.md
+++ b/docs/go/primitives/api-errors.md
@@ -121,14 +121,15 @@ import (
 	"encore.dev/storage/sqldb/sqlerr"
 )
 
-err := db.Exec(ctx, "INSERT INTO user (email) VALUES ($1)", email)
+_, err := db.Exec(ctx, "INSERT INTO user (email) VALUES ($1)", email)
 var dbErr *sqldb.Error
 if errors.As(err, &dbErr) {
 	if dbErr.Code == sqlerr.UniqueViolation {
-		return nil, errs.B().Code(errs.AlreadyExists).Msg("email already exists").Err()
+		return errs.B().Code(errs.AlreadyExists).Msg("email already exists").Err()
 	}
 	// DatabaseCode contains the PostgreSQL SQLSTATE, such as "23505".
-	log.Error("database query failed", "sqlstate", dbErr.DatabaseCode)
+	sqlstate := dbErr.DatabaseCode
+	_ = sqlstate
 }
 ```
 


### PR DESCRIPTION
## Summary

Documents the existing Go `sqldb.Error` API for handling PostgreSQL errors:

- shows how to inspect `sqlerr.Code` with `errors.As`
- explains that `DatabaseCode` contains the PostgreSQL SQLSTATE
- points readers to `sqldb.ErrCode` for code-only checks

This documents the capability requested in #386, which is already available in the runtime.

## Validation

- Verified the example against `runtimes/go/storage/sqldb/errors.go` and `sqlerr/sqlerr.go`.
- Confirmed the PR diff contains only the added documentation section.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789871243&installation_model_id=427204&pr_number=2547&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2547&signature=f70e09741432b5434104f3b2fcf6d7948b61d9c96fa327919c7bac3974c1392d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->