### PR TITLE
mcp: include lang:all in search_docs facet filters

### DIFF
--- a/cli/daemon/mcp/docs_tools.go
+++ b/cli/daemon/mcp/docs_tools.go
@@ -24,7 +24,7 @@ func (m *Manager) registerDocsTools() {
 		mcp.WithArray("facet_filters",
 			mcp.Items(map[string]any{
 				"type":        "string",
-				"description": "Optional array of facet filters to narrow down search results. These can include categories, tags, or other metadata to refine the search.",
+				"description": "Optional array of facet filters to narrow down search results. These can include categories, tags, or other metadata to refine the search. Use 'lang:go' or 'lang:ts' to scope results to a language; language-agnostic pages (indexed as 'lang:all') are always included.",
 			})),
 	), m.searchDocs)
 
@@ -86,6 +86,45 @@ func (m *Manager) searchDocs(ctx context.Context, request mcp.CallToolRequest) (
 	return mcp.NewToolResultText(string(jsonData)), nil
 }
 
+const (
+	// langFacetPrefix is the Algolia facet used to scope docs pages to a language.
+	langFacetPrefix = "lang:"
+
+	// langFacetAll is the sentinel emitted for language-agnostic docs pages.
+	// They must surface no matter which language the caller filters on.
+	langFacetAll = "lang:all"
+)
+
+// buildFacetFilterGroups turns the caller-provided facet filters into Algolia
+// filter groups, where each group is ORed internally and the groups are ANDed
+// together. All filters are ANDed as-is, except lang: filters which are ORed
+// with each other and with lang:all, so language-agnostic pages always match.
+func buildFacetFilterGroups(facetFilters []string) [][]string {
+	var groups [][]string
+	var langs []string
+	seenLang := make(map[string]bool)
+
+	for _, filter := range facetFilters {
+		if !strings.HasPrefix(filter, langFacetPrefix) {
+			groups = append(groups, []string{filter})
+			continue
+		}
+		if !seenLang[filter] {
+			seenLang[filter] = true
+			langs = append(langs, filter)
+		}
+	}
+
+	if len(langs) > 0 {
+		if !seenLang[langFacetAll] {
+			langs = append(langs, langFacetAll)
+		}
+		groups = append(groups, langs)
+	}
+
+	return groups
+}
+
 // performAlgoliaSearch performs the actual search against Algolia
 func performAlgoliaSearch(ctx context.Context, query string, page, hitsPerPage int, facetFilters []string) (map[string]interface{}, error) {
 	// Initialize Algolia client with configurable app ID and API key
@@ -103,18 +142,13 @@ func performAlgoliaSearch(ctx context.Context, query string, page, hitsPerPage i
 	}
 
 	// Add facet filters if any
-	if len(facetFilters) > 0 {
-		// For a simple AND of all filters - need to convert []string to variadic arguments
-		if len(facetFilters) == 1 {
-			params = append(params, opt.FacetFilter(facetFilters[0]))
-		} else {
-			// Convert []string to []interface{} for compatibility
-			facetFilterInterfaces := make([]interface{}, len(facetFilters))
-			for i, filter := range facetFilters {
-				facetFilterInterfaces[i] = filter
-			}
-			params = append(params, opt.FacetFilterAnd(facetFilterInterfaces...))
+	if groups := buildFacetFilterGroups(facetFilters); len(groups) > 0 {
+		// Each group is ORed internally, and the groups are ANDed together.
+		groupsAny := make([]interface{}, len(groups))
+		for i, group := range groups {
+			groupsAny[i] = group
 		}
+		params = append(params, opt.FacetFilterAnd(groupsAny...))
 	}
 
 	// Perform the search

--- a/cli/daemon/mcp/docs_tools_test.go
+++ b/cli/daemon/mcp/docs_tools_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBuildFacetFilterGroups(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		in   []string
+		want [][]string
+	}{
+		{
+			name: "no filters",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "single lang includes lang:all",
+			in:   []string{"lang:go"},
+			want: [][]string{{"lang:go", "lang:all"}},
+		},
+		{
+			name: "multiple langs are ORed together",
+			in:   []string{"lang:go", "lang:ts"},
+			want: [][]string{{"lang:go", "lang:ts", "lang:all"}},
+		},
+		{
+			name: "explicit lang:all is not duplicated",
+			in:   []string{"lang:all", "lang:go"},
+			want: [][]string{{"lang:all", "lang:go"}},
+		},
+		{
+			name: "duplicate langs are deduped",
+			in:   []string{"lang:go", "lang:go"},
+			want: [][]string{{"lang:go", "lang:all"}},
+		},
+		{
+			name: "non-lang filters are ANDed as-is",
+			in:   []string{"section:docs", "type:page"},
+			want: [][]string{{"section:docs"}, {"type:page"}},
+		},
+		{
+			name: "mixed filters AND the non-lang ones with the lang group",
+			in:   []string{"section:docs", "lang:ts"},
+			want: [][]string{{"section:docs"}, {"lang:ts", "lang:all"}},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(buildFacetFilterGroups(test.in), qt.DeepEquals, test.want)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Language-agnostic docs pages now emit `lang: "all"` in Algolia — 237 objects across 36 docs. The object shape is unchanged (`lang` is still present, still a string), so this is not a shape change. The facet has three values: `ts`, `go`, and the `all` sentinel.

The website needed no change: `mod/docs/DocsSearch.tsx` already builds its filter as `lang:all` unconditionally, ORed with whichever of `lang:ts` / `lang:go` the chips select — so agnostic pages surface under every chip combination. The `lang:all` sentinel was already in the query contract, just never emitted.

The `search_docs` MCP tool was the gap — and it was slightly wider than just "missing `lang:all`". It never emitted a lang filter of its own; it passed the caller's `facet_filters` straight through and ANDed all of them via `opt.FacetFilterAnd`. So:

- `facet_filters: ["lang:go"]` → agnostic pages invisible. The reported bug.
- `facet_filters: ["lang:go", "lang:ts"]` → **zero hits**, since a page only ever carries one lang value. Pre-existing, fixed by the same change.
- No `facet_filters` → already fine, everything came back.

## Change

- New `buildFacetFilterGroups` partitions the incoming filters: non-`lang:` filters each become their own AND group as before; `lang:` filters collapse into a single OR group with `lang:all` appended (deduped, so an explicit `lang:all` isn't doubled). Mirrors what `DocsSearch.tsx` does.
- `performAlgoliaSearch` feeds those groups to `opt.FacetFilterAnd` as `[]string` groups — the Algolia Go client treats a nested `[]string` as OR-within-AND, so there's no query-string hand-rolling. The old single-filter `opt.FacetFilter` special case is gone; one path now handles both.
- Widened the `facet_filters` tool description so the calling model knows the lang values (`lang:go`, `lang:ts`) and that agnostic pages are always included.

## Testing

Added `cli/daemon/mcp/docs_tools_test.go` — 7 table cases over the grouping logic, all passing. `go vet ./cli/daemon/mcp/` and `go build ./cli/...` clean.

## Note

CLIs already installed in the wild won't have this either way, so agnostic pages stay invisible to `search_docs` for those users until they update. Accepted — the alternative was double-emitting every agnostic page under both languages.