### PR TITLE
feat: run different daemon setups for different release channels

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,5 @@
   },
   "extensions": ["golang.go"],
   "postCreateCommand": "bash /scripts/prepare.sh",
-  "forwardPorts": [4000, 9400]
+  "forwardPorts": [4000, 9404]
 }

--- a/cli/cmd/encore/cmdutil/daemon.go
+++ b/cli/cmd/encore/cmdutil/daemon.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -15,13 +14,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"encr.dev/internal/daemonconfig"
 	"encr.dev/internal/version"
 	"encr.dev/pkg/xos"
 	daemonpb "encr.dev/proto/encore/daemon"
 )
 
 func IsDaemonRunning(ctx context.Context) bool {
-	socketPath, err := daemonSockPath()
+	socketPath, err := daemonconfig.SocketPath()
 	if err != nil {
 		return false
 	}
@@ -41,7 +41,7 @@ func IsDaemonRunning(ctx context.Context) bool {
 // ConnectDaemon returns a client connection to the Encore daemon.
 // By default, it will start the daemon if it is not already running.
 func ConnectDaemon(ctx context.Context) daemonpb.DaemonClient {
-	socketPath, err := daemonSockPath()
+	socketPath, err := daemonconfig.SocketPath()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "fatal: ", err)
 		os.Exit(1)
@@ -95,7 +95,7 @@ func ConnectDaemon(ctx context.Context) daemonpb.DaemonClient {
 }
 
 func StopDaemon() {
-	socketPath, err := daemonSockPath()
+	socketPath, err := daemonconfig.SocketPath()
 	if err != nil {
 		Fatal("stopping daemon: ", err)
 	}
@@ -104,18 +104,9 @@ func StopDaemon() {
 	}
 }
 
-// daemonSockPath reports the path to the Encore daemon unix socket.
-func daemonSockPath() (string, error) {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return "", fmt.Errorf("could not determine cache dir: %v", err)
-	}
-	return filepath.Join(cacheDir, "encore", "encored.sock"), nil
-}
-
 // StartDaemonInBackground starts the Encore daemon in the background.
 func StartDaemonInBackground(ctx context.Context) error {
-	socketPath, err := daemonSockPath()
+	socketPath, err := daemonconfig.SocketPath()
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/encore/daemon/daemon.go
+++ b/cli/cmd/encore/daemon/daemon.go
@@ -49,6 +49,7 @@ import (
 	"encr.dev/cli/daemon/sqldb/docker"
 	"encr.dev/cli/daemon/sqldb/external"
 	"encr.dev/internal/conf"
+	"encr.dev/internal/daemonconfig"
 	"encr.dev/internal/env"
 	"encr.dev/pkg/eerror"
 	"encr.dev/pkg/httpx"
@@ -200,11 +201,10 @@ func (d *Daemon) serve() {
 // listenDaemonSocket listens on the encored.sock UNIX socket
 // and arranges to exit when the socket is closed.
 func (d *Daemon) listenDaemonSocket() *net.UnixListener {
-	userCacheDir, err := os.UserCacheDir()
+	socketPath, err := daemonconfig.SocketPath()
 	if err != nil {
 		fatal(err)
 	}
-	socketPath := filepath.Join(userCacheDir, "encore", "encored.sock")
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
 		fatal(err)
 	}

--- a/cli/cmd/encore/daemon/daemon.go
+++ b/cli/cmd/encore/daemon/daemon.go
@@ -127,13 +127,17 @@ type Daemon struct {
 }
 
 func (d *Daemon) init(ctx context.Context) {
+	ports, err := daemonconfig.DefaultPorts()
+	if err != nil {
+		fatal(err)
+	}
 	d.Daemon = d.listenDaemonSocket()
-	d.Dash = d.listenTCPRetry("dashboard", env.EncoreDevDashListenAddr(), 9400)
-	d.DBProxy = d.listenTCPRetry("dbproxy", option.None[string](), 9500)
-	d.Runtime = d.listenTCPRetry("runtime", option.None[string](), 9600)
-	d.Debug = d.listenTCPRetry("debug", option.None[string](), 9700)
-	d.ObjectStorage = d.listenTCPRetry("objectstorage", env.EncoreObjectStorageListAddr(), 9800)
-	d.MCP = d.listenTCPRetry("mcp", env.EncoreMCPSSEListenAddr(), 9900)
+	d.Dash = d.listenTCPRetry("dashboard", env.EncoreDevDashListenAddr(), ports.Dashboard)
+	d.DBProxy = d.listenTCPRetry("dbproxy", option.None[string](), ports.DatabaseProxy)
+	d.Runtime = d.listenTCPRetry("runtime", option.None[string](), ports.Runtime)
+	d.Debug = d.listenTCPRetry("debug", option.None[string](), ports.Debug)
+	d.ObjectStorage = d.listenTCPRetry("objectstorage", env.EncoreObjectStorageListAddr(), ports.ObjectStorage)
+	d.MCP = d.listenTCPRetry("mcp", env.EncoreMCPSSEListenAddr(), ports.MCP)
 	d.EncoreDB = d.openDB()
 
 	d.Apps = apps.NewManager(d.EncoreDB)

--- a/cli/cmd/encore/mcp.go
+++ b/cli/cmd/encore/mcp.go
@@ -20,6 +20,7 @@ import (
 	"encr.dev/cli/cmd/encore/cmdutil"
 	"encr.dev/cli/cmd/encore/root"
 	"encr.dev/cli/internal/jsonrpc2"
+	"encr.dev/internal/daemonconfig"
 )
 
 var mcpCmd = &cobra.Command{
@@ -29,7 +30,6 @@ var mcpCmd = &cobra.Command{
 
 var (
 	appID   string
-	mcpPort int = 9900
 )
 
 var startCmd = &cobra.Command{
@@ -41,10 +41,14 @@ var startCmd = &cobra.Command{
 			appID = cmdutil.AppSlugOrLocalID()
 		}
 		setupDaemon(ctx)
+		ports, err := daemonconfig.DefaultPorts()
+		if err != nil {
+			fatal(err)
+		}
 
 		_, _ = fmt.Fprintf(os.Stderr, "  MCP Service is running!\n\n")
 		_, _ = fmt.Fprintf(os.Stderr, "  MCP SSE URL:        %s\n", aurora.Cyan(fmt.Sprintf(
-			"http://localhost:%d/sse?app=%s", mcpPort, appID)))
+			"http://localhost:%d/sse?app=%s", ports.MCP, appID)))
 		_, _ = fmt.Fprintf(os.Stderr, "  MCP stdio Command:  %s\n", aurora.Cyan(fmt.Sprintf(
 			"encore mcp run --app=%s", appID)))
 	},
@@ -135,12 +139,17 @@ func (c *sseConnection) connect(ctx context.Context) error {
 		c.client = &http.Client{}
 	}
 
+	ports, err := daemonconfig.DefaultPorts()
+	if err != nil {
+		return err
+	}
+
 	// Initialize the request IDs map
 	c.mu.Lock()
 	c.requestIDs = make(map[jsonrpc2.ID]struct{})
 	c.mu.Unlock()
 
-	resp, err := c.client.Get(fmt.Sprintf("http://localhost:%d/sse?app=%s", mcpPort, c.appID))
+	resp, err := c.client.Get(fmt.Sprintf("http://localhost:%d/sse?app=%s", ports.MCP, c.appID))
 	if err != nil {
 		return err
 	}
@@ -184,7 +193,12 @@ func (c *sseConnection) SendMessage(data []byte) error {
 		}
 	}
 
-	resp, err := c.client.Post(fmt.Sprintf("http://localhost:%d%s", mcpPort, c.path), "application/json", bytes.NewReader(data))
+	ports, err := daemonconfig.DefaultPorts()
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Post(fmt.Sprintf("http://localhost:%d%s", ports.MCP, c.path), "application/json", bytes.NewReader(data))
 	if err != nil {
 		return err
 	}

--- a/internal/daemonconfig/daemonconfig.go
+++ b/internal/daemonconfig/daemonconfig.go
@@ -36,3 +36,55 @@ func socketDir(channel version.ReleaseChannel) (string, error) {
 		return "", fmt.Errorf("unknown release channel %q", channel)
 	}
 }
+
+type Ports struct {
+	Dashboard     uint16
+	DatabaseProxy uint16
+	Runtime       uint16
+	Debug         uint16
+	ObjectStorage uint16
+	MCP           uint16
+}
+
+// These is currently no alpha release
+// To leave room for it offset 1 is skipped
+//
+// 	 Service           Stable    Beta    Nightly   Develop
+//  ━━━━━━━━━━━━━━━━  ━━━━━━━━  ━━━━━━  ━━━━━━━━  ━━━━━━━━━━
+//   Dashboard           9400    9402       9403      9404
+//  ────────────────  ────────  ──────  ────────  ──────────
+//   Database proxy      9500    9502       9503      9504
+//  ────────────────  ────────  ──────  ────────  ──────────
+//   Runtime             9600    9602       9603      9604
+//  ────────────────  ────────  ──────  ────────  ──────────
+//   Debug               9700    9702       9703      9704
+//  ────────────────  ────────  ──────  ────────  ──────────
+//   Object storage      9800    9802       9803      9804
+//  ────────────────  ────────  ──────  ────────  ──────────
+//   MCP                 9900    9902       9903      9904
+func DefaultPorts() (Ports, error) {
+	var offset uint16
+	switch version.Channel {
+	case version.GA:
+		offset = 0
+	case version.Beta:
+		offset = 2
+	case version.Nightly:
+		offset = 3
+	case version.DevBuild:
+		offset = 4
+	default:
+		return Ports{}, fmt.Errorf(
+			"unknown release channel %q", version.Channel,
+		)
+	}
+
+	return Ports{
+		Dashboard:     9400 + offset,
+		DatabaseProxy: 9500 + offset,
+		Runtime:       9600 + offset,
+		Debug:         9700 + offset,
+		ObjectStorage: 9800 + offset,
+		MCP:           9900 + offset,
+	}, nil
+}

--- a/internal/daemonconfig/daemonconfig.go
+++ b/internal/daemonconfig/daemonconfig.go
@@ -1,0 +1,38 @@
+package daemonconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"encr.dev/internal/version"
+)
+
+func SocketPath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("get user cache dir: %w", err)
+	}
+
+	dir, err := socketDir(version.Channel)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(cacheDir, dir, "encored.sock"), nil
+}
+
+func socketDir(channel version.ReleaseChannel) (string, error) {
+	switch channel {
+	case version.DevBuild:
+		return "encore-develop", nil
+	case version.Beta:
+		return "encore-beta", nil
+	case version.Nightly:
+		return "encore-nightly", nil
+	case version.GA:
+		return "encore", nil
+	default:
+		return "", fmt.Errorf("unknown release channel %q", channel)
+	}
+}


### PR DESCRIPTION
To be able to run different release channel builds side-by-side without interference between the builds they must use different daemon setups

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791389639&installation_model_id=427204&pr_number=2572&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2572&signature=be8264c93c2e8edea39cd049e1db6e853fb5f14948362aa15bfddf1df8d29827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->