### PR TITLE
runtime: Remove automaxprocs

### DIFF
--- a/runtimes/go/appruntime/apisdk/app/app.go
+++ b/runtimes/go/appruntime/apisdk/app/app.go
@@ -1,13 +1,11 @@
 package app
 
 import (
-	"github.com/rs/zerolog"
-	"go.uber.org/automaxprocs/maxprocs"
-
 	"encore.dev/appruntime/apisdk/api"
 	"encore.dev/appruntime/apisdk/service"
 	"encore.dev/appruntime/exported/config"
 	"encore.dev/appruntime/shared/shutdown"
+	"github.com/rs/zerolog"
 
 	// Initialize the metric subsystem
 	_ "encore.dev/appruntime/infrasdk/metrics"
@@ -34,25 +32,6 @@ func New(runtime *config.Runtime, service *service.Manager, api *api.Server, shu
 }
 
 func (app *App) Run() error {
-	if app.runtime.EnvCloud != "local" {
-		// Set the maximum number of processes to use based on the enviroment we're running inside
-		// and what we can detect. Note this is required because the default value of GOMAXPROCS is
-		// the number of logical CPUs on the machine, which inside a kubernetes environment is not
-		// the same as the number of CPUs allocated to the container. This can lead to CPU throttling
-		// by the kernel and high tail latencies.
-		//
-		// We only do this when the app starts up, rather than using the automaxprocs magic import
-		// so it does not impact anything else which imports the Encore runtime (such as the CLI tooling).
-		undoMaxProcs, err := maxprocs.Set(maxprocs.Logger(func(s string, args ...interface{}) {
-			app.logger.Debug().Msgf(s, args...)
-		}))
-		if err != nil {
-			app.logger.Err(err).Msg("failed to set GOMAXPROCS")
-		} else {
-			defer undoMaxProcs()
-		}
-	}
-
 	ln, err := Listen()
 	if err != nil {
 		return err

--- a/runtimes/go/go.mod
+++ b/runtimes/go/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/rs/xid v1.5.0
 	github.com/rs/zerolog v1.31.0
 	go.encore.dev/platform-sdk v1.1.0
-	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/crypto v0.49.0
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0


### PR DESCRIPTION
Since GO 1.25 GOMAXPROCS default is CPU limit-aware
https://github.com/golang/go/issues/73193

automaxprocs doesn't correctly handle Cloud Runs CPU allocation during startup

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790495128&installation_model_id=427204&pr_number=2554&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2554&signature=82be7fca5a0365e3ff040e18e8c19760f918fce8a9d3aaaf45599c09ea230c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->