### PR TITLE
feat: support production-only dependency installs for TypeScript apps

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -38,6 +38,17 @@ const (
 	DebugModeBreak    DebugMode = "break"
 )
 
+// InstallMode selects which dependencies to install for TypeScript apps.
+type InstallMode string
+
+const (
+	// InstallAll installs every dependency. It is the default.
+	InstallAll InstallMode = "all"
+	// InstallProduction omits development dependencies, using each
+	// package manager's equivalent of npm's --omit=dev.
+	InstallProduction InstallMode = "production"
+)
+
 type BuildInfo struct {
 	BuildTags          []string
 	CgoEnabled         bool
@@ -97,6 +108,10 @@ type PrepareParams struct {
 	App        *apps.Instance
 	WorkingDir string
 	Stderr     option.Option[io.Writer]
+
+	// InstallMode selects which dependencies to install for TypeScript apps.
+	// The zero value means InstallAll. Ignored by the Go builder.
+	InstallMode InstallMode
 }
 
 type PrepareResult struct {

--- a/tsparser/src/bin/tsparser-encore.rs
+++ b/tsparser/src/bin/tsparser-encore.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
             {
                 let pp = builder::PrepareParams {
                     app_root: prepare.app_root.clone(),
+                    install_mode: prepare.install_mode,
 
                     encore_dev_version: match prepare.local_runtime_override {
                         Some(buf) => builder::PackageVersion::Local(buf.join("encore.dev")),
@@ -292,6 +293,8 @@ struct PrepareInput {
     runtime_version: String,
     #[serde(default)]
     local_runtime_override: Option<PathBuf>,
+    #[serde(default)]
+    install_mode: builder::InstallMode,
 }
 
 #[derive(Deserialize, Debug)]

--- a/tsparser/src/builder/codegen.rs
+++ b/tsparser/src/builder/codegen.rs
@@ -17,7 +17,7 @@ use crate::parser::resources::apis::api::Methods;
 use crate::parser::resources::Resource;
 use crate::parser::{FilePath, Range};
 
-use super::prepare::{PackageVersion, PrepareError};
+use super::prepare::{InstallMode, PackageVersion, PrepareError};
 use super::{App, Builder};
 
 #[derive(Debug)]
@@ -38,9 +38,10 @@ impl Builder<'_> {
         &self,
         app_root: &Path,
         encore_dev_version: &PackageVersion,
+        install_mode: InstallMode,
     ) -> Result<(), PrepareError> {
         let pkg_mgr = resolve_package_manager(app_root)?;
-        pkg_mgr.setup_deps(encore_dev_version)
+        pkg_mgr.setup_deps(encore_dev_version, install_mode)
     }
 
     pub fn generate_code(&self, params: &CodegenParams) -> Result<CodegenResult, PrepareError> {

--- a/tsparser/src/builder/mod.rs
+++ b/tsparser/src/builder/mod.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub use codegen::{CodegenParams, CodegenResult};
 pub use compile::CompileParams;
 pub use parse::{ParseError, ParseParams};
-pub use prepare::{PackageVersion, PrepareParams};
+pub use prepare::{InstallMode, PackageVersion, PrepareParams};
 pub use test::TestParams;
 
 mod codegen;

--- a/tsparser/src/builder/package_mgmt.rs
+++ b/tsparser/src/builder/package_mgmt.rs
@@ -4,12 +4,11 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use duct::cmd;
 use serde::Deserialize;
 
 use crate::builder::compile::CmdSpec;
 
-use super::prepare::{PackageVersion, PrepareError};
+use super::prepare::{InstallMode, PackageVersion, PrepareError};
 
 #[derive(Debug, Clone)]
 pub enum InstalledVersion {
@@ -150,8 +149,22 @@ fn resolve_executable(name: &str) -> OsString {
     }
 }
 
+// Arguments are passed directly to the executable, never interpreted by a shell.
+fn run_install(dir: &Path, command: &[&str]) -> Result<(), PrepareError> {
+    duct::cmd(resolve_executable(command[0]), &command[1..])
+        .dir(dir)
+        .stdout_to_stderr()
+        .run()
+        .map_err(|e| PrepareError::InstallNodeModules(e, command.join(" ")))?;
+    Ok(())
+}
+
 pub(super) trait PackageManager {
-    fn setup_deps(&self, encore_dev_version: &PackageVersion) -> Result<(), PrepareError>;
+    fn setup_deps(
+        &self,
+        encore_dev_version: &PackageVersion,
+        mode: InstallMode,
+    ) -> Result<(), PrepareError>;
 
     fn run_tests(&self) -> CmdSpec;
 
@@ -165,7 +178,11 @@ struct NpmPackageManager {
 }
 
 impl PackageManager for NpmPackageManager {
-    fn setup_deps(&self, encore_dev_version: &PackageVersion) -> Result<(), PrepareError> {
+    fn setup_deps(
+        &self,
+        encore_dev_version: &PackageVersion,
+        mode: InstallMode,
+    ) -> Result<(), PrepareError> {
         // Install `encore.dev` if necessary
         let installed = self.pkg_json.dependencies.get("encore.dev");
         let v = installed.map_or(InstalledVersion::NotInstalled, |v| {
@@ -175,13 +192,14 @@ impl PackageManager for NpmPackageManager {
         // First ensure the package.json file is up to date.
         let modified = update_package_json(&self.dir, v, encore_dev_version)?;
 
-        // If we modified anything or don't have a node_modules directory, run 'npm install'.
-        if modified || !self.dir.join("node_modules").exists() {
-            cmd!(resolve_executable("npm"), "install")
-                .dir(&self.dir)
-                .stdout_to_stderr()
-                .run()
-                .map_err(|e| PrepareError::InstallNodeModules(e, "npm install".into()))?;
+        // Production installs always run; an existing tree may contain dev dependencies.
+        if mode == InstallMode::Production || modified || !self.dir.join("node_modules").exists() {
+            let mut command = vec!["npm", "install"];
+            match mode {
+                InstallMode::All => {}
+                InstallMode::Production => command.push("--omit=dev"),
+            }
+            run_install(&self.dir, &command)?;
         }
 
         Ok(())
@@ -213,7 +231,11 @@ struct BunPackageManager {
 }
 
 impl PackageManager for BunPackageManager {
-    fn setup_deps(&self, encore_dev_version: &PackageVersion) -> Result<(), PrepareError> {
+    fn setup_deps(
+        &self,
+        encore_dev_version: &PackageVersion,
+        mode: InstallMode,
+    ) -> Result<(), PrepareError> {
         // Install `encore.dev` if necessary
         let installed = self.pkg_json.dependencies.get("encore.dev");
         let v = installed.map_or(InstalledVersion::NotInstalled, |v| {
@@ -223,27 +245,20 @@ impl PackageManager for BunPackageManager {
         // First ensure the package.json file is up to date.
         let modified = update_package_json(&self.dir, v, encore_dev_version)?;
 
-        // If we modified anything or don't have a node_modules directory, run 'bun install'.
-        if modified || !self.dir.join("node_modules").exists() {
+        // Production installs always run; an existing tree may contain dev dependencies.
+        if mode == InstallMode::Production || modified || !self.dir.join("node_modules").exists() {
             let backend = std::env::var("BUN_INSTALL_BACKEND").unwrap_or_default();
-            if backend.is_empty() {
-                cmd!(resolve_executable("bun"), "install")
-                    .dir(&self.dir)
-                    .stdout_to_stderr()
-                    .run()
-                    .map_err(|e| PrepareError::InstallNodeModules(e, "bun install".into()))?;
-            } else {
-                cmd!(resolve_executable("bun"), "install", "--backend", &backend)
-                    .dir(&self.dir)
-                    .stdout_to_stderr()
-                    .run()
-                    .map_err(|e| {
-                        PrepareError::InstallNodeModules(
-                            e,
-                            format!("bun install --backend {backend}"),
-                        )
-                    })?;
+            let mut command = vec!["bun", "install"];
+            if !backend.is_empty() {
+                command.extend(["--backend", backend.as_str()]);
             }
+            match mode {
+                InstallMode::All => {}
+                // --production also freezes the lockfile in Bun. Prepare may have just
+                // updated encore.dev, so omit dev dependencies without freezing it.
+                InstallMode::Production => command.extend(["--omit", "dev"]),
+            }
+            run_install(&self.dir, &command)?;
         }
 
         Ok(())
@@ -275,7 +290,11 @@ struct YarnPackageManager {
 }
 
 impl PackageManager for YarnPackageManager {
-    fn setup_deps(&self, encore_dev_version: &PackageVersion) -> Result<(), PrepareError> {
+    fn setup_deps(
+        &self,
+        encore_dev_version: &PackageVersion,
+        mode: InstallMode,
+    ) -> Result<(), PrepareError> {
         self.ensure_nodelinker()?;
 
         // Install `encore.dev` if necessary
@@ -287,13 +306,23 @@ impl PackageManager for YarnPackageManager {
         // First ensure the package.json file is up to date.
         let modified = update_package_json(&self.dir, v, encore_dev_version)?;
 
-        // If we modified anything or don't have a node_modules directory, run 'npm install'.
-        if modified || !self.dir.join("node_modules").exists() {
-            cmd!(resolve_executable("yarn"), "install")
-                .dir(&self.dir)
-                .stdout_to_stderr()
-                .run()
-                .map_err(|e| PrepareError::InstallNodeModules(e, "yarn install".into()))?;
+        // Production installs always run; an existing tree may contain dev dependencies.
+        if mode == InstallMode::Production || modified || !self.dir.join("node_modules").exists() {
+            let command = match mode {
+                InstallMode::All => vec!["yarn", "install"],
+                InstallMode::Production => {
+                    // Query from the app root so Corepack and yarnPath select the
+                    // actual version, including a workspace's inherited selection.
+                    let version = duct::cmd(resolve_executable("yarn"), ["--version"])
+                        .dir(&self.dir)
+                        .read()
+                        .map_err(|e| {
+                            PrepareError::InstallNodeModules(e, "yarn --version".into())
+                        })?;
+                    yarn_production_command(&version)?
+                }
+            };
+            run_install(&self.dir, &command)?;
         }
 
         Ok(())
@@ -310,6 +339,31 @@ impl PackageManager for YarnPackageManager {
     fn mgr_name(&self) -> &'static str {
         "yarn"
     }
+}
+
+// Yarn Classic accepts --production; Modern uses workspace-tools (built in
+// since Yarn 4). --all preserves the whole workspace install scope.
+fn yarn_production_command(version: &str) -> Result<Vec<&'static str>, PrepareError> {
+    let major = version
+        .trim()
+        .split('.')
+        .next()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .ok_or_else(|| {
+            PrepareError::InstallNodeModules(
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid Yarn version: {version:?}"),
+                ),
+                "yarn --version".into(),
+            )
+        })?;
+    Ok(if major == 1 {
+        vec!["yarn", "install", "--production=true"]
+    } else {
+        vec!["yarn", "workspaces", "focus", "--all", "--production"]
+    })
 }
 
 impl YarnPackageManager {
@@ -350,7 +404,11 @@ struct PnpmPackageManager {
 }
 
 impl PackageManager for PnpmPackageManager {
-    fn setup_deps(&self, encore_dev_version: &PackageVersion) -> Result<(), PrepareError> {
+    fn setup_deps(
+        &self,
+        encore_dev_version: &PackageVersion,
+        mode: InstallMode,
+    ) -> Result<(), PrepareError> {
         // Install `encore.dev` if necessary
         let installed = self.pkg_json.dependencies.get("encore.dev");
         let v = installed.map_or(InstalledVersion::NotInstalled, |v| {
@@ -360,13 +418,14 @@ impl PackageManager for PnpmPackageManager {
         // First ensure the package.json file is up to date.
         let modified = update_package_json(&self.dir, v, encore_dev_version)?;
 
-        // If we modified anything or don't have a node_modules directory, run 'npm install'.
-        if modified || !self.dir.join("node_modules").exists() {
-            cmd!(resolve_executable("pnpm"), "install")
-                .dir(&self.dir)
-                .stdout_to_stderr()
-                .run()
-                .map_err(|e| PrepareError::InstallNodeModules(e, "pnpm install".into()))?;
+        // Production installs always run; an existing tree may contain dev dependencies.
+        if mode == InstallMode::Production || modified || !self.dir.join("node_modules").exists() {
+            let mut command = vec!["pnpm", "install"];
+            match mode {
+                InstallMode::All => {}
+                InstallMode::Production => command.push("--prod"),
+            }
+            run_install(&self.dir, &command)?;
         }
         Ok(())
     }

--- a/tsparser/src/builder/prepare.rs
+++ b/tsparser/src/builder/prepare.rs
@@ -1,5 +1,6 @@
 use std::{io, path::PathBuf};
 
+use serde::Deserialize;
 use thiserror::Error;
 
 use super::Builder;
@@ -8,6 +9,19 @@ use super::Builder;
 pub struct PrepareParams {
     pub encore_dev_version: PackageVersion,
     pub app_root: PathBuf,
+    pub install_mode: InstallMode,
+}
+
+/// Which dependencies a prepare installs.
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum InstallMode {
+    /// Every dependency.
+    #[default]
+    All,
+    /// Omits development dependencies, using each package manager's
+    /// equivalent of npm's `--omit=dev`.
+    Production,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +72,10 @@ pub enum PrepareError {
 
 impl Builder<'_> {
     pub fn prepare(&self, params: &PrepareParams) -> Result<(), PrepareError> {
-        self.setup_deps(&params.app_root, &params.encore_dev_version)
+        self.setup_deps(
+            &params.app_root,
+            &params.encore_dev_version,
+            params.install_mode,
+        )
     }
 }

--- a/tsparser/tests/production_install.rs
+++ b/tsparser/tests/production_install.rs
@@ -1,0 +1,146 @@
+#![cfg(unix)]
+
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+
+// Exercise the actual prepare protocol, manager resolution and child execution.
+// Each parser subprocess gets an isolated PATH, so tests never mutate global env
+// or invoke the user's package managers. No registry or VM is needed.
+#[test]
+fn production_install_commands() {
+    for (manager, yarn_version, expected) in [
+        ("npm", "", "install\n--omit=dev\n"),
+        ("pnpm", "", "install\n--prod\n"),
+        ("bun", "", "install\n--backend\ncopyfile\n--omit\ndev\n"),
+        ("yarn", "1.22.22", "install\n--production=true\n"),
+        ("yarn", "4.6.0", "workspaces\nfocus\n--all\n--production\n"),
+    ] {
+        for existing_tree in [false, true] {
+            let case = PrepareCase::new(manager, yarn_version, existing_tree);
+            assert!(case.prepare(Some("production"), false), "{manager}");
+            assert_eq!(case.args(), expected, "{manager}, existing={existing_tree}");
+            assert_eq!(
+                std::fs::read_to_string(case.root.path().join("cwd"))
+                    .unwrap()
+                    .trim(),
+                case.root.path().canonicalize().unwrap().to_str().unwrap()
+            );
+        }
+    }
+}
+
+#[test]
+fn default_install_keeps_development_behavior() {
+    for manager in ["npm", "pnpm", "bun", "yarn"] {
+        for mode in [None, Some("all")] {
+            for existing in [false, true] {
+                let case = PrepareCase::new(manager, "4.6.0", existing);
+                assert!(case.prepare(mode, false));
+                let expected = if existing {
+                    ""
+                } else if manager == "bun" {
+                    "install\n--backend\ncopyfile\n"
+                } else {
+                    "install\n"
+                };
+                assert_eq!(case.args(), expected, "{manager}");
+            }
+        }
+    }
+}
+
+#[test]
+fn production_install_inherits_workspace_manager() {
+    let case = PrepareCase::new("yarn", "4.6.0", false);
+    let app = case.root.path().join("nested-app");
+    std::fs::create_dir(&app).unwrap();
+    std::fs::write(
+        app.join("package.json"),
+        r#"{"dependencies":{"encore.dev":"1.2.3"}}"#,
+    )
+    .unwrap();
+    assert!(case.prepare_in(&app, Some("production"), false));
+    assert_eq!(
+        std::fs::read_to_string(app.join("args")).unwrap(),
+        "workspaces\nfocus\n--all\n--production\n"
+    );
+    assert_eq!(case.args(), "");
+}
+
+#[test]
+fn production_install_failure_is_reported() {
+    let case = PrepareCase::new("npm", "", false);
+    assert!(!case.prepare(Some("production"), true));
+    let case = PrepareCase::new("yarn", "invalid-version", false);
+    assert!(!case.prepare(Some("production"), false));
+    assert_eq!(case.args(), "");
+}
+
+struct PrepareCase {
+    root: tempdir::TempDir,
+    bin: tempdir::TempDir,
+    yarn_version: String,
+}
+impl PrepareCase {
+    fn new(manager: &str, yarn_version: &str, existing: bool) -> Self {
+        let root = tempdir::TempDir::new("prepare-app").unwrap();
+        let bin = tempdir::TempDir::new("prepare-bin").unwrap();
+        std::fs::write(
+            root.path().join("package.json"),
+            serde_json::json!({
+                "packageManager": format!("{manager}@1.0.0"),
+                "dependencies": {"encore.dev": "1.2.3"}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        if existing {
+            std::fs::create_dir(root.path().join("node_modules")).unwrap();
+        }
+        let program = bin.path().join(manager);
+        std::fs::write(&program, "#!/bin/sh\nif [ \"$1\" = --version ]; then printf '%s\\n' \"$TEST_YARN_VERSION\"; exit; fi\nprintf '%s\\n' \"$@\" > args\npwd > cwd\nexit \"$TEST_INSTALL_EXIT\"\n").unwrap();
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755)).unwrap();
+        Self {
+            root,
+            bin,
+            yarn_version: yarn_version.to_owned(),
+        }
+    }
+    // `mode` is the wire value of builder.InstallMode; None omits the field.
+    fn prepare(&self, mode: Option<&str>, fail: bool) -> bool {
+        self.prepare_in(self.root.path(), mode, fail)
+    }
+    fn prepare_in(&self, app: &std::path::Path, mode: Option<&str>, fail: bool) -> bool {
+        let mut input = serde_json::json!({"app_root": app, "runtime_version": "v1.2.3"});
+        if let Some(mode) = mode {
+            input["install_mode"] = mode.into();
+        }
+        let mut child = Command::new(env!("CARGO_BIN_EXE_tsparser-encore"))
+            .env("PATH", self.bin.path())
+            .env("BUN_INSTALL_BACKEND", "copyfile")
+            .env("TEST_YARN_VERSION", &self.yarn_version)
+            .env("TEST_INSTALL_EXIT", if fail { "1" } else { "0" })
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        writeln!(child.stdin.take().unwrap(), "prepare\n{input}").unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            output.stdout.len() >= 5,
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout[4] == 0
+    }
+    fn args(&self) -> String {
+        std::fs::read_to_string(self.root.path().join("args")).unwrap_or_default()
+    }
+}

--- a/v2/tsbuilder/tsbuilder.go
+++ b/v2/tsbuilder/tsbuilder.go
@@ -14,9 +14,10 @@ import (
 	"sync"
 	"time"
 
-	"encore.dev/appruntime/exported/experiments"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/protobuf/proto"
+
+	"encore.dev/appruntime/exported/experiments"
 
 	"encr.dev/internal/env"
 	"encr.dev/internal/lookpath"
@@ -151,6 +152,7 @@ func (i *BuilderImpl) Prepare(ctx context.Context, p builder.PrepareParams) (*bu
 		AppRoot:        paths.FS(p.App.Root()),
 		JSRuntimeRoot:  jsRuntimePath,
 		RuntimeVersion: version.Version,
+		InstallMode:    p.InstallMode,
 	}
 	if p.Build.UseLocalJSRuntime {
 		input.LocalRuntimeOverride = jsRuntimePath.ToIO()
@@ -373,10 +375,11 @@ const (
 )
 
 type prepareInput struct {
-	JSRuntimeRoot        paths.FS `json:"js_runtime_root"`
-	AppRoot              paths.FS `json:"app_root"`
-	RuntimeVersion       string   `json:"runtime_version"`
-	LocalRuntimeOverride string   `json:"local_runtime_override,omitempty"`
+	JSRuntimeRoot        paths.FS            `json:"js_runtime_root"`
+	AppRoot              paths.FS            `json:"app_root"`
+	RuntimeVersion       string              `json:"runtime_version"`
+	LocalRuntimeOverride string              `json:"local_runtime_override,omitempty"`
+	InstallMode          builder.InstallMode `json:"install_mode,omitempty"`
 }
 
 func readResp(reader io.Reader) (isSuccess bool, data []byte, err error) {


### PR DESCRIPTION
Add an InstallMode ("all" by default, or "production") to builder.PrepareParams and plumb it through the tsbuilder prepare protocol to tsparser. Each package manager selects its own production install command (npm --omit=dev, pnpm --prod, bun --omit dev, yarn --production / workspaces focus --all --production).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791465826&installation_model_id=427204&pr_number=2575&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2575&signature=02f00d571c7d3073bceeb04b6fc037e3e384d61a7a99742777348c597e70ab29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->