### PR TITLE
cli: logout rotates anonymous ID

### DIFF
--- a/cli/cmd/encore/auth/auth.go
+++ b/cli/cmd/encore/auth/auth.go
@@ -10,6 +10,7 @@ import (
 	"encr.dev/cli/cmd/encore/cmdutil"
 	"encr.dev/cli/cmd/encore/root"
 	"encr.dev/cli/internal/login"
+	"encr.dev/cli/internal/telemetry"
 	"encr.dev/internal/conf"
 )
 
@@ -111,6 +112,11 @@ func DoLogin(flow Flow) (err error) {
 }
 
 func DoLogout() {
+	if err := telemetry.RotateAnonymousID(); err != nil {
+		fmt.Fprintln(os.Stderr, "could not logout:", err)
+		os.Exit(1)
+	}
+
 	if err := conf.Logout(); err != nil {
 		fmt.Fprintln(os.Stderr, "could not logout:", err)
 		os.Exit(1)

--- a/cli/cmd/encore/auth/auth.go
+++ b/cli/cmd/encore/auth/auth.go
@@ -114,7 +114,6 @@ func DoLogin(flow Flow) (err error) {
 func DoLogout() {
 	if err := telemetry.RotateAnonymousID(); err != nil {
 		fmt.Fprintln(os.Stderr, "could not logout:", err)
-		os.Exit(1)
 	}
 
 	if err := conf.Logout(); err != nil {

--- a/cli/internal/telemetry/telemetry.go
+++ b/cli/internal/telemetry/telemetry.go
@@ -204,3 +204,16 @@ func GetAnonID() string {
 func IsDebug() bool {
 	return singleton.cfg.Debug
 }
+
+func RotateAnonymousID() error {
+	newAnonID, err := uuid.NewV4()
+	if err != nil {
+		return err
+	}
+
+	singleton.mu.Lock()
+	singleton.cfg.AnonID = newAnonID.String()
+	singleton.mu.Unlock()
+
+	return singleton.saveConfig()
+}


### PR DESCRIPTION
To be able to alias anonoymous ID's with user id's for telemetry without failure there cannot be a many to many relation between user ID's and anonymous ID's.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790943094&installation_model_id=427204&pr_number=2558&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2558&signature=5f0bb71d633d0afffd672c7acf1cdf8e492316f755aec98af5da361378ca194d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->