### PR TITLE
fix: load secrets once on local startup

### DIFF
--- a/cli/daemon/run.go
+++ b/cli/daemon/run.go
@@ -176,7 +176,10 @@ func (s *Server) Run(req *daemonpb.RunRequest, stream daemonpb.Daemon_RunServer)
 
 	ops.AllDone()
 
-	secrets, _ := s.sm.Load(app).Get(ctx, nil)
+	secrets, err := runInstance.SecretValues(ctx)
+	if err != nil {
+		log.Warn().Err(err).Str("runInstanceID", runInstance.ID).Msg("failed to load secrets")
+	}
 	externalDBs := map[string]string{}
 	for key, val := range secrets.Values {
 		if db, ok := strings.CutPrefix(key, "sqldb::"); ok {

--- a/cli/daemon/run/run.go
+++ b/cli/daemon/run/run.go
@@ -71,6 +71,10 @@ type Run struct {
 	started chan struct{}   // started is closed once the run has fully started
 }
 
+func (r *Run) SecretValues(ctx context.Context) (*secret.Data, error) {
+	return r.secrets.Get(ctx, nil)
+}
+
 // StartParams groups the parameters for the Run method.
 type StartParams struct {
 	// App is the app to start.


### PR DESCRIPTION
preferred this approach to DI 

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790953817&installation_model_id=427204&pr_number=2563&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2563&signature=66eed71e8ad5294fe3842dd1b23b21e71e609febdd06fa8f568eab28d1a06c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->