### PR TITLE
fix(runtime/ts): DummySocket.setKeepAlive incompatible with @types/node 26.4.0+

### DIFF
--- a/runtimes/js/encore.dev/api/node_http.ts
+++ b/runtimes/js/encore.dev/api/node_http.ts
@@ -309,6 +309,13 @@ export class RawResponse extends stream.Writable {
   }
 }
 
+interface SetKeepAliveOptions {
+  enable?: boolean;
+  initialDelay?: number;
+  interval?: number;
+  count?: number;
+}
+
 // DummySocket is a dummy implementation of the net.Socket class.
 //
 // It's provided because certain libraries like Express expect the `socket` attribute
@@ -323,7 +330,9 @@ class DummySocket extends stream.Duplex {
   resume(): this { return this; }
   setTimeout(_timeout: number, _callback?: () => void): this { return this; }
   setNoDelay(_noDelay?: boolean): this { return this; }
-  setKeepAlive(_enable?: boolean, _initialDelay?: number): this { return this; }
+  setKeepAlive(options: SetKeepAliveOptions): this;
+  setKeepAlive(enable?: boolean, initialDelay?: number, interval?: number, count?: number): this;
+  setKeepAlive(_enable?: boolean | SetKeepAliveOptions, _initialDelay?: number, _interval?: number, _count?: number): this { return this; }
   getTypeOfService(): number { return 0; }
   setTypeOfService(_tos: number): this { return this; }
   address(): AddressInfo | {} { return {}; }


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><p><code>@types/node</code> 26.4.0 changed <code>net.Socket.setKeepAlive()</code> by adding a new overload and extra parameters. Encore's internal <code>DummySocket</code> still used the old signature, making it structurally incompatible with <code>net.Socket</code> and causing <code>TS2352</code> in <code>encore.dev/api/node_http.ts</code>.</p><p>Because this file is shipped as <code>.ts</code>, <code>--skipLibCheck</code> does not suppress the error.</p><h2>Fix</h2><p>Update <code>DummySocket.setKeepAlive</code> to match the new overloads while keeping the implementation a no-op.</p><p><code>SetKeepAliveOptions</code> is redeclared locally instead of imported so the shim remains compatible with older <code>@types/node</code> versions.</p><p>Runtime behavior is unchanged.</p>
<h2>Testing</h2>

<p>Consumer repro with <code>encore.dev@1.58.4</code>:</p>

<ul>
  <li>Published 1.58.4 + <code>@types/node@26.4.0</code> → ❌ TS2352</li>
  <li>Published 1.58.4 + <code>@types/node@26.3.0</code> → ✅ clean</li>
  <li>This branch + <code>@types/node@26.4.0</code> → ✅ clean</li>
  <li>This branch + <code>@types/node@20.11.19</code> → ✅ clean</li>
</ul>


<h2>Workaround</h2><p>Pin:</p><p><code>"@types/node": "26.3.0"</code></p><p>Fixes #2560</p></body></html><!--EndFragment-->
</body>
</html>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791048116&installation_model_id=427204&pr_number=2569&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2569&signature=7bd647e8b5e8f3cbc9509a5a4466d064ade2946416fcdd7f1c33a619a889708b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

AI disclosure: this change was developed with the assistance of Claude Code. I have reviewed, tested, and understand the change.