### PR TITLE
runtime/{core,js}: adds caller data into requests

### DIFF
--- a/docs/ts/runtime/encore-dev.mdx
+++ b/docs/ts/runtime/encore-dev.mdx
@@ -19,6 +19,15 @@ Describes an API call being processed.
 
 Describes the API Endpoint being called.
 
+##### callerService?
+
+`optional callerService?: string`
+
+The name of the service that made the API call, for
+service-to-service calls. Not set when the request comes from
+outside the application (e.g. through an API gateway) or when
+the caller is unknown.
+
 ##### headers
 
 `headers: Record<string, string | string[]>`
@@ -172,7 +181,7 @@ Information about the environment the app is running in.
 <!-- symbol-end -->
 
 <!-- symbol-start: BaseRequestMeta -->
-### BaseRequestMeta <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L145" />
+### BaseRequestMeta <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L153" />
 
 Common fields shared by all request meta types.
 
@@ -282,7 +291,7 @@ The name of the service
 <!-- symbol-end -->
 
 <!-- symbol-start: PubSubMessageMeta -->
-### PubSubMessageMeta <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L87" />
+### PubSubMessageMeta <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L95" />
 
 Describes a Pub/Sub message being processed.
 
@@ -338,7 +347,7 @@ Specifies that the request is a Pub/Sub message.
 <!-- symbol-end -->
 
 <!-- symbol-start: TraceData -->
-### TraceData <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L120" />
+### TraceData <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L128" />
 
 Provides information about the active trace.
 
@@ -423,7 +432,7 @@ type Method =
 <!-- symbol-end -->
 
 <!-- symbol-start: RequestMeta -->
-### RequestMeta <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L151" />
+### RequestMeta <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L159" />
 
 `type RequestMeta = APICallMeta | PubSubMessageMeta & BaseRequestMeta`
 
@@ -452,7 +461,7 @@ and therefore must not be modified by the caller.
 <!-- symbol-end -->
 
 <!-- symbol-start: currentRequest() -->
-### currentRequest() <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L160" />
+### currentRequest() <SymbolSource href="https://github.com/encoredev/encore/blob/main/runtimes/js/encore.dev/req_meta.ts#L168" />
 
 `function currentRequest(): RequestMeta | undefined`
 

--- a/e2e-tests/testdata/testscript/encore_currentrequest.txt
+++ b/e2e-tests/testdata/testscript/encore_currentrequest.txt
@@ -10,6 +10,14 @@ checkresp '{"Path": "/svc.CurrentRequest", "IdempotencyKey": "foo"}'
 call GET X-Encore-Cron-Execution=foo /svc.CurrentRequest '' no-platform-auth
 checkresp '{"Path": "/svc.CurrentRequest", "IdempotencyKey": ""}'
 
+# Requests from outside the application have no caller service
+call GET /svc.WhoCalled ''
+checkresp '{"CallerService": ""}'
+
+# Service-to-service calls report the name of the calling service
+call GET /svc2.CallWho ''
+checkresp '{"CallerService": "svc2"}'
+
 
 -- svc/svc.go --
 package svc
@@ -43,6 +51,17 @@ func CurrentRequest(ctx context.Context) (*RequestData, error) {
     }, nil
 }
 
+type CallerData struct {
+    CallerService string
+}
+
+//encore:api public
+func WhoCalled(ctx context.Context) (*CallerData, error) {
+    return &CallerData{
+        CallerService: encore.CurrentRequest().CallerService,
+    }, nil
+}
+
 var topic = pubsub.NewTopic[*Event]("topic", pubsub.TopicConfig{
     DeliveryGuarantee: pubsub.AtLeastOnce,
 })
@@ -57,3 +76,17 @@ var _ = pubsub.NewSubscription(topic, "sub", pubsub.SubscriptionConfig[*Event]{
         return nil
     },
 })
