### PR TITLE
tsparser: make clients lazy-load during tests

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -9,3 +9,10 @@ The tests will:
 3. Generate the front end clients for the app
 4. Run tests against using generated clients against the running app
 5. Shutdown the running app
+
+The TypeScript app's `client_imports.test.ts` covers lazy generated test clients:
+importing `~encore/clients` must not initialize service definitions or middleware.
+The first endpoint call loads its service's test module; the module loader owns
+caching so Vitest mocks and `vi.resetModules()` remain effective. Handler lookup
+and registration still happen on every call. Keep the test import inside the
+`ENCORE_DROP_TESTS` guard in the client template so production bundles omit it.

--- a/e2e-tests/testdata/tsapp/client_imports.test.ts
+++ b/e2e-tests/testdata/tsapp/client_imports.test.ts
@@ -1,0 +1,70 @@
+import { expect, it, vi } from "vitest";
+import { service1, service2 } from "~encore/clients";
+
+const loaded = vi.hoisted(() => ({
+  service1: vi.fn(),
+  service2: vi.fn()
+}));
+
+vi.mock("./service1/encore.service", async (importOriginal) => {
+  loaded.service1();
+  return importOriginal();
+});
+vi.mock("./service2/encore.service", async (importOriginal) => {
+  loaded.service2();
+  return importOriginal();
+});
+
+// Keep the lifecycle in one test: the initial assertions must run before any
+// client call, and the final reset must exercise the original client exports.
+it("loads service test modules on demand and respects module resets", async () => {
+  expect(loaded.service1).not.toHaveBeenCalled();
+  expect(loaded.service2).not.toHaveBeenCalled();
+  expect(service2.ref()).toBe(service2.ref());
+  expect(loaded.service2).not.toHaveBeenCalled();
+
+  // Concurrent first calls share module initialization. Importing api.ts also
+  // imports the client catalog again, exercising the circular import path.
+  const [alice, bob, middleware] = await Promise.all([
+    service1.hello({ name: "Alice" }),
+    service1.ref().hello({ name: "Bob" }),
+    service1.middlewareDemo()
+  ]);
+  expect(alice).toEqual({ message: "Hello Alice" });
+  expect(bob).toEqual({ message: "Hello Bob" });
+  expect(middleware).toEqual({
+    message: "Hello",
+    middlewareMsg: "Hello from middleware!"
+  });
+  expect(loaded.service1).toHaveBeenCalledTimes(1);
+  expect(loaded.service2).not.toHaveBeenCalled();
+
+  const greeting = await service1.getGreetingViaService2({ name: "Charlie" });
+  expect(greeting.greeting).toContain("Charlie");
+  expect(loaded.service2).toHaveBeenCalledTimes(1);
+
+  // Handler lookup and registration must continue to happen on every call.
+  const hello = vi.fn(async () => ({ message: "mocked" }));
+  vi.doMock("./service1/api", () => ({ hello }));
+  try {
+    expect(await service1.hello({ name: "ignored" })).toEqual({ message: "mocked" });
+    expect(hello).toHaveBeenCalledTimes(1);
+  } finally {
+    vi.doUnmock("./service1/api");
+  }
+
+  // A promise retained by the original client wrapper would bypass this new
+  // service module and keep using the old test module after resetModules().
+  vi.resetModules();
+  vi.doMock("./service1/encore.service", () => {
+    throw new Error("service initialization failed");
+  });
+  try {
+    // Vitest wraps errors from mock factories; retain the initialization cause.
+    await expect(service1.hello({ name: "Alice" })).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: "service initialization failed" })
+    });
+  } finally {
+    vi.doUnmock("./service1/encore.service");
+  }
+});

--- a/tsparser/src/builder/templates/catalog/clients/endpoints_js.handlebars
+++ b/tsparser/src/builder/templates/catalog/clients/endpoints_js.handlebars
@@ -1,9 +1,5 @@
 import { apiCall, streamIn, streamOut, streamInOut } from "encore.dev/internal/codegen/api";
 
-const TEST_ENDPOINTS = typeof ENCORE_DROP_TESTS === "undefined" && process.env.NODE_ENV === "test"
-    ? await import("./endpoints_testing.js")
-    : null;
-
 {{#each endpoints}}
 {{#if has_params}}
 export async function {{name}}(params, opts) {
@@ -12,7 +8,10 @@ export async function {{name}}(opts) {
     const params = undefined;
 {{/if}}
     if (typeof ENCORE_DROP_TESTS === "undefined" && process.env.NODE_ENV === "test") {
-        return TEST_ENDPOINTS.{{name}}(params, opts);
+        // Load this service's test handlers and middleware only when called.
+        // Leave caching to the module loader so test module resets still work.
+        const endpoints = await import("./endpoints_testing.js");
+        return endpoints.{{name}}(params, opts);
     }
 
     {{#if (or streaming_request streaming_response)}}


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791465764&installation_model_id=427204&pr_number=2574&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2574&signature=8d6d8d1146601d497f13d9a1874fb0c9a5b0c41588bd223ff9e6c6e305b23fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->