### PR TITLE
ts-runtime: Move DB pools up to be shared across process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,6 @@ dependencies = [
  "futures",
  "log",
  "malachite",
- "mappable-rc",
  "metrics",
  "napi",
  "napi-build",
@@ -4059,12 +4058,6 @@ dependencies = [
  "malachite-base",
  "malachite-nz",
 ]
-
-[[package]]
-name = "mappable-rc"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204651f31b0a6a7b2128d2b92c372cd94607b210c3a6b6e542c57a8cfd4db996"
 
 [[package]]
 name = "match_cfg"

--- a/runtimes/core/src/sqldb/client.rs
+++ b/runtimes/core/src/sqldb/client.rs
@@ -2,32 +2,136 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
 
 use bb8::{ErrorSink, PooledConnection, RunError};
 use bb8_postgres::PostgresConnectionManager;
 use futures_util::StreamExt;
 
+use tokio_postgres::config::Host;
 use tokio_postgres::types::BorrowToSql;
 
 use crate::sqldb::val::RowValue;
 use crate::trace::{protocol, Tracer};
 use crate::{model, sqldb};
 
+use super::manager::PoolConfig;
 use super::transaction::Transaction;
 
 type Mgr = PostgresConnectionManager<postgres_native_tls::MakeTlsConnector>;
 
+/// Identifies a set of interchangeable connections.
+///
+/// Two databases with equal keys are the same database reached the same way, so
+/// a single set of connections serves both. The fields are therefore everything
+/// that makes two connections *not* interchangeable — including the password,
+/// not as an authorization check (nothing outside the runtime config can choose
+/// one; see `databases_from_cfg`) but so that a credential which differs for any
+/// reason cannot be served a pool that was opened with another.
+///
+/// TLS is deliberately absent. It is configured per server, and a server is
+/// identified by its host and port, so equal keys already imply equal TLS.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct PoolKey {
+    hosts: Vec<String>,
+    ports: Vec<u16>,
+    dbname: Option<String>,
+    user: Option<String>,
+    password: Option<Vec<u8>>,
+    min_conns: u32,
+    max_conns: u32,
+}
+
+/// Compared in full, but never printed: `tokio_postgres::Config` redacts its own
+/// password for this reason, and a derived `Debug` here would undo that.
+impl std::fmt::Debug for PoolKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PoolKey")
+            .field("hosts", &self.hosts)
+            .field("ports", &self.ports)
+            .field("dbname", &self.dbname)
+            .field("user", &self.user)
+            .field("password", &self.password.as_ref().map(|_| "_"))
+            .field("min_conns", &self.min_conns)
+            .field("max_conns", &self.max_conns)
+            .finish()
+    }
+}
+
+impl PoolKey {
+    fn new(config: &tokio_postgres::Config, pool_cfg: &PoolConfig) -> Self {
+        Self {
+            hosts: config
+                .get_hosts()
+                .iter()
+                .map(|host| match host {
+                    Host::Tcp(host) => host.clone(),
+                    #[cfg(unix)]
+                    Host::Unix(path) => path.to_string_lossy().into_owned(),
+                })
+                .collect(),
+            ports: config.get_ports().to_vec(),
+            dbname: config.get_dbname().map(str::to_owned),
+            user: config.get_user().map(str::to_owned),
+            password: config.get_password().map(<[u8]>::to_vec),
+            min_conns: pool_cfg.min_conns,
+            max_conns: pool_cfg.max_conns,
+        }
+    }
+}
+
+/// The connection pools in use by this process, shared across runtimes.
+///
+/// A process can hold more than one runtime: in test mode every `Runtime`
+/// construction builds a fresh one (see the JS runtime's `test_mode` branch), and
+/// a test runner that re-evaluates the module declaring a database does exactly
+/// that. Keying the pools on the connection itself rather than on the runtime
+/// that asked for it bounds a process to one pool per database however many
+/// runtimes it accumulates.
+///
+/// Held weakly so a pool is released once the last handle to it goes away. A dead
+/// entry is simply overwritten the next time its database is opened.
+static POOLS: OnceLock<Mutex<HashMap<PoolKey, Weak<bb8::Pool<Mgr>>>>> = OnceLock::new();
+
 pub struct Pool {
-    pool: bb8::Pool<Mgr>,
+    /// Shared with every other handle to the same database in this process.
+    pool: Arc<bb8::Pool<Mgr>>,
+    /// Not shared: traces belong to the runtime that issued the query.
     tracer: QueryTracer,
 }
 
 impl Pool {
     pub fn new<DB: sqldb::Database>(db: &DB, tracer: Tracer) -> anyhow::Result<Self> {
+        let pool_cfg = db.pool_config()?;
+        let key = PoolKey::new(db.config()?, &pool_cfg);
+
+        let mut pools = POOLS
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+
+        let pool = match pools.get(&key).and_then(Weak::upgrade) {
+            Some(pool) => pool,
+            None => {
+                let pool = Arc::new(Self::build_conn_pool(db, &pool_cfg)?);
+                pools.insert(key, Arc::downgrade(&pool));
+                pool
+            }
+        };
+
+        Ok(Self {
+            pool,
+            tracer: QueryTracer(tracer),
+        })
+    }
+
+    fn build_conn_pool<DB: sqldb::Database>(
+        db: &DB,
+        pool_cfg: &PoolConfig,
+    ) -> anyhow::Result<bb8::Pool<Mgr>> {
         let tls = db.tls()?.clone();
         let mgr = Mgr::new(db.config()?.clone(), tls);
 
-        let pool_cfg = db.pool_config()?;
         let mut pool = bb8::Pool::builder()
             .error_sink(Box::new(RustLoggerSink {
                 db_name: db.name().to_string(),
@@ -42,11 +146,13 @@ impl Pool {
             pool = pool.min_idle(Some(pool_cfg.min_conns));
         }
 
-        let pool = pool.build_unchecked(mgr);
-        Ok(Self {
-            pool,
-            tracer: QueryTracer(tracer),
-        })
+        Ok(pool.build_unchecked(mgr))
+    }
+
+    /// Reports whether two handles draw on the same connections.
+    #[cfg(test)]
+    pub(crate) fn shares_connections_with(&self, other: &Pool) -> bool {
+        Arc::ptr_eq(&self.pool, &other.pool)
     }
 }
 
@@ -274,5 +380,31 @@ impl QueryTracer {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod key_test {
+    use super::*;
+
+    /// The password is part of the key but must not be printable: it would
+    /// otherwise leak through any log line or panic message that formats a key,
+    /// undoing the redaction `tokio_postgres::Config` does for the same reason.
+    #[test]
+    fn debug_does_not_print_the_password() {
+        let mut config = tokio_postgres::Config::new();
+        config.host("localhost").user("encore").password("hunter2");
+        let key = PoolKey::new(
+            &config,
+            &PoolConfig {
+                min_conns: 0,
+                max_conns: 30,
+            },
+        );
+
+        let rendered = format!("{key:?}");
+        assert!(!rendered.contains("hunter2"), "{rendered}");
+        // The bytes must not leak in numeric form either.
+        assert!(!rendered.contains("104"), "{rendered}");
     }
 }

--- a/runtimes/core/src/sqldb/manager.rs
+++ b/runtimes/core/src/sqldb/manager.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio_postgres::proxy;
 
 use tokio_postgres::proxy::{AcceptConn, AuthMethod, ClientBouncer, RejectConn};
@@ -108,7 +108,18 @@ pub trait Database: Send + Sync {
     fn pool_config(&self) -> anyhow::Result<PoolConfig>;
     fn config(&self) -> anyhow::Result<&tokio_postgres::Config>;
     fn tls(&self) -> anyhow::Result<&postgres_native_tls::MakeTlsConnector>;
-    fn new_pool(&self) -> anyhow::Result<Pool>;
+
+    /// Returns the connection pool for this database, opening it on first use.
+    ///
+    /// The pool belongs to the database, not to the caller: every handle to the
+    /// same database shares it. Handing out a fresh pool per handle would let a
+    /// host that resolves the same database repeatedly — a test runner
+    /// re-evaluating the module that declares it, say — accumulate a full set of
+    /// connections per resolution, with nothing closing the earlier ones.
+    ///
+    /// The error is shared rather than cloned because [`anyhow::Error`] isn't
+    /// `Clone`, and a pool that failed to build stays failed.
+    fn pool(&self) -> Result<&Pool, Arc<anyhow::Error>>;
 
     /// Returns the connection string for connecting to this database via the proxy.
     fn proxy_conn_string(&self) -> &str;
@@ -124,6 +135,9 @@ pub struct DatabaseImpl {
 
     min_conns: u32,
     max_conns: u32,
+
+    /// The connection pool, built on first use and shared from then on.
+    pool: OnceLock<Result<Pool, Arc<anyhow::Error>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -152,8 +166,14 @@ impl Database for DatabaseImpl {
         Ok(&self.tls)
     }
 
-    fn new_pool(&self) -> anyhow::Result<Pool> {
-        Pool::new(self, self.tracer.clone())
+    fn pool(&self) -> Result<&Pool, Arc<anyhow::Error>> {
+        match self
+            .pool
+            .get_or_init(|| Pool::new(self, self.tracer.clone()).map_err(Arc::new))
+        {
+            Ok(pool) => Ok(pool),
+            Err(err) => Err(err.clone()),
+        }
     }
 
     fn proxy_conn_string(&self) -> &str {
@@ -183,8 +203,10 @@ impl Database for NoopDatabase {
         anyhow::bail!("this database is not configured for use by this process")
     }
 
-    fn new_pool(&self) -> anyhow::Result<Pool> {
-        anyhow::bail!("this database is not configured for use by this process")
+    fn pool(&self) -> Result<&Pool, Arc<anyhow::Error>> {
+        Err(Arc::new(anyhow::anyhow!(
+            "this database is not configured for use by this process"
+        )))
     }
 
     fn proxy_conn_string(&self) -> &str {
@@ -374,6 +396,8 @@ fn databases_from_cfg(
 
                     min_conns: pool.min_connections as u32,
                     max_conns: pool.max_connections as u32,
+
+                    pool: OnceLock::new(),
                 }),
             );
         }
@@ -401,4 +425,84 @@ fn convert_client_key_if_necessary(pem: &[u8]) -> anyhow::Result<Cow<'_, [u8]>> 
         .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
         .context("failed to convert PKCS#1 private key to PKCS#8")?;
     Ok(Cow::Owned(pkcs8.as_bytes().to_owned()))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn database(dbname: &str, max_conns: u32) -> DatabaseImpl {
+        let tls = native_tls::TlsConnector::new().expect("build tls connector");
+        let mut config = tokio_postgres::Config::new();
+        config
+            .host("localhost")
+            .port(5432)
+            .dbname(dbname)
+            .user("encore");
+        DatabaseImpl {
+            name: dbname.into(),
+            config: Arc::new(config),
+            tls: postgres_native_tls::MakeTlsConnector::new(tls),
+            proxy_conn_string: String::new(),
+            tracer: Tracer::noop(),
+            min_conns: 0,
+            max_conns,
+            pool: OnceLock::new(),
+        }
+    }
+
+    /// Every handle to a database shares one pool.
+    ///
+    /// Building a pool per handle meant a host that resolves the same database
+    /// repeatedly — a test runner re-evaluating the module that declares it —
+    /// opened a fresh set of up to `max_conns` connections each time, with
+    /// nothing ever closing the earlier ones, until the server refused more.
+    #[tokio::test]
+    async fn pool_is_shared_across_lookups() {
+        let db = database("shared_lookups", 30);
+        let first = db.pool().expect("first pool");
+        let second = db.pool().expect("second pool");
+        assert!(
+            std::ptr::eq(first, second),
+            "each lookup built its own pool"
+        );
+    }
+
+    /// A process can accumulate runtimes — in test mode each `Runtime`
+    /// construction builds its own, and a test runner that re-evaluates the
+    /// declaring module builds one per test file. Each brings its own
+    /// `DatabaseImpl`, so pooling per database object still multiplied the
+    /// connections; they have to be keyed on the connection instead.
+    #[tokio::test]
+    async fn connections_are_shared_across_runtimes() {
+        let one = database("shared_runtimes", 30);
+        let two = database("shared_runtimes", 30);
+        assert!(one
+            .pool()
+            .expect("first pool")
+            .shares_connections_with(two.pool().expect("second pool")));
+    }
+
+    #[tokio::test]
+    async fn connections_are_not_shared_across_databases() {
+        let one = database("distinct_a", 30);
+        let two = database("distinct_b", 30);
+        assert!(!one
+            .pool()
+            .expect("first pool")
+            .shares_connections_with(two.pool().expect("second pool")));
+    }
+
+    /// Pool sizing is part of what makes connections interchangeable: a handle
+    /// asking for a different ceiling must not be handed a pool built for
+    /// another one.
+    #[tokio::test]
+    async fn connections_are_not_shared_across_pool_sizes() {
+        let one = database("distinct_sizes", 10);
+        let two = database("distinct_sizes", 30);
+        assert!(!one
+            .pool()
+            .expect("first pool")
+            .shares_connections_with(two.pool().expect("second pool")));
+    }
 }

--- a/runtimes/js/Cargo.toml
+++ b/runtimes/js/Cargo.toml
@@ -25,7 +25,6 @@ bytes = "1.5.0"
 prost = "0.12.3"
 prost-types = "0.12.3"
 futures = "0.3.30"
-mappable-rc = "0.1.1"
 tokio-util = { version = "0.7.10", features = ["io"] }
 chrono = "0.4.38"
 num_cpus = "1.16.0"

--- a/runtimes/js/src/sqldb.rs
+++ b/runtimes/js/src/sqldb.rs
@@ -1,17 +1,15 @@
 use crate::api::Request;
 use crate::pvalue::{parse_pvalue, pvalue_to_js};
 use encore_runtime_core::sqldb;
-use mappable_rc::Marc;
 use napi::{Env, JsUnknown};
 use napi_derive::napi;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 #[napi]
 pub struct SQLDatabase {
     db: Arc<dyn sqldb::Database>,
-    pool: OnceLock<Marc<napi::Result<sqldb::Pool>>>,
 }
 
 #[napi]
@@ -49,10 +47,7 @@ fn convert_row_values(params: Vec<JsUnknown>) -> napi::Result<Vec<sqldb::RowValu
 #[napi]
 impl SQLDatabase {
     pub(crate) fn new(db: Arc<dyn sqldb::Database>) -> Self {
-        Self {
-            db,
-            pool: OnceLock::new(),
-        }
+        Self { db }
     }
 
     /// Reports the connection string to connect to this database.
@@ -117,21 +112,13 @@ impl SQLDatabase {
         Ok(row.map(|row| Row { row }))
     }
 
+    /// The pool is owned by the underlying database and shared across every
+    /// `SQLDatabase` handle resolving to the same name, so constructing this
+    /// object repeatedly costs nothing in connections.
     fn pool(&self) -> napi::Result<&sqldb::Pool> {
-        match self.pool_marc().as_ref() {
-            Ok(pool) => Ok(pool),
-            Err(e) => Err(e.clone()),
-        }
-    }
-
-    fn pool_marc(&self) -> &Marc<napi::Result<sqldb::Pool>> {
-        self.pool.get_or_init(|| {
-            let pool = self
-                .db
-                .new_pool()
-                .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e));
-            Marc::new(pool)
-        })
+        self.db
+            .pool()
+            .map_err(|e| napi::Error::new(napi::Status::GenericFailure, format!("{e:#}")))
     }
 }
 


### PR DESCRIPTION
TS test-mode recreates the rs Runtime for every test file, and therefore create new db pools. Completed test files do not release their db pool connections until GC, because we don't have a generic hook to identify when a test has been completed. This PR addresses this by moving the pools up to be sharable across the process rather than per Runtime.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790504458&installation_model_id=427204&pr_number=2555&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2555&signature=73414576004dbed47362246ef716a4dc2ebdf20ccfcccba75123b6f977b335d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->