+
+-- svc2/svc2.go --
+package svc2
+
+import (
+    "context"
+
+    "test/svc"
+)
+
+//encore:api public
+func CallWho(ctx context.Context) (*svc.CallerData, error) {
+    return svc.WhoCalled(ctx)
+}

--- a/e2e-tests/testdata/tsapp/service1/api.ts
+++ b/e2e-tests/testdata/tsapp/service1/api.ts
@@ -55,6 +55,14 @@ export const getGreetingViaService2 = api(
   }
 );
 
+// Service-to-service call: Ask service2 who called it
+export const getCallerViaService2 = api(
+  { expose: true, method: "GET", path: "/get-caller" },
+  async (): Promise<{ callerService?: string }> => {
+    return await service2.whoCalled();
+  }
+);
+
 // Endpoint with custom HTTP status
 export const customStatus = api(
   { expose: true, method: "GET", path: "/test-custom-status" },

--- a/e2e-tests/testdata/tsapp/service2/api.ts
+++ b/e2e-tests/testdata/tsapp/service2/api.ts
@@ -2,6 +2,7 @@ import { api, HttpStatus } from "encore.dev/api";
 import { IsEmail, MaxLen, MinLen } from "encore.dev/validate";
 import log from "encore.dev/log";
 import { APIError } from "encore.dev/api";
+import { APICallMeta, currentRequest } from "encore.dev";
 
 interface GreetingRequest {
   name: string;
@@ -30,6 +31,15 @@ export const greet = api(
       greeting,
       timestamp: new Date()
     };
+  }
+);
+
+// Returns the name of the service that called this endpoint, if any.
+export const whoCalled = api(
+  { expose: true, method: "GET", path: "/who-called" },
+  async (): Promise<{ callerService?: string }> => {
+    const req = currentRequest() as APICallMeta;
+    return { callerService: req.callerService };
   }
 );
 

--- a/e2e-tests/ts_app_test.go
+++ b/e2e-tests/ts_app_test.go
@@ -108,6 +108,34 @@ func TestTSEndToEndWithApp(t *testing.T) {
 		c.Assert(response["greeting"], qt.Equals, "Hey Charlie! How's it going?")
 	})
 
+	c.Run("caller service - service-to-service call", func(c *qt.C) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/get-caller", nil)
+		run.ServeHTTP(w, req)
+
+		c.Assert(w.Code, qt.Equals, 200)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(response["callerService"], qt.Equals, "service1")
+	})
+
+	c.Run("caller service - external call", func(c *qt.C) {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/who-called", nil)
+		run.ServeHTTP(w, req)
+
+		c.Assert(w.Code, qt.Equals, 200)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(response["callerService"], qt.IsNil)
+	})
+
 	c.Run("service2 input validation - valid", func(c *qt.C) {
 		requestBody := `{"message": "Hello world", "recipient": "test@example.com"}`
 		w := httptest.NewRecorder()

--- a/runtimes/go/appruntime/apisdk/api/call_meta.go
+++ b/runtimes/go/appruntime/apisdk/api/call_meta.go
@@ -199,6 +199,18 @@ func (meta CallMeta) PrivateAPIAccess() bool {
 	return meta.Internal != nil && meta.Internal.Caller != nil && meta.Internal.Caller.PrivateAPIAccess()
 }
 
+// CallerServiceName reports the name of the service that made the call,
+// if the caller is another API endpoint. Otherwise it reports "".
+func (meta CallMeta) CallerServiceName() string {
+	if meta.Internal == nil {
+		return ""
+	}
+	if caller, ok := meta.Internal.Caller.(ApiCaller); ok {
+		return caller.ServiceName
+	}
+	return ""
+}
+
 // MetaFromRequest reads the metadata from the given request and returns it
 func (s *Server) MetaFromRequest(req transport.Transport) (meta CallMeta, err error) {
 	// Read the meta version if set and check it's only version 1

--- a/runtimes/go/appruntime/apisdk/api/handler.go
+++ b/runtimes/go/appruntime/apisdk/api/handler.go
@@ -273,6 +273,7 @@ func (d *Desc[Req, Resp]) begin(c IncomingContext) (reqData Req, beginErr error)
 			RequestHeaders:       headersWithHost(c.req),
 			FromEncorePlatform:   platformauth.IsEncorePlatformRequest(c.req.Context()),
 			ServiceToServiceCall: c.callMeta.IsServiceToService(),
+			CallerService:        c.callMeta.CallerServiceName(),
 		},
 
 		ExtRequestID:            clampTo64Chars(c.req.Header.Get("X-Request-ID")),
@@ -675,6 +676,7 @@ func (d *Desc[Req, Resp]) runCall(c CallContext, req Req, mocked bool, executor 
 				FromEncorePlatform:   false,
 				RequestHeaders:       nil, // not set right now for internal requests
 				ServiceToServiceCall: true,
+				CallerService:        meta.CallerServiceName(),
 				Mocked:               mocked,
 			},
 		})

