### PR TITLE
fix(daemon): stop ResourceManager upon Test completion to prevent resource leaks

### DIFF
--- a/cli/daemon/run/tests.go
+++ b/cli/daemon/run/tests.go
@@ -45,9 +45,12 @@ func (mgr *Manager) Test(ctx context.Context, params TestParams) (err error) {
 	bld := builderimpl.Resolve(params.App.Lang(), expSet)
 	defer fns.CloseIgnore(bld)
 
-	spec, err := mgr.testSpec(ctx, bld, expSet, params.TestSpecParams)
+	spec, rm, err := mgr.testSpec(ctx, bld, expSet, params.TestSpecParams)
 	if err != nil {
 		return err
+	}
+	if rm != nil {
+		defer rm.StopAll()
 	}
 
 	workingDir := paths.RootedFSPath(params.App.Root(), params.WorkingDir)
@@ -104,7 +107,7 @@ func (mgr *Manager) TestSpec(ctx context.Context, params TestSpecParams) (*TestS
 	bld := builderimpl.Resolve(params.App.Lang(), expSet)
 	defer fns.CloseIgnore(bld)
 
-	spec, err := mgr.testSpec(ctx, bld, expSet, &params)
+	spec, _, err := mgr.testSpec(ctx, bld, expSet, &params)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +119,12 @@ func (mgr *Manager) TestSpec(ctx context.Context, params TestSpecParams) (*TestS
 }
 
 // testSpec returns how to run the tests.
-func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *experiments.Set, params *TestSpecParams) (*builder.TestSpecResult, error) {
+func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *experiments.Set, params *TestSpecParams) (*builder.TestSpecResult, *infra.ResourceManager, error) {
 	var secrets map[string]string
 	if params.Secrets != nil {
 		secretData, err := params.Secrets.Get(ctx, expSet)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		secrets = secretData.Values
 		// remove db override secrets for tests
@@ -155,7 +158,7 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 		WorkingDir: params.WorkingDir,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	parse, err := bld.Parse(ctx, builder.ParseParams{
 		Build:       buildInfo,
@@ -166,10 +169,10 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 		Prepare:     prepareResult,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := params.App.CacheMetadata(parse.Meta); err != nil {
-		return nil, errors.Wrap(err, "cache metadata")
+		return nil, nil, errors.Wrap(err, "cache metadata")
 	}
 
 	rm := infra.NewResourceManager(params.App, mgr.ClusterMgr, mgr.ObjectsMgr, mgr.PublicBuckets, params.NS, nil, mgr.DBProxyPort, true)
@@ -179,7 +182,8 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 
 	// Note: jobs.Wait must be called before generateConfig.
 	if err := jobs.Wait(); err != nil {
-		return nil, err
+		rm.StopAll()
+		return nil, nil, err
 	}
 
 	gateways := make(map[string]GatewayConfig)
@@ -201,7 +205,8 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 		},
 	})
 	if err != nil {
-		return nil, err
+		rm.StopAll()
+		return nil, nil, err
 	}
 
 	var runtimeConfigPath option.Option[string]
@@ -241,11 +246,12 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 
 	env, err := configGen.ForTests(bld.UseNewRuntimeConfig())
 	if err != nil {
-		return nil, err
+		rm.StopAll()
+		return nil, nil, err
 	}
 	env = append(env, encodeServiceConfigs(cfg.Configs)...)
 
-	return bld.TestSpec(ctx, builder.TestSpecParams{
+	spec, err := bld.TestSpec(ctx, builder.TestSpecParams{
 		Compile: builder.CompileParams{
 			Build:       buildInfo,
 			App:         params.App,
@@ -257,4 +263,9 @@ func (mgr *Manager) testSpec(ctx context.Context, bld builder.Impl, expSet *expe
 		Env:  append(params.Environ, env...),
 		Args: params.Args,
 	})
+	if err != nil {
+		rm.StopAll()
+		return nil, nil, err
+	}
+	return spec, rm, nil
 }


### PR DESCRIPTION
## Problem

When `encore test` is executed, `Manager.Test()` calls `mgr.testSpec()` which initializes a new `infra.ResourceManager` via `infra.NewResourceManager(..., forTests: true)` and calls `rm.StartRequiredServices(jobs, parse.Meta)` to boot ephemeral test infrastructure (such as local NSQ pubsub daemons or local redis).

Unlike `ExecScript` (which defers `rm.StopAll()`) and `Run.Stop()` (which terminates its resource manager), `Manager.Test()` did not capture or stop the `ResourceManager` after test execution finished or failed.

As a result, long-running daemon processes leak child processes (`nsqd`, `miniredis`) and file descriptors across repeated test runs.

## Solution

1. Update `mgr.testSpec()` to return `(*builder.TestSpecResult, *infra.ResourceManager, error)`.
2. Add `defer rm.StopAll()` in `Manager.Test()` once the test execution finishes or errors out.
3. Clean up `rm.StopAll()` in `testSpec` error return paths (`jobs.Wait()`, `ServiceConfigs`, `ForTests`, `TestSpec`).

## Verification

- Verified `go vet ./cli/daemon/run/...` runs cleanly.
- Code mirrors existing lifecycle pattern in `cli/daemon/run/exec_script.go:69`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791225112&installation_model_id=427204&pr_number=2571&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2571&signature=ce8c60c9ec66a4f314fd719d0d928369d125d84310416f89d81e818c6ad63f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->