### PR TITLE
fix(bits): honor caller context in HTTP requests

### DIFF
--- a/cli/cmd/encore/bits/api.go
+++ b/cli/cmd/encore/bits/api.go
@@ -24,7 +24,11 @@ type ListResponse struct {
 }
 
 func List(ctx context.Context) ([]*Bit, error) {
-	resp, err := http.Get("https://automativity.encore.dev/bits")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://automativity.encore.dev/bits", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +48,11 @@ func List(ctx context.Context) ([]*Bit, error) {
 var errBitNotFound = errors.New("bit not found")
 
 func Get(ctx context.Context, slug string) (*Bit, error) {
-	resp, err := http.Get("https://automativity.encore.dev/bits/" + url.PathEscape(slug))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://automativity.encore.dev/bits/"+url.PathEscape(slug), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bits/bits.go
+++ b/pkg/bits/bits.go
@@ -22,7 +22,11 @@ type Bit struct {
 
 // List lists available bits.
 func List(ctx context.Context) ([]*Bit, error) {
-	resp, err := http.Get("https://automativity.encore.dev/bits")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://automativity.encore.dev/bits", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +51,11 @@ var ErrNotFound = errors.New("bit not found")
 
 // Get retrieves a bit by its slug.
 func Get(ctx context.Context, slug string) (*Bit, error) {
-	resp, err := http.Get("https://automativity.encore.dev/bits/" + url.PathEscape(slug))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://automativity.encore.dev/bits/"+url.PathEscape(slug), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Bits `List` and `Get` functions accept a `context.Context`, but their requests are currently sent with `http.Get`, so cancellation and deadlines from the caller are ignored.

This change creates each request with `http.NewRequestWithContext` in both Bits clients. Response handling and API behavior are otherwise unchanged.

Validated with `go test ./pkg/bits ./cli/cmd/encore/bits`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790183944&installation_model_id=427204&pr_number=2549&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2549&signature=f2c1ef3205b048fa5086e95cdc9bd3cc24950d66a183f92d264031341ee10361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->