--- a/runtimes/go/appruntime/exported/model/request.go
+++ b/runtimes/go/appruntime/exported/model/request.go
@@ -128,6 +128,11 @@ type RPCData struct {
 	// otherwise it is false if the request originates from outside the Encore application.
 	ServiceToServiceCall bool
 
+	// CallerService is the name of the service that made the API call,
+	// for service-to-service calls. It is empty if the request did not
+	// come from another service.
+	CallerService string
+
 	// Mocked is true if the request was handled by a mock.
 	Mocked bool
 }

--- a/runtimes/go/request.go
+++ b/runtimes/go/request.go
@@ -55,6 +55,11 @@ type Request struct {
 	PathParams PathParams // If there are path parameters, what are they?
 	Method     string     // What HTTP method was used
 
+	// CallerService is the name of the service that made the API call,
+	// for service-to-service calls. It is empty if the request did not
+	// come from another service.
+	CallerService string
+
 	// Headers contains the request headers sent with the request, if any.
 	//
 	// It is currently empty for service-to-service API calls when the caller
@@ -185,6 +190,7 @@ func (mgr *Manager) CurrentRequest() *Request {
 		}
 		result.Method = data.HTTPMethod
 		result.Headers = data.RequestHeaders
+		result.CallerService = data.CallerService
 
 		result.API = &APIDesc{
 			RequestType:  desc.RequestType,

--- a/runtimes/js/encore.dev/req_meta.ts
+++ b/runtimes/js/encore.dev/req_meta.ts
@@ -81,6 +81,14 @@ export interface APICallMeta {
    * Contains values set in middlewares via `MiddlewareRequest.data`.
    */
   middlewareData?: Record<string, any>;
+
+  /**
+   * The name of the service that made the API call, for
+   * service-to-service calls. Not set when the request comes from
+   * outside the application (e.g. through an API gateway) or when
+   * the caller is unknown.
+   */
+  callerService?: string;
 }
 
 /** Describes a Pub/Sub message being processed. */
@@ -184,7 +192,8 @@ export function currentRequest(): RequestMeta | undefined {
       pathParams: meta.apiCall.pathParams ?? {},
       parsedPayload: meta.apiCall.parsedPayload,
       headers: meta.apiCall.headers,
-      middlewareData: (req as any).middlewareData
+      middlewareData: (req as any).middlewareData,
+      callerService: meta.apiCall.callerService
     };
     return { ...base, ...api };
   } else if (meta.pubsubMessage) {

--- a/runtimes/js/src/request_meta.rs
+++ b/runtimes/js/src/request_meta.rs
@@ -1,7 +1,10 @@
 use chrono::{DateTime, SecondsFormat, Utc};
 use napi_derive::napi;
 
-use encore_runtime_core::{api::reqauth::meta::HeaderValueExt, model};
+use encore_runtime_core::{
+    api::reqauth::{caller::Caller, meta::HeaderValueExt},
+    model,
+};
 
 use crate::pvalue::PVals;
 
@@ -33,6 +36,7 @@ pub fn meta(req: &model::Request) -> Result<RequestMeta, serde_json::Error> {
                     .map(serde_json::to_value)
                     .transpose()?,
                 headers: serialize_headers(&rpc.req_headers),
+                caller_service: caller_service(req.internal_caller.as_ref()),
             };
             (Some(api), None)
         }
@@ -60,6 +64,7 @@ pub fn meta(req: &model::Request) -> Result<RequestMeta, serde_json::Error> {
                     .map(serde_json::to_value)
                     .transpose()?,
                 headers: Default::default(),
+                caller_service: caller_service(req.internal_caller.as_ref()),
             };
             (Some(api), None)
         }
@@ -111,6 +116,17 @@ pub struct APICallData {
     pub path_params: Option<serde_json::Value>,
     pub parsed_payload: Option<serde_json::Value>,
     pub headers: serde_json::Map<String, serde_json::Value>,
+    pub caller_service: Option<String>,
+}
+
+/// Reports the name of the service that made the call, if the
+/// caller is another API endpoint. Other caller kinds (gateways,
+/// Pub/Sub messages, etc.) have no calling service.
+fn caller_service(caller: Option<&Caller>) -> Option<String> {
+    match caller {
+        Some(Caller::APIEndpoint(name)) => Some(name.service().to_string()),
+        _ => None,
+    }
 }
 
 #[napi(object)]
@@ -188,9 +204,39 @@ fn serialize_headers(
 
 #[cfg(test)]
 mod tests {
-    use super::serialize_headers;
+    use super::{caller_service, serialize_headers};
     use axum::http::{HeaderMap, HeaderValue};
+    use encore_runtime_core::api::reqauth::caller::Caller;
+    use encore_runtime_core::EndpointName;
     use serde_json::{json, Value};
+
+    #[test]
+    fn caller_service_only_set_for_api_endpoint_callers() {
+        let caller = Caller::APIEndpoint(EndpointName::new("svc", "ep"));
+        assert_eq!(caller_service(Some(&caller)).as_deref(), Some("svc"));
+
+        let caller = Caller::PubSubMessage {
+            topic: "topic".into(),
+            subscription: "sub".into(),
+            message_id: "msg-1".into(),
+        };
+        assert_eq!(caller_service(Some(&caller)), None);
+
+        let caller = Caller::Gateway {
+            gateway: "api-gateway".into(),
+        };
+        assert_eq!(caller_service(Some(&caller)), None);
+
+        let caller = Caller::App {
+            deploy_id: "deploy-1".into(),
+        };
+        assert_eq!(caller_service(Some(&caller)), None);
+
+        let caller = Caller::EncorePrincipal("platform".into());
+        assert_eq!(caller_service(Some(&caller)), None);
+
+        assert_eq!(caller_service(None), None);
+    }
 
     #[test]
     fn strips_encore_internal_meta_headers() {


### PR DESCRIPTION
Adds the name of the calling service to request metadata, for service-to-service calls.

The field is optional: it is only set when the caller is another API endpoint. It is not set when the request comes from outside the application (e.g. through an API gateway) or when the caller is unknown.

## TypeScript

`currentRequest()` now includes `callerService` on API call metadata:

```ts
import { currentRequest } from "encore.dev";

const meta = currentRequest();
if (meta?.type === "api-call") {
  // "service1" when called from service1, undefined for external requests
  console.log(meta.callerService);
}
```

## Go

`encore.CurrentRequest()` now includes `CallerService`:

```go
req := encore.CurrentRequest()
// "service1" when called from service1, "" for external requests
log.Println(req.CallerService)
```

Covered by e2e tests in both runtimes (`ts_app_test.go` and `testscript/encore_currentrequest.txt`), asserting the field is set on service-to-service calls and absent on external requests.
