### PR TITLE
perf: improve performance of `encore build docker`

### DIFF
--- a/cli/daemon/export/export.go
+++ b/cli/daemon/export/export.go
@@ -257,6 +257,8 @@ func Docker(ctx context.Context, app *apps.Instance, req *daemonpb.ExportRequest
 		return false, errors.Wrap(err, "build docker image")
 	}
 
+	defer fns.CloseIgnore(img)
+
 	if params.LocalDaemonTag != "" {
 		tag, err := name.NewTag(params.LocalDaemonTag, name.WeakValidation)
 		if err != nil {

--- a/pkg/dockerbuild/dockerbuild.go
+++ b/pkg/dockerbuild/dockerbuild.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -19,9 +20,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
 
+	"encr.dev/pkg/fns"
 	"encr.dev/pkg/option"
 )
 
@@ -55,10 +57,32 @@ type ImageBuildConfig struct {
 
 	// A URL to a http proxy used to fetch images
 	DockerOptions []remote.Option
+
+	// CompressionLevel is the gzip level (1-9). Zero uses level 5.
+	CompressionLevel int
+	// CompressionConcurrency bounds concurrent layer compression per image.
+	// Zero uses at most two workers, limited by GOMAXPROCS.
+	CompressionConcurrency int
+	// TempDir is the parent directory for compressed blobs; empty uses os.TempDir.
+	TempDir string
 }
 
-// BuildImage builds a docker image from the given spec.
-func BuildImage(ctx context.Context, spec *ImageSpec, cfg ImageBuildConfig) (v1.Image, error) {
+// BuildImage builds a docker image from the given spec. The caller must Close
+// the returned image after all exports, uploads and layer readers have finished.
+func BuildImage(ctx context.Context, spec *ImageSpec, cfg ImageBuildConfig) (*Image, error) {
+	if cfg.CompressionLevel == 0 {
+		cfg.CompressionLevel = 5
+	}
+	if cfg.CompressionLevel < 1 || cfg.CompressionLevel > 9 {
+		return nil, errors.New("compression level must be between 1 and 9")
+	}
+	if cfg.CompressionConcurrency == 0 {
+		cfg.CompressionConcurrency = min(2, runtime.GOMAXPROCS(0))
+	}
+	if cfg.CompressionConcurrency < 1 {
+		return nil, errors.New("compression concurrency must be positive")
+	}
+
 	options := append(cfg.DockerOptions,
 		remote.WithPlatform(v1.Platform{
 			OS:           spec.OS,
@@ -75,23 +99,42 @@ func BuildImage(ctx context.Context, spec *ImageSpec, cfg ImageBuildConfig) (v1.
 		return nil, errors.Wrap(err, "build image fs")
 	}
 
-	adds := make([]mutate.Addendum, 0, len(layers))
-	for _, l := range layers {
-		layer, err := tarball.LayerFromOpener(l.opener,
-			tarball.WithCompressionLevel(5), // balance speed and compression
-		)
-		if err != nil {
-			return nil, errors.Wrapf(err, "create %s layer", l.kind)
+	dir, err := os.MkdirTemp(cfg.TempDir, "encore-image-")
+	if err != nil {
+		return nil, errors.Wrap(err, "create image blob directory")
+	}
+	built := &Image{dir: dir}
+	success := false
+	defer func() {
+		if !success {
+			fns.CloseIgnore(built)
 		}
-		adds = append(adds, mutate.Addendum{
-			Layer: layer,
-			History: v1.History{
-				Author:    "encore-app",
-				Created:   v1.Time{Time: cfg.BuildTime},
-				CreatedBy: "encore.dev",
-				Comment:   fmt.Sprintf("%s layer, built with encore.dev", l.kind),
-			},
+	}()
+
+	// Each worker writes its own blob and result slot. Keep the original layer
+	// order regardless of completion order, so parallelism cannot change digests.
+	adds := make([]mutate.Addendum, len(layers))
+	g, compressCtx := errgroup.WithContext(ctx)
+	g.SetLimit(cfg.CompressionConcurrency)
+	for idx, l := range layers {
+		g.Go(func() error {
+			layer, err := compressLayer(compressCtx, built, l.opener, cfg.CompressionLevel)
+			if err != nil {
+				return errors.Wrapf(err, "create %s layer", l.kind)
+			}
+			adds[idx] = mutate.Addendum{
+				Layer: layer,
+				History: v1.History{
+					Author: "encore-app", Created: v1.Time{Time: cfg.BuildTime},
+					CreatedBy: "encore.dev",
+					Comment:   fmt.Sprintf("%s layer, built with encore.dev", l.kind),
+				},
+			}
+			return nil
 		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	log.Info().Int("layers", len(adds)).Msg("adding layers to base image")
@@ -129,7 +172,9 @@ func BuildImage(ctx context.Context, spec *ImageSpec, cfg ImageBuildConfig) (v1.
 	if err != nil {
 		return nil, errors.Wrap(err, "add config")
 	}
-	return img, nil
+	built.Image = img
+	success = true
+	return built, nil
 }
 
 // ResolveRemoteImage resolves the base image with the given reference.

--- a/pkg/dockerbuild/dockerbuild.go
+++ b/pkg/dockerbuild/dockerbuild.go
@@ -63,6 +63,18 @@ type ImageBuildConfig struct {
 	// CompressionConcurrency bounds concurrent layer compression per image.
 	// Zero uses at most two workers, limited by GOMAXPROCS.
 	CompressionConcurrency int
+	// PreparationConcurrency bounds metadata/header preparation workers per image.
+	// Zero uses at most two workers, limited by GOMAXPROCS. All images also
+	// share a process-wide metadata budget of min(4, startup GOMAXPROCS).
+	PreparationConcurrency int
+	// ReadAheadBytes limits prefetched file contents per active layer.
+	// Zero uses 256 KiB; -1 disables read-ahead for sequential comparisons.
+	// Tiny (<=64 KiB) and memory-only layers skip read-ahead.
+	ReadAheadBytes int
+	// ReadAheadConcurrency bounds distinct source files being prefetched per
+	// active layer. Zero uses four workers sharing ReadAheadBytes. The number
+	// of source files and a small byte budget can further reduce worker count.
+	ReadAheadConcurrency int
 	// TempDir is the parent directory for compressed blobs; empty uses os.TempDir.
 	TempDir string
 }
@@ -205,7 +217,30 @@ func resolveBaseImage(ctx context.Context, baseImgTag string, overrideBaseImage 
 }
 
 func buildImageFilesystem(ctx context.Context, spec *ImageSpec, cfg *ImageBuildConfig) ([]imageLayer, error) {
-	lc := newLayeredTarCopier(setFileTimes(layerEpoch))
+	workers := cfg.PreparationConcurrency
+	if workers == 0 {
+		workers = min(2, runtime.GOMAXPROCS(0))
+	}
+	if workers < 1 {
+		return nil, errors.New("preparation concurrency must be positive")
+	}
+	ahead := cfg.ReadAheadBytes
+	if ahead == 0 {
+		ahead = 256 << 10
+	}
+	if ahead < -1 {
+		return nil, errors.New("read-ahead bytes must be positive or -1 to disable")
+	}
+	readers := cfg.ReadAheadConcurrency
+	if readers == 0 {
+		readers = 4
+	}
+	if readers < 1 {
+		return nil, errors.New("read-ahead concurrency must be positive")
+	}
+	lc := newLayeredTarCopier(setFileTimes(layerEpoch), func(tc *tarCopier) {
+		tc.ctx, tc.preparationWorkers, tc.readAheadBytes, tc.readAheadWorkers = ctx, workers, ahead, readers
+	})
 
 	// Bundle the source code, if requested.
 	if bundle, ok := spec.BundleSource.Get(); ok {

--- a/pkg/dockerbuild/dockerbuild_test.go
+++ b/pkg/dockerbuild/dockerbuild_test.go
@@ -83,6 +83,8 @@ func TestBuildImage(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 
+	t.Cleanup(func() { c.Check(img.Close(), qt.IsNil) })
+
 	_, err = img.Digest()
 	c.Assert(err, qt.IsNil)
 
@@ -132,6 +134,7 @@ func TestBuildImage_ReproducibleLayers(t *testing.T) {
 			SupervisorPath: option.Some(supervisorPath),
 		})
 		c.Assert(err, qt.IsNil)
+		t.Cleanup(func() { c.Check(img.Close(), qt.IsNil) })
 		layers, err := img.Layers()
 		c.Assert(err, qt.IsNil)
 		return layers

--- a/pkg/dockerbuild/layer.go
+++ b/pkg/dockerbuild/layer.go
@@ -1,0 +1,201 @@
+package dockerbuild
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"encr.dev/pkg/fns"
+)
+
+// Image owns the temporary compressed blobs for its newly built layers.
+// Call Close after all exports, uploads and layer readers have finished.
+// Base image layers retain their original storage and are not owned by Image.
+type Image struct {
+	v1.Image
+	dir string
+
+	mu      sync.Mutex
+	closed  bool
+	readers map[*os.File]struct{}
+}
+
+func (i *Image) Close() error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.closed = true
+	var errs []error
+	// Some image exporters do not close Compressed readers on early failure.
+	// The image owns those handles too, including on platforms where an open
+	// file would prevent removal of the temporary directory.
+	for f := range i.readers {
+		errs = append(errs, f.Close())
+		delete(i.readers, f)
+	}
+	errs = append(errs, os.RemoveAll(i.dir))
+	return errors.Join(errs...)
+}
+
+func (i *Image) openBlob(path string) (io.ReadCloser, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.closed {
+		return nil, fs.ErrClosed
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	if i.readers == nil {
+		i.readers = make(map[*os.File]struct{})
+	}
+	i.readers[f] = struct{}{}
+	return &blobReader{file: f, owner: i}, nil
+}
+
+type blobReader struct {
+	file  *os.File
+	owner *Image
+	done  atomic.Bool
+}
+
+func (r *blobReader) Read(p []byte) (int, error) {
+	if r.done.Load() {
+		return 0, io.EOF
+	}
+	n, err := r.file.Read(p)
+	if err == io.EOF {
+		fns.CloseIgnore(r)
+	}
+	return n, err
+}
+
+func (r *blobReader) Close() error {
+	if r.done.Swap(true) {
+		return nil
+	}
+	r.owner.mu.Lock()
+	defer r.owner.mu.Unlock()
+	if _, open := r.owner.readers[r.file]; !open {
+		return nil
+	}
+	delete(r.owner.readers, r.file)
+	return r.file.Close()
+}
+
+// fileLayer records both hashes while reading the source tar exactly once.
+// Only compressed bytes are retained, on disk rather than in a large buffer.
+type fileLayer struct {
+	owner          *Image
+	path           string
+	digest, diffID v1.Hash
+	size           int64
+}
+
+var _ v1.Layer = (*fileLayer)(nil)
+
+func (l *fileLayer) Digest() (v1.Hash, error)            { return l.digest, nil }
+func (l *fileLayer) DiffID() (v1.Hash, error)            { return l.diffID, nil }
+func (l *fileLayer) Size() (int64, error)                { return l.size, nil }
+func (l *fileLayer) MediaType() (types.MediaType, error) { return types.DockerLayer, nil }
+func (l *fileLayer) Compressed() (io.ReadCloser, error)  { return l.owner.openBlob(l.path) }
+
+func (l *fileLayer) Uncompressed() (io.ReadCloser, error) {
+	f, err := l.Compressed()
+	if err != nil {
+		return nil, err
+	}
+	z, err := gzip.NewReader(f)
+	if err != nil {
+		fns.CloseIgnore(f)
+		return nil, err
+	}
+	return &gzipFileReader{Reader: z, file: f}, nil
+}
+
+type gzipFileReader struct {
+	*gzip.Reader
+	file io.ReadCloser
+}
+
+func (r *gzipFileReader) Close() error {
+	return errors.Join(r.Reader.Close(), r.file.Close())
+}
+
+// The image owns the directory and removes it on failure as well as after use.
+func compressLayer(ctx context.Context, owner *Image, opener tarball.Opener, level int) (*fileLayer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	src, err := opener()
+	if err != nil {
+		return nil, errors.Wrap(err, "open layer tar")
+	}
+	defer fns.CloseIgnore(src)
+	f, err := os.CreateTemp(owner.dir, "layer-*.gz")
+	if err != nil {
+		return nil, errors.Wrap(err, "create layer blob")
+	}
+	defer fns.CloseIgnore(f)
+
+	compressedHash, tarHash := sha256.New(), sha256.New()
+	// Coalesce gzip's small writes without buffering the whole layer.
+	out := bufio.NewWriterSize(io.MultiWriter(f, compressedHash), 128<<10)
+	z, err := gzip.NewWriterLevel(out, level)
+	if err != nil {
+		return nil, err
+	}
+	defer fns.CloseIgnore(z)
+	if _, err := io.Copy(z, io.TeeReader(layerContextReader{ctx, src}, tarHash)); err != nil {
+		return nil, errors.Wrap(err, "compress layer")
+	}
+	if err := z.Close(); err != nil {
+		return nil, errors.Wrap(err, "finish layer gzip")
+	}
+	if err := out.Flush(); err != nil {
+		return nil, errors.Wrap(err, "flush layer blob")
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "stat layer blob")
+	}
+	if err := f.Close(); err != nil {
+		return nil, errors.Wrap(err, "close layer blob")
+	}
+	if err := src.Close(); err != nil {
+		return nil, errors.Wrap(err, "close layer tar")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &fileLayer{
+		owner: owner,
+		path:  f.Name(), size: stat.Size(),
+		digest: v1.Hash{Algorithm: "sha256", Hex: hex.EncodeToString(compressedHash.Sum(nil))},
+		diffID: v1.Hash{Algorithm: "sha256", Hex: hex.EncodeToString(tarHash.Sum(nil))},
+	}, nil
+}
+
+type layerContextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r layerContextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}

--- a/pkg/dockerbuild/layer_test.go
+++ b/pkg/dockerbuild/layer_test.go
@@ -1,0 +1,242 @@
+package dockerbuild
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+
+	"encr.dev/pkg/fns"
+	"encr.dev/pkg/option"
+)
+
+func TestCompressedLayerReadsSourceOnce(t *testing.T) {
+	var tarData bytes.Buffer
+	tw := tar.NewWriter(&tarData)
+	payload := bytes.Repeat([]byte("a dependency's source code\n"), 8192)
+	if err := tw.WriteHeader(&tar.Header{Name: "app.js", Size: int64(len(payload)), Mode: 0644}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, level := range []int{1, 5} {
+		t.Run(string(rune('0'+level)), func(t *testing.T) {
+			opens := 0
+			opener := func() (io.ReadCloser, error) {
+				opens++
+				if opens > 1 {
+					return nil, errors.New("source reopened")
+				}
+				return io.NopCloser(bytes.NewReader(tarData.Bytes())), nil
+			}
+			layer, err := compressLayer(t.Context(), &Image{dir: t.TempDir()}, opener, level)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if opens != 1 {
+				t.Fatalf("opens = %d", opens)
+			}
+			// Compare to the former implementation, including the exact gzip digest.
+			old, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(tarData.Bytes())), nil
+			}, tarball.WithCompressionLevel(level))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantDigest, err := old.Digest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if layer.digest != wantDigest {
+				t.Fatalf("compressed digest = %s, want %s", layer.digest, wantDigest)
+			}
+			wantDiffID, _, err := v1.SHA256(bytes.NewReader(tarData.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if layer.diffID != wantDiffID {
+				t.Fatalf("diffID = %s, want %s", layer.diffID, wantDiffID)
+			}
+			// Push retries and concurrent consumers read independent file handles.
+			var wg sync.WaitGroup
+			for range 4 {
+				wg.Go(func() {
+					r, err := layer.Compressed()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					defer fns.CloseIgnore(r)
+					digest, size, err := v1.SHA256(r)
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					if digest != wantDigest || size != layer.size {
+						t.Errorf("blob = %s / %d, want %s / %d", digest, size, wantDigest, layer.size)
+					}
+				})
+			}
+			wg.Wait()
+			r, err := layer.Uncompressed()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fns.CloseIgnore(r)
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, tarData.Bytes()) {
+				t.Fatal("uncompressed bytes changed")
+			}
+			if opens != 1 {
+				t.Fatalf("source reopened %d times", opens)
+			}
+		})
+	}
+}
+
+func TestImageBlobLifetimeAndParallelOrder(t *testing.T) {
+	root, blobs := t.TempDir(), t.TempDir()
+	source := filepath.Join(root, "app.js")
+	if err := os.WriteFile(source, []byte("original source"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	spec := &ImageSpec{OS: "linux", Arch: "amd64", CopyData: map[ImagePath]HostPath{"/app.js": HostPath(source)}, BuildInfo: BuildInfoSpec{InfoPath: "/build-info.json"}}
+	var digest v1.Hash
+	for _, workers := range []int{1, 2, 4} {
+		img, err := BuildImage(t.Context(), spec, ImageBuildConfig{TempDir: blobs, CompressionConcurrency: workers})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { fns.CloseIgnore(img) })
+		d, err := img.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if workers == 1 {
+			digest = d
+		} else if d != digest {
+			t.Fatal("parallelism changed image digest")
+		}
+		// Once built, even removal of the source cannot change or break an export.
+		if err := os.Remove(source); err != nil {
+			t.Fatal(err)
+		}
+		if err := tarball.Write(name.MustParseReference("test:latest"), img, io.Discard); err != nil {
+			t.Fatal(err)
+		}
+		img.mu.Lock()
+		openReaders := len(img.readers)
+		img.mu.Unlock()
+		if openReaders != 0 {
+			t.Fatalf("export leaked %d readers after EOF", openReaders)
+		}
+		layers, err := img.Layers()
+		if err != nil {
+			t.Fatal(err)
+		}
+		partial, err := layers[0].Compressed()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fns.CloseIgnore(partial)
+		if err := img.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := partial.Read(make([]byte, 1)); !errors.Is(err, fs.ErrClosed) {
+			t.Fatalf("partial reader still open after image Close: %v", err)
+		}
+		if _, err := layers[0].Compressed(); !errors.Is(err, fs.ErrClosed) {
+			t.Fatalf("reopened closed image: %v", err)
+		}
+		entries, err := os.ReadDir(blobs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("leaked blobs: %v", entries)
+		}
+		if err := os.WriteFile(source, []byte("original source"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+type badConfigImage struct{ v1.Image }
+
+func (badConfigImage) ConfigFile() (*v1.ConfigFile, error) { return nil, errors.New("bad config") }
+
+func TestImageCleansBlobsOnFailure(t *testing.T) {
+	for _, cancel := range []bool{false, true} {
+		dir := t.TempDir()
+		ctx, stop := context.WithCancel(t.Context())
+		if cancel {
+			stop()
+		}
+		img, err := BuildImage(ctx, &ImageSpec{BuildInfo: BuildInfoSpec{InfoPath: "/build-info.json"}, WriteFiles: map[ImagePath][]byte{"/config": []byte("payload")}}, ImageBuildConfig{
+			TempDir: dir, BaseImageOverride: option.Some[v1.Image](badConfigImage{empty.Image}),
+		})
+		stop()
+		if !cancel && (err == nil || !strings.Contains(err.Error(), "bad config")) {
+			t.Fatalf("expected config failure after compression: %v", err)
+		}
+		if cancel && !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected cancellation: %v", err)
+		}
+		if err == nil || img != nil {
+			t.Fatal("expected failed build")
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("leaked blobs: %v", entries)
+		}
+	}
+}
+
+type cancelLayerReader struct {
+	cancel context.CancelFunc
+	closed bool
+}
+
+func (r *cancelLayerReader) Read(p []byte) (int, error) { r.cancel(); return copy(p, "data"), nil }
+func (r *cancelLayerReader) Close() error               { r.closed = true; return nil }
+
+func TestCompressionCancellationClosesSource(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	src := &cancelLayerReader{cancel: cancel}
+	dir := t.TempDir()
+	img := &Image{dir: dir}
+	layer, err := compressLayer(ctx, img, func() (io.ReadCloser, error) { return src, nil }, 5)
+	if !errors.Is(err, context.Canceled) || layer != nil || !src.closed {
+		t.Fatalf("layer=%v err=%v closed=%v", layer, err, src.closed)
+	}
+	// The image owns partial files as well; its cleanup removes them.
+	if err := img.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("directory still exists: %v", err)
+	}
+}

--- a/pkg/dockerbuild/packaging_bench_test.go
+++ b/pkg/dockerbuild/packaging_bench_test.go
@@ -1,0 +1,182 @@
+package dockerbuild
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+
+	"encr.dev/pkg/fns"
+	"encr.dev/pkg/option"
+)
+
+// BenchmarkImagePackaging measures the real file-backed assembler and complete
+// serialization without a VM or registry. One operation is a wave of jobs sharing
+// CPUs and disk; stage metrics are average per-job latency under that contention.
+// Filesystem caches are warm. Inputs combine many JS files and a native binary;
+// they are deterministic synthetic fixtures, not estimates for a specific app.
+func BenchmarkImagePackaging(b *testing.B) {
+	logger := log.Logger
+	log.Logger = log.Output(io.Discard)
+	defer func() { log.Logger = logger }()
+	for _, layout := range []string{"balanced", "dependencies"} {
+		b.Run(layout, func(b *testing.B) {
+			spec, bytes := packagingFixture(b, layout)
+			for _, legacy := range []bool{true, false} {
+				for _, level := range []int{1, 5} {
+					for _, workers := range []int{1, 2, 4} {
+						if legacy && (level != 5 || workers != 1) {
+							continue
+						}
+						for _, jobs := range []int{1, 4} {
+							method := "blob"
+							if legacy {
+								method = "legacy"
+							}
+							b.Run(fmt.Sprintf("%s/gzip%d/workers%d/jobs%d", method, level, workers, jobs), func(b *testing.B) {
+								cfg := ImageBuildConfig{TempDir: b.TempDir(), CompressionLevel: level, CompressionConcurrency: workers}
+								type result struct {
+									assemble, serialize time.Duration
+									size                int64
+								}
+								results := make([]result, jobs)
+								var assemble, serialize time.Duration
+								var size int64
+								b.SetBytes(bytes * int64(jobs))
+								b.ReportAllocs()
+								b.ResetTimer()
+								for range b.N {
+									var g errgroup.Group
+									for j := range jobs {
+										g.Go(func() error {
+											start := time.Now()
+											var img v1.Image
+											var err error
+											if legacy {
+												img, err = legacyPackagingImage(b.Context(), spec, cfg)
+											} else {
+												var built *Image
+												built, err = BuildImage(b.Context(), spec, cfg)
+												if err == nil {
+													defer fns.CloseIgnore(built)
+													img = built
+												}
+											}
+											if err != nil {
+												return err
+											}
+											assembled := time.Now()
+											manifest, err := img.Manifest()
+											if err != nil {
+												return err
+											}
+											var blobSize int64
+											for _, l := range manifest.Layers {
+												blobSize += l.Size
+											}
+											if err := tarball.Write(name.MustParseReference("bench:latest"), img, io.Discard); err != nil {
+												return err
+											}
+											results[j] = result{assembled.Sub(start), time.Since(assembled), blobSize}
+											return nil
+										})
+									}
+									if err := g.Wait(); err != nil {
+										b.Fatal(err)
+									}
+									for _, r := range results {
+										assemble += r.assemble
+										serialize += r.serialize
+										size += r.size
+									}
+								}
+								b.StopTimer()
+								n := float64(b.N * jobs)
+								b.ReportMetric(float64(assemble)/float64(time.Millisecond)/n, "assemble-ms/job")
+								b.ReportMetric(float64(serialize)/float64(time.Millisecond)/n, "serialize-ms/job")
+								b.ReportMetric(float64(size)/(1<<20)/n, "blob-MiB/job")
+							})
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// The former compression algorithm: serial source tar construction, eager digest and
+// diffID calculation, followed by lazy re-compression during serialization.
+func legacyPackagingImage(ctx context.Context, spec *ImageSpec, cfg ImageBuildConfig) (v1.Image, error) {
+	layers, err := buildImageFilesystem(ctx, spec, &cfg)
+	if err != nil {
+		return nil, err
+	}
+	var adds []v1.Layer
+	for _, l := range layers {
+		layer, err := tarball.LayerFromOpener(l.opener, tarball.WithCompressionLevel(cfg.CompressionLevel))
+		if err != nil {
+			return nil, err
+		}
+		adds = append(adds, layer)
+	}
+	return mutate.AppendLayers(empty.Image, adds...)
+}
+
+func packagingFixture(b *testing.B, layout string) (*ImageSpec, int64) {
+	b.Helper()
+	root := b.TempDir()
+	rng := rand.New(rand.NewSource(1))
+	runtimeMiB, depsMiB, appMiB := 8, 8, 8
+	if layout == "dependencies" {
+		runtimeMiB, depsMiB, appMiB = 2, 32, 2
+	}
+	write := func(path string, data []byte) {
+		b.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	writeCode := func(dir string, mib int) {
+		for file := range mib * 64 {
+			data := make([]byte, 16<<10)
+			// Some opaque data (maps/assets) plus compressible but varying code.
+			if _, err := rng.Read(data[:len(data)/4]); err != nil {
+				b.Fatal(err)
+			}
+			for offset := len(data) / 4; offset < len(data); {
+				line := fmt.Sprintf("export function f%d(arg) { return { key: %d, value: arg.property%d }; }\n", rng.Intn(1000), rng.Intn(100000), rng.Intn(100))
+				offset += copy(data[offset:], line)
+			}
+			write(filepath.Join(dir, fmt.Sprintf("pkg-%04d", file), "index.js"), data)
+		}
+	}
+	writeCode(filepath.Join(root, "app", "node_modules"), depsMiB)
+	writeCode(filepath.Join(root, "app", "src"), appMiB)
+	native := make([]byte, runtimeMiB<<20)
+	if _, err := rng.Read(native[:len(native)*3/4]); err != nil {
+		b.Fatal(err)
+	}
+	write(filepath.Join(root, "runtime.node"), native)
+	return &ImageSpec{
+		OS: "linux", Arch: "amd64", Entrypoint: []string{"node", "/workspace/main.js"},
+		BundleSource: option.Some(BundleSourceSpec{Source: HostPath(filepath.Join(root, "app")), Dest: "/workspace", AppRootRelpath: "."}),
+		CopyData:     map[ImagePath]HostPath{"/encore/runtimes/js/runtime.node": HostPath(filepath.Join(root, "runtime.node"))},
+		WriteFiles:   map[ImagePath][]byte{"/encore/meta": make([]byte, 64<<10)},
+		BuildInfo:    BuildInfoSpec{InfoPath: "/encore/build-info.json"},
+	}, int64(runtimeMiB+depsMiB+appMiB) << 20
+}

--- a/pkg/dockerbuild/packaging_bench_test.go
+++ b/pkg/dockerbuild/packaging_bench_test.go
@@ -119,6 +119,7 @@ func BenchmarkImagePackaging(b *testing.B) {
 // The former compression algorithm: serial source tar construction, eager digest and
 // diffID calculation, followed by lazy re-compression during serialization.
 func legacyPackagingImage(ctx context.Context, spec *ImageSpec, cfg ImageBuildConfig) (v1.Image, error) {
+	cfg.PreparationConcurrency, cfg.ReadAheadBytes = 1, -1
 	layers, err := buildImageFilesystem(ctx, spec, &cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/dockerbuild/read_ahead.go
+++ b/pkg/dockerbuild/read_ahead.go
@@ -1,0 +1,252 @@
+package dockerbuild
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+
+	"encr.dev/pkg/tarstream"
+)
+
+// fileReadAhead prefetches distinct source-file entries before tar assembly.
+// A fixed pool reads files in order within each slot. Each slot owns
+// its buffers, so a later file cannot exhaust the memory needed by an earlier
+// file and deadlock the consumer. Headers and padding are never prefetched.
+type fileReadAhead struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
+	tar          *tarstream.TarVec
+	done         chan struct{}
+	workerErrors []error    // each worker owns one element, read after done
+	readMu       sync.Mutex // TarVec is sequential; also excludes Close from Read
+	closeOnce    sync.Once
+	closeErr     error
+}
+
+type fileReadSlot struct {
+	free  chan []byte
+	ready chan fileReadChunk
+}
+
+type fileReadChunk struct {
+	buf []byte
+	n   int
+	err error
+}
+
+// fileIndices identifies the source-file vectors, in tar order. The other
+// vectors are immutable in-memory headers, contents and padding. Each opener
+// gets its own pool; a source file is never split across workers.
+func newFileReadAhead(ctx context.Context, vecs []tarstream.Datavec, fileIndices []int, budget, workers int) io.ReadCloser {
+	if budget <= 0 || len(fileIndices) == 0 {
+		return tarstream.NewTarVec(vecs)
+	}
+	workers = min(workers, len(fileIndices), budget)
+	ctx, cancel := context.WithCancel(ctx)
+	r := &fileReadAhead{ctx: ctx, cancel: cancel, done: make(chan struct{}), workerErrors: make([]error, workers)}
+	wrapped := append([]tarstream.Datavec(nil), vecs...)
+	var wg sync.WaitGroup
+	for idx := range workers {
+		// Reusable buffers include all free, queued, producer- and consumer-held
+		// bytes. Completed files can remain queued while the worker reads another
+		// file; four buffers per slot keep small files from stalling that pipeline.
+		perWorker := budget / workers
+		count := min(4, perWorker)
+		slot := &fileReadSlot{free: make(chan []byte, count), ready: make(chan fileReadChunk, count)}
+		for range count {
+			slot.free <- make([]byte, perWorker/count)
+		}
+		for file := idx; file < len(fileIndices); file += workers {
+			vecIdx := fileIndices[file]
+			wrapped[vecIdx] = &prefetchedFileVec{ctx: ctx, slot: slot, size: vecs[vecIdx].GetSize()}
+		}
+		wg.Go(func() {
+			for file := idx; file < len(fileIndices); file += workers {
+				if ctx.Err() != nil {
+					return
+				}
+				if err := slot.prefetch(ctx, vecs[fileIndices[file]]); err != nil {
+					r.workerErrors[idx] = errors.Join(r.workerErrors[idx], err)
+				}
+			}
+		})
+	}
+	r.tar = tarstream.NewTarVec(wrapped)
+	go func() { wg.Wait(); close(r.done) }()
+	return r
+}
+
+func (s *fileReadSlot) prefetch(ctx context.Context, vec tarstream.Datavec) (closeErr error) {
+	src, err := vec.Open()
+	if err != nil {
+		select {
+		case <-ctx.Done():
+		case s.ready <- fileReadChunk{err: errors.Wrap(err, "open source file")}:
+		}
+		return nil
+	}
+	// The worker owns both ReadAt and Close, including during cancellation.
+	defer func() { closeErr = src.Close() }()
+	for offset := int64(0); offset < vec.GetSize(); {
+		var buf []byte
+		select {
+		case <-ctx.Done():
+			return nil
+		case buf = <-s.free:
+		}
+		want := int(min(int64(len(buf)), vec.GetSize()-offset))
+		n, err := readFileChunk(ctx, src, buf[:want], offset)
+		offset += int64(n)
+		if err == nil && offset == vec.GetSize() {
+			err = io.EOF
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case s.ready <- fileReadChunk{buf: buf, n: n, err: err}:
+		}
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+func readFileChunk(ctx context.Context, src io.ReaderAt, p []byte, offset int64) (int, error) {
+	n := 0
+	for n < len(p) {
+		if err := ctx.Err(); err != nil {
+			return n, err
+		}
+		nn, err := src.ReadAt(p[n:], offset+int64(n))
+		n += nn
+		if err == io.EOF {
+			if n < len(p) {
+				err = io.ErrUnexpectedEOF
+			} else {
+				err = nil
+			}
+		}
+		if err != nil {
+			return n, err
+		}
+		if nn == 0 {
+			return n, io.ErrNoProgress
+		}
+	}
+	return n, nil
+}
+
+func (r *fileReadAhead) Read(p []byte) (int, error) {
+	r.readMu.Lock()
+	defer r.readMu.Unlock()
+	if len(p) == 0 {
+		return 0, nil
+	}
+	// Coalesce headers, contents and padding in the caller's buffer. Feeding
+	// gzip one tiny header at a time costs CPU and loses the old stream buffer's
+	// batching benefit; this needs no additional buffer or filesystem reads.
+	n := 0
+	for n < len(p) {
+		if err := r.ctx.Err(); err != nil {
+			return n, err
+		}
+		nn, err := r.tar.Read(p[n:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+		if nn == 0 {
+			return n, io.ErrNoProgress
+		}
+	}
+	return n, nil
+}
+
+func (r *fileReadAhead) Close() error {
+	r.closeOnce.Do(func() {
+		r.cancel()
+		<-r.done
+		r.readMu.Lock()
+		defer r.readMu.Unlock()
+		r.closeErr = errors.Join(append(r.workerErrors, r.tar.Close())...)
+	})
+	return r.closeErr
+}
+
+type prefetchedFileVec struct {
+	ctx  context.Context
+	slot *fileReadSlot
+	size int64
+}
+
+func (v *prefetchedFileVec) GetSize() int64           { return v.size }
+func (v *prefetchedFileVec) Clone() tarstream.Datavec { return v }
+func (v *prefetchedFileVec) Open() (tarstream.DataReader, error) {
+	return &prefetchedFileReader{ctx: v.ctx, slot: v.slot}, nil
+}
+
+type prefetchedFileReader struct {
+	ctx      context.Context
+	slot     *fileReadSlot
+	current  fileReadChunk
+	offset   int
+	pos      int64
+	terminal error
+}
+
+// This private ReaderAt is only used by the forward-only tar assembler. It
+// consumes file buffers in order rather than issuing more filesystem reads.
+func (r *prefetchedFileReader) ReadAt(p []byte, off int64) (int, error) {
+	if off != r.pos {
+		return 0, errors.Newf("non-sequential prefetched file read: offset %d, want %d", off, r.pos)
+	}
+	n := 0
+	for n < len(p) {
+		nn, err := r.read(p[n:])
+		n += nn
+		r.pos += int64(nn)
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func (r *prefetchedFileReader) read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if r.terminal != nil {
+		return 0, r.terminal
+	}
+	if r.current.buf == nil {
+		select {
+		case <-r.ctx.Done():
+			return 0, r.ctx.Err()
+		case r.current = <-r.slot.ready:
+		}
+		r.offset = 0
+	}
+	n := copy(p, r.current.buf[r.offset:r.current.n])
+	r.offset += n
+	if r.offset == r.current.n {
+		r.terminal = r.current.err
+		r.releaseBuffer()
+	}
+	return n, r.terminal
+}
+
+func (r *prefetchedFileReader) releaseBuffer() {
+	if r.current.buf != nil {
+		r.slot.free <- r.current.buf
+	}
+	r.current = fileReadChunk{}
+}
+
+func (r *prefetchedFileReader) Close() error {
+	r.releaseBuffer()
+	return nil
+}

--- a/pkg/dockerbuild/read_ahead_bench_test.go
+++ b/pkg/dockerbuild/read_ahead_bench_test.go
@@ -1,0 +1,67 @@
+package dockerbuild
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+
+	"encr.dev/pkg/fns"
+)
+
+// BenchmarkImageFileReadAhead compares file-level I/O concurrency at a fixed
+// 256 KiB per-layer budget, gzip 5 and two metadata/compression workers. Each
+// operation is one wave of jobs sharing GOMAXPROCS and warm on-disk inputs.
+func BenchmarkImageFileReadAhead(b *testing.B) {
+	logger := log.Logger
+	log.Logger = log.Output(io.Discard)
+	defer func() { log.Logger = logger }()
+	for _, layout := range []string{"balanced", "dependencies"} {
+		b.Run(layout, func(b *testing.B) {
+			spec, size := packagingFixture(b, layout)
+			for _, readers := range []int{1, 2, 4} {
+				for _, jobs := range []int{1, 4} {
+					b.Run(fmt.Sprintf("files%d/jobs%d", readers, jobs), func(b *testing.B) {
+						cfg := ImageBuildConfig{PreparationConcurrency: 2, ReadAheadBytes: 256 << 10, ReadAheadConcurrency: readers, CompressionLevel: 5, CompressionConcurrency: 2, TempDir: b.TempDir()}
+						durations := make([]time.Duration, jobs)
+						var total time.Duration
+						b.SetBytes(size * int64(jobs))
+						b.ReportAllocs()
+						b.ResetTimer()
+						for range b.N {
+							var g errgroup.Group
+							for j := range jobs {
+								g.Go(func() error {
+									start := time.Now()
+									img, err := BuildImage(b.Context(), spec, cfg)
+									if err != nil {
+										return err
+									}
+									defer fns.CloseIgnore(img)
+									if err := tarball.Write(name.MustParseReference("bench:latest"), img, io.Discard); err != nil {
+										return err
+									}
+									durations[j] = time.Since(start)
+									return nil
+								})
+							}
+							if err := g.Wait(); err != nil {
+								b.Fatal(err)
+							}
+							for _, d := range durations {
+								total += d
+							}
+						}
+						b.StopTimer()
+						b.ReportMetric(float64(total)/float64(time.Millisecond)/float64(b.N*jobs), "ms/job")
+					})
+				}
+			}
+		})
+	}
+}

--- a/pkg/dockerbuild/read_ahead_test.go
+++ b/pkg/dockerbuild/read_ahead_test.go
@@ -1,0 +1,375 @@
+package dockerbuild
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/cockroachdb/errors"
+
+	"encr.dev/pkg/tarstream"
+)
+
+func TestFileReadAheadOverlapsWithinBudget(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		stats := &fileReadStats{}
+		var vecs []tarstream.Datavec
+		for range 8 {
+			vecs = append(vecs, &testFileVec{data: bytes.Repeat([]byte("abcdefgh"), 16), stats: stats})
+		}
+		r := newFileReadAhead(t.Context(), vecs, allFileIndices(vecs), 32, 4)
+		synctest.Wait()
+		if stats.bytes.Load() != 32 || stats.opens.Load() != 4 {
+			t.Fatalf("prefetched bytes=%d, files=%d", stats.bytes.Load(), stats.opens.Load())
+		}
+		if _, err := r.Read(make([]byte, 1)); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+		if stats.bytes.Load() != 32 {
+			t.Fatal("partially consumed buffer exceeded budget")
+		}
+		if _, err := r.Read(make([]byte, 1)); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+		if stats.bytes.Load() != 34 {
+			t.Fatalf("prefetch did not refill the released buffer: %d", stats.bytes.Load())
+		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if stats.active.Load() != 0 || stats.closes.Load() != 4 {
+			t.Fatal("early close leaked a file")
+		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if stats.closes.Load() != 4 {
+			t.Fatal("closed a file twice")
+		}
+	})
+}
+
+func TestFileReadAheadFourDistinctFilesAndOrderedTar(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		stats := &fileReadStats{}
+		var vecs []tarstream.Datavec
+		var files []int
+		var sources []*testFileVec
+		var want []byte
+		gates := make([]chan struct{}, 4)
+		for i := range 8 {
+			data := bytes.Repeat([]byte{byte('a' + i)}, 4)
+			src := &testFileVec{data: data, stats: stats}
+			if i < 4 {
+				gates[i] = make(chan struct{})
+				src.gate = gates[i]
+			}
+			sources = append(sources, src)
+			vecs = append(vecs, tarstream.MemVec{Data: []byte("header")})
+			files = append(files, len(vecs))
+			vecs = append(vecs, src, tarstream.PadVec{Size: 2})
+			want = append(want, []byte("header")...)
+			want = append(want, data...)
+			want = append(want, 0, 0)
+		}
+		r := newFileReadAhead(t.Context(), vecs, files, 16, 4)
+		synctest.Wait()
+		if stats.reading.Load() != 4 || stats.active.Load() != 4 {
+			t.Fatalf("not four concurrent disk reads: reading=%d, open=%d", stats.reading.Load(), stats.active.Load())
+		}
+		// Later files complete before the first one, then workers can open more
+		// files while their contents remain queued. Bytes still cannot overtake
+		// the earlier file or exceed the buffer budget.
+		for _, i := range []int{3, 2, 1} {
+			close(gates[i])
+			synctest.Wait()
+		}
+		if stats.bytes.Load() != 12 || stats.peak.Load() != 4 {
+			t.Fatal("exceeded the buffer or open-file bound")
+		}
+		close(gates[0])
+		synctest.Wait()
+		if stats.bytes.Load() != 16 || stats.peak.Load() != 4 {
+			t.Fatal("exceeded the buffer or open-file bound")
+		}
+		got, err := io.ReadAll(r)
+		if err != nil || !bytes.Equal(got, want) {
+			t.Fatalf("ordered tar contents changed: %q, %v", got, err)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if stats.peak.Load() != 4 || stats.active.Load() != 0 || stats.closes.Load() != 8 {
+			t.Fatalf("file lifecycle: peak=%d active=%d closes=%d", stats.peak.Load(), stats.active.Load(), stats.closes.Load())
+		}
+		for _, src := range sources {
+			if src.opens.Load() != 1 {
+				t.Fatal("split a source file across readers or reopened it")
+			}
+		}
+	})
+}
+
+func TestFileReadAheadLargeFileWithSmallFollowers(t *testing.T) {
+	for _, workers := range []int{1, 2, 4} {
+		for _, budget := range []int{1, 3, 16, 100} {
+			stats := &fileReadStats{}
+			var vecs []tarstream.Datavec
+			var want []byte
+			for i, size := range []int{1001, 1, 19, 5, 2001, 3, 0} {
+				data := bytes.Repeat([]byte{byte('a' + i)}, size)
+				vecs = append(vecs, &testFileVec{data: data, stats: stats})
+				want = append(want, data...)
+			}
+			r := newFileReadAhead(t.Context(), vecs, allFileIndices(vecs), budget, workers)
+			if n, err := r.Read(nil); n != 0 || err != nil {
+				t.Fatalf("empty read: %d, %v", n, err)
+			}
+			got, err := io.ReadAll(r)
+			if err != nil || !bytes.Equal(got, want) {
+				t.Fatalf("workers=%d budget=%d: got %d bytes, %v", workers, budget, len(got), err)
+			}
+			if err := r.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if stats.active.Load() != 0 || stats.peak.Load() > int64(min(workers, budget)) {
+				t.Fatal("exceeded open file bound or leaked files")
+			}
+		}
+	}
+}
+
+func TestFileReadAheadSourceErrors(t *testing.T) {
+	sentinel := errors.New("source failed")
+	for _, tc := range []struct {
+		name   string
+		source *testFileVec
+		want   string
+		err    error
+	}{
+		{"open", &testFileVec{data: []byte("abcdefgh"), openErr: sentinel}, "", sentinel},
+		{"truncated", &testFileVec{data: []byte("abc"), recordedSize: 8}, "abc", io.ErrUnexpectedEOF},
+		{"grown", &testFileVec{data: []byte("abcdefgh"), recordedSize: 4}, "abcd", nil},
+		{"full-chunk-error", &testFileVec{data: []byte("abcdefgh"), readErr: sentinel}, "ab", sentinel},
+		{"no-progress", &testFileVec{data: []byte("abcdefgh"), noProgress: true}, "", io.ErrNoProgress},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := &fileReadStats{}
+			tc.source.stats = stats
+			r := newFileReadAhead(t.Context(), []tarstream.Datavec{tc.source}, []int{0}, 8, 4)
+			got, err := io.ReadAll(r)
+			if string(got) != tc.want || !errors.Is(err, tc.err) {
+				t.Fatalf("got %q / %v, want %q / %v", got, err, tc.want, tc.err)
+			}
+			if err := r.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if stats.active.Load() != 0 || stats.opens.Load() != stats.closes.Load() {
+				t.Fatal("failed read leaked a file")
+			}
+		})
+	}
+}
+
+func TestFileReadAheadReportsIntermediateCloseErrors(t *testing.T) {
+	sentinel := errors.New("close failed")
+	stats := &fileReadStats{}
+	var vecs []tarstream.Datavec
+	for i := range 9 {
+		src := &testFileVec{data: []byte("abcdefgh"), stats: stats}
+		if i == 0 {
+			src.closeErr = sentinel
+		} // Not the last file of its worker.
+		vecs = append(vecs, src)
+	}
+	r := newFileReadAhead(t.Context(), vecs, allFileIndices(vecs), 16, 4)
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); !errors.Is(err, sentinel) {
+		t.Fatalf("Close lost error: %v", err)
+	}
+	if stats.opens.Load() != 9 || stats.closes.Load() != 9 {
+		t.Fatal("did not close every file")
+	}
+}
+
+func TestFileReadAheadCancellationDuringReads(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		stats := &fileReadStats{}
+		gate := make(chan struct{})
+		var vecs []tarstream.Datavec
+		for range 8 {
+			vecs = append(vecs, &testFileVec{data: []byte("abcdefgh"), gate: gate, stats: stats})
+		}
+		r := newFileReadAhead(t.Context(), vecs, allFileIndices(vecs), 16, 4)
+		readDone := make(chan error, 1)
+		go func() { _, err := io.ReadAll(r); readDone <- err }()
+		synctest.Wait()
+		if stats.reading.Load() != 4 {
+			t.Fatal("four file reads did not start")
+		}
+		closed := make(chan error, 1)
+		go func() { closed <- r.Close() }()
+		synctest.Wait()
+		if err := <-readDone; !errors.Is(err, context.Canceled) {
+			t.Fatalf("Read did not wake on cancellation: %v", err)
+		}
+		if stats.closes.Load() != 0 {
+			t.Fatal("closed a file while ReadAt was in flight")
+		}
+		select {
+		case <-closed:
+			t.Fatal("Close did not join the filesystem reads")
+		default:
+		}
+		close(gate)
+		if err := <-closed; err != nil {
+			t.Fatal(err)
+		}
+		if stats.opens.Load() != 4 || stats.closes.Load() != 4 || stats.active.Load() != 0 {
+			t.Fatal("cancellation opened another file or leaked one")
+		}
+	})
+}
+
+func TestFileReadAheadLaterErrorWaitsForEarlierFile(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		stats := &fileReadStats{}
+		gate := make(chan struct{})
+		sentinel := errors.New("later file failed")
+		vecs := []tarstream.Datavec{&testFileVec{data: []byte("first"), stats: stats, gate: gate}, &testFileVec{data: []byte("second"), stats: stats, openErr: sentinel}}
+		r := newFileReadAhead(t.Context(), vecs, []int{0, 1}, 32, 4)
+		type result struct {
+			data []byte
+			err  error
+		}
+		done := make(chan result, 1)
+		go func() { data, err := io.ReadAll(r); done <- result{data, err} }()
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("later error overtook earlier file")
+		default:
+		}
+		close(gate)
+		got := <-done
+		if string(got.data) != "first" || !errors.Is(got.err, sentinel) {
+			t.Fatalf("got %q, %v", got.data, got.err)
+		}
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func allFileIndices(vecs []tarstream.Datavec) []int {
+	var indices []int
+	for i, vec := range vecs {
+		if vec.GetSize() > 0 {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
+type fileReadStats struct{ opens, closes, active, peak, bytes, reading atomic.Int64 }
+type testFileVec struct {
+	data                       []byte
+	recordedSize               int64
+	stats                      *fileReadStats
+	readLatency                time.Duration
+	gate                       <-chan struct{}
+	openErr, readErr, closeErr error
+	noProgress                 bool
+	opens                      atomic.Int64
+}
+
+func (v *testFileVec) GetSize() int64 {
+	if v.recordedSize > 0 {
+		return v.recordedSize
+	}
+	return int64(len(v.data))
+}
+func (v *testFileVec) Clone() tarstream.Datavec { return v }
+func (v *testFileVec) Open() (tarstream.DataReader, error) {
+	if v.openErr != nil {
+		return nil, v.openErr
+	}
+	v.opens.Add(1)
+	v.stats.opens.Add(1)
+	n := v.stats.active.Add(1)
+	for old := v.stats.peak.Load(); n > old && !v.stats.peak.CompareAndSwap(old, n); old = v.stats.peak.Load() {
+	}
+	return &testFileReader{vec: v, reader: bytes.NewReader(v.data)}, nil
+}
+
+type testFileReader struct {
+	vec    *testFileVec
+	reader *bytes.Reader
+}
+
+func (r *testFileReader) ReadAt(p []byte, off int64) (int, error) {
+	r.vec.stats.reading.Add(1)
+	defer r.vec.stats.reading.Add(-1)
+	if r.vec.readLatency > 0 {
+		time.Sleep(r.vec.readLatency)
+	}
+	if r.vec.gate != nil {
+		<-r.vec.gate
+	}
+	if r.vec.noProgress {
+		return 0, nil
+	}
+	n, err := r.reader.ReadAt(p, off)
+	r.vec.stats.bytes.Add(int64(n))
+	if r.vec.readErr != nil {
+		err = r.vec.readErr
+	}
+	return n, err
+}
+func (r *testFileReader) Close() error {
+	r.vec.stats.closes.Add(1)
+	r.vec.stats.active.Add(-1)
+	return r.vec.closeErr
+}
+
+// A deterministic latency model, not a measurement of SSD speed: each file fits
+// one read and that read waits 1 ms. Four workers must overlap those waits while
+// preserving identical output. The test uses virtual time, without a VM or sleep
+// in wall-clock time.
+func TestFileReadAheadOverlapsReadLatency(t *testing.T) {
+	for _, workers := range []int{1, 4} {
+		t.Run(fmt.Sprint(workers), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				stats := &fileReadStats{}
+				var vecs []tarstream.Datavec
+				var want []byte
+				for i := range 16 {
+					data := bytes.Repeat([]byte{byte(i)}, 1024)
+					vecs = append(vecs, &testFileVec{data: data, stats: stats, readLatency: time.Millisecond})
+					want = append(want, data...)
+				}
+				start := time.Now()
+				r := newFileReadAhead(t.Context(), vecs, allFileIndices(vecs), 64<<10, workers)
+				got, err := io.ReadAll(r)
+				if err != nil || !bytes.Equal(got, want) {
+					t.Fatalf("read: %v", err)
+				}
+				if err := r.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if elapsed := time.Since(start); elapsed != time.Duration(16/workers)*time.Millisecond {
+					t.Fatalf("workers %d: read waits did not overlap: %s", workers, elapsed)
+				}
+			})
+		})
+	}
+}

--- a/pkg/dockerbuild/tar_bench_test.go
+++ b/pkg/dockerbuild/tar_bench_test.go
@@ -1,0 +1,69 @@
+package dockerbuild
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+
+	"encr.dev/pkg/fns"
+)
+
+// BenchmarkImageTar separates directory/header preparation from streaming
+// tar bytes, so compression is not mistaken for tar work. It uses the same files
+// as BenchmarkImagePackaging and deliberately does no hashing or gzip work.
+func BenchmarkImageTar(b *testing.B) {
+	logger := log.Logger
+	log.Logger = log.Output(io.Discard)
+	defer func() { log.Logger = logger }()
+	for _, layout := range []string{"balanced", "dependencies"} {
+		b.Run(layout, func(b *testing.B) {
+			spec, size := packagingFixture(b, layout)
+
+			for _, workers := range []int{1, 2, 4} {
+				b.Run(fmt.Sprintf("prepare/workers%d", workers), func(b *testing.B) {
+					b.ReportAllocs()
+					for range b.N {
+						if _, err := buildImageFilesystem(b.Context(), spec, &ImageBuildConfig{PreparationConcurrency: workers, ReadAheadBytes: -1}); err != nil {
+							b.Fatal(err)
+						}
+					}
+				})
+			}
+			for _, ahead := range []int{-1, 256 << 10} {
+				layers, err := buildImageFilesystem(b.Context(), spec, &ImageBuildConfig{ReadAheadBytes: ahead})
+				if err != nil {
+					b.Fatal(err)
+				}
+				for _, workers := range []int{1, 2, 4} {
+					b.Run(fmt.Sprintf("read/ahead%d/workers%d", max(0, ahead>>10), workers), func(b *testing.B) {
+						b.SetBytes(size)
+						b.ReportAllocs()
+						for range b.N {
+							var g errgroup.Group
+							g.SetLimit(workers)
+							for _, layer := range layers {
+								g.Go(func() error {
+									r, err := layer.opener()
+									if err != nil {
+										return err
+									}
+									defer fns.CloseIgnore(r)
+									// Match the compressor's 32 KiB copy buffer, disabling
+									// io.Discard's differently sized ReadFrom fast path.
+									_, err = io.CopyBuffer(struct{ io.Writer }{io.Discard}, r, make([]byte, 32<<10))
+									return err
+								})
+							}
+							if err := g.Wait(); err != nil {
+								b.Fatal(err)
+							}
+						}
+					})
+				}
+			}
+		})
+	}
+}

--- a/pkg/dockerbuild/tar_golden_test.go
+++ b/pkg/dockerbuild/tar_golden_test.go
@@ -1,0 +1,197 @@
+package dockerbuild
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"encr.dev/pkg/fns"
+	"encr.dev/pkg/option"
+)
+
+// Captured from the serial assembler before parallel preparation/read-ahead,
+// running on Linux. Tar hashes pin exact headers, contents, symlinks, filtering
+// and DFS order. Symlink modes are normalized to 0777 so macOS agrees.
+func TestTarPreparationGolden(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses Unix modes and symlinks")
+	}
+	spec := tarGoldenFixture(t)
+	want := []string{
+		"sha256:b5e3a1a89f24e88e228aaf3b5aaafff51e6ca1c899173c0e96758b45f0d64171",
+		"sha256:182a34f2d7128ceac5160f5ccc161d8c50ebdf059dc688252956e8206950e41c",
+		"sha256:26cc06029f9a9c6a627bc516cbd7c974685b2285d1ae91d73846fcfb49a116da",
+	}
+	for _, workers := range []int{1, 2, 4} {
+		for _, budget := range []int{-1, 64 << 10, 256 << 10, 1 << 20} {
+			cfg := ImageBuildConfig{PreparationConcurrency: workers, ReadAheadBytes: budget}
+			layers, err := buildImageFilesystem(t.Context(), spec, &cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got []string
+			for _, layer := range layers {
+				r, err := layer.opener()
+				if err != nil {
+					t.Fatal(err)
+				}
+				h, _, err := v1.SHA256(r)
+				fns.CloseIgnore(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, h.String())
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("workers=%d ahead=%d: %q", workers, budget, got)
+			}
+		}
+	}
+}
+
+func TestTarOptionsPreserveCompressedDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses Unix modes and symlinks")
+	}
+	spec := tarGoldenFixture(t)
+	// Exercise more than four real disk sources in the dependency layer. Keep
+	// the original fixture unchanged for the pre-optimization tar goldens above.
+	bundle, ok := spec.BundleSource.Get()
+	if !ok {
+		t.Fatal("fixture has no source bundle")
+	}
+	for i := range 6 {
+		path := filepath.Join(bundle.Source.String(), "node_modules", "pkg", fmt.Sprintf("parallel-%d.js", i))
+		if err := os.WriteFile(path, bytes.Repeat([]byte{byte(i)}, 128<<10), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, level := range []int{1, 5} {
+		var want []v1.Hash
+		for _, cfg := range []ImageBuildConfig{
+			{},
+			{PreparationConcurrency: 1, ReadAheadBytes: -1},
+			{PreparationConcurrency: 4, ReadAheadBytes: 64 << 10, ReadAheadConcurrency: 1},
+			{PreparationConcurrency: 2, ReadAheadBytes: 256 << 10, ReadAheadConcurrency: 2},
+			{PreparationConcurrency: 4, ReadAheadBytes: 64 << 10, ReadAheadConcurrency: 4},
+			{PreparationConcurrency: 4, ReadAheadBytes: 1 << 20},
+		} {
+			cfg.CompressionLevel = level
+			img, err := BuildImage(t.Context(), spec, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			layers, err := img.Layers()
+			if err != nil {
+				fns.CloseIgnore(img)
+				t.Fatal(err)
+			}
+			var got []v1.Hash
+			for _, l := range layers {
+				h, err := l.Digest()
+				if err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, h)
+				r, err := l.Compressed()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := io.Copy(io.Discard, r); err != nil {
+					t.Fatal(err)
+				}
+				fns.CloseIgnore(r)
+			}
+			if err := img.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if want == nil {
+				want = got
+			} else if !slices.Equal(got, want) {
+				t.Fatalf("level %d changed gzip bytes", level)
+			}
+		}
+	}
+}
+
+func tarGoldenFixture(t *testing.T) *ImageSpec {
+	t.Helper()
+	root := t.TempDir()
+	// a/x before a.txt distinguishes WalkDir DFS order from sorting full paths.
+	files := map[string][]byte{
+		"a/x": []byte("nested"), "a.txt": []byte("sibling"), "empty": nil,
+		"node_modules/pkg/index.js":                     bytes.Repeat([]byte("export const value = 42;\n"), 40000),
+		"node_modules/pkg/fixtures/.modules.yaml":       []byte("keep"),
+		"node_modules/.modules.yaml":                    []byte("skip"),
+		"node_modules/.pnpm-workspace-state-v1.json":    []byte("skip"),
+		"excluded/secret":                               []byte("skip"),
+		"deep/" + strings.Repeat("long-", 30) + "/file": []byte("long header"),
+	}
+	for name, data := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Make the golden independent of the process umask. Directory and file
+	// modes match the original fixture captured with umask 022.
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		mode := fs.FileMode(0644)
+		if d.IsDir() {
+			mode = 0755
+		}
+		return os.Chmod(path, mode)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for name, target := range map[string]string{"link": "a/x", "node_modules/pkg/link": "index.js", "escape": "../outside"} {
+		if err := os.Symlink(target, filepath.Join(root, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &ImageSpec{OS: "linux", Arch: "amd64",
+		BundleSource: option.Some(BundleSourceSpec{Source: HostPath(root), Dest: "/workspace", AppRootRelpath: ".", ExcludeSource: []RelPath{"excluded"}}),
+		BuildInfo:    BuildInfoSpec{InfoPath: "/encore/build-info.json"},
+		WriteFiles:   map[ImagePath][]byte{"/encore/meta": []byte("metadata")},
+	}
+}
+
+func TestTarReadAheadRejectsTruncatedSource(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large-file")
+	if err := os.WriteFile(path, make([]byte, 2<<20), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tc := newTarCopier(setFileTimes(layerEpoch))
+	if err := tc.CopyFile("/file", HostPath(path), fi, ""); err != nil {
+		t.Fatal(err)
+	}
+	opener := tc.Opener()
+	if err := os.Truncate(path, 500000); err != nil {
+		t.Fatal(err)
+	}
+	// Real source -> read-ahead -> gzip: failure must reach image assembly rather
+	// than producing a corrupt tar or panicking in a background goroutine.
+	if _, err := compressLayer(t.Context(), &Image{dir: t.TempDir()}, opener, 5); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("compress truncated source = %v", err)
+	}
+}

--- a/pkg/dockerbuild/tar_pipeline_bench_test.go
+++ b/pkg/dockerbuild/tar_pipeline_bench_test.go
@@ -1,0 +1,69 @@
+package dockerbuild
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+
+	"encr.dev/pkg/fns"
+)
+
+// BenchmarkImageTarPipeline isolates the two tar optimizations with the same
+// compressor (gzip 5, two layers), including serialization and cleanup. Each
+// operation is a wave of jobs sharing immutable inputs, disk and GOMAXPROCS.
+func BenchmarkImageTarPipeline(b *testing.B) {
+	logger := log.Logger
+	log.Logger = log.Output(io.Discard)
+	defer func() { log.Logger = logger }()
+	for _, layout := range []string{"balanced", "dependencies"} {
+		b.Run(layout, func(b *testing.B) {
+			spec, size := packagingFixture(b, layout)
+			for _, workers := range []int{1, 2, 4} {
+				for _, ahead := range []int{-1, 64 << 10, 256 << 10, 1 << 20} {
+					for _, jobs := range []int{1, 4} {
+						b.Run(fmt.Sprintf("prepare%d/ahead%d/jobs%d", workers, max(0, ahead>>10), jobs), func(b *testing.B) {
+							cfg := ImageBuildConfig{PreparationConcurrency: workers, ReadAheadBytes: ahead, CompressionLevel: 5, CompressionConcurrency: 2, TempDir: b.TempDir()}
+							var total time.Duration
+							durations := make([]time.Duration, jobs)
+							b.SetBytes(size * int64(jobs))
+							b.ReportAllocs()
+							b.ResetTimer()
+							for range b.N {
+								var g errgroup.Group
+								for j := range jobs {
+									g.Go(func() error {
+										start := time.Now()
+										img, err := BuildImage(b.Context(), spec, cfg)
+										if err != nil {
+											return err
+										}
+										defer fns.CloseIgnore(img)
+										if err := tarball.Write(name.MustParseReference("bench:latest"), img, io.Discard); err != nil {
+											return err
+										}
+										durations[j] = time.Since(start)
+										return nil
+									})
+								}
+								if err := g.Wait(); err != nil {
+									b.Fatal(err)
+								}
+								for _, d := range durations {
+									total += d
+								}
+							}
+							b.StopTimer()
+							b.ReportMetric(float64(total)/float64(time.Millisecond)/float64(b.N*jobs), "ms/job")
+						})
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/dockerbuild/tar_prepare.go
+++ b/pkg/dockerbuild/tar_prepare.go
@@ -1,0 +1,195 @@
+package dockerbuild
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/semaphore"
+
+	"encr.dev/pkg/xos"
+)
+
+// Across concurrent builds in one process, metadata syscalls share a CPU-sized
+// budget (at most four). Per-image worker limits alone overdrive the filesystem
+// when several images are assembled together. These slots cover only preparation,
+// never compression or a wait for another node.
+var tarPreparationSlots = semaphore.NewWeighted(int64(min(4, runtime.GOMAXPROCS(0))))
+
+// A node's children retain os.ReadDir's lexical order. Workers only fill their
+// own nodes; the copier's mutable state is updated later in depth-first order.
+type tarNode struct {
+	path       HostPath
+	dirEntry   fs.DirEntry
+	entry      *tarEntry
+	dst        *tarCopier
+	depsParent bool
+	children   []*tarNode
+	err        error
+}
+
+func (tc *tarCopier) copyDir(ctx context.Context, desc *dirCopyDesc, workers int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fi, err := os.Lstat(desc.SrcPath.String())
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	root := &tarNode{path: desc.SrcPath, dirEntry: fs.FileInfoToDirEntry(fi)}
+	if err := prepareTarTree(ctx, root, workers, func(node *tarNode) {
+		if err := tarPreparationSlots.Acquire(ctx, 1); err != nil {
+			node.err = err
+			return
+		}
+		defer tarPreparationSlots.Release(1)
+		node.err = tc.prepareNode(desc, node)
+	}); err != nil {
+		return err
+	}
+	var merge func(*tarNode) error
+	merge = func(node *tarNode) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if node.err != nil {
+			return node.err
+		}
+		if node.depsParent {
+			rel, err := desc.SrcPath.Rel(node.path)
+			if err != nil {
+				return err
+			}
+			if err := node.dst.MkdirAll(desc.DstPath.Join(string(rel.ToImage())).Dir(), 0755); err != nil {
+				return err
+			}
+		}
+		if node.entry != nil {
+			node.dst.appendEntry(node.entry)
+		}
+		for _, child := range node.children {
+			if err := merge(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return errors.WithStack(merge(root))
+}
+
+// One coordinator dispatches work; workers never enqueue children themselves,
+// so a broad/deep tree cannot deadlock a bounded work channel. There are only
+// workers goroutines, regardless of tree size. Cancellation joins all of them.
+func prepareTarTree(ctx context.Context, root *tarNode, workers int, prepare func(*tarNode)) error {
+	ctx, cancel := context.WithCancel(ctx)
+	jobs := make(chan *tarNode)
+	done := make(chan *tarNode)
+	var wg sync.WaitGroup
+	defer func() { cancel(); close(jobs); wg.Wait() }()
+	for range workers {
+		wg.Go(func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case node, ok := <-jobs:
+					if !ok {
+						return
+					}
+					prepare(node)
+					select {
+					case done <- node:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		})
+	}
+	pending := []*tarNode{root}
+	active := 0
+	for len(pending) > 0 || active > 0 {
+		var out chan *tarNode
+		var next *tarNode
+		if len(pending) > 0 {
+			out, next = jobs, pending[len(pending)-1]
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- next:
+			pending[len(pending)-1] = nil
+			pending = pending[:len(pending)-1]
+			active++
+		case node := <-done:
+			active--
+			if node.err == nil {
+				pending = append(pending, node.children...)
+			}
+		}
+	}
+	return ctx.Err()
+}
+
+func (tc *tarCopier) prepareNode(desc *dirCopyDesc, node *tarNode) error {
+	path, d := node.path, node.dirEntry
+	if !shouldInclude(desc, path) || desc.ExcludeSrcPaths[path] {
+		return nil
+	}
+	rel, err := desc.SrcPath.Rel(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !d.IsDir() && isVolatilePnpmMetadata(rel) {
+		return nil
+	}
+	node.dst = tc
+	if desc.DepsCopier != nil {
+		if within, root := nodeModulesPath(rel); within {
+			node.dst, node.depsParent = desc.DepsCopier, root
+		}
+	}
+	dstPath := desc.DstPath.Join(string(rel.ToImage()))
+	var link ImagePath
+	isSymlink := d.Type()&fs.ModeSymlink != 0
+	if !isSymlink && runtime.GOOS == "windows" {
+		if junction, _ := xos.IsWindowsJunctionPoint(path.String()); junction {
+			return errors.Newf("%q is a windows junction point and cannot be copied to a docker image. Use symlinks instead.", path)
+		}
+	}
+	if isSymlink {
+		target, err := os.Readlink(path.String())
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		link, err = tc.rewriteSymlink(desc, path, HostPath(target))
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if link == "" {
+			return nil
+		}
+	}
+	fi, err := d.Info()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	node.entry, err = node.dst.prepareFile(dstPath, path, fi, link)
+	if err != nil {
+		return errors.Wrap(err, "add file")
+	}
+	if d.IsDir() {
+		children, err := os.ReadDir(path.String())
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		for _, child := range children {
+			node.children = append(node.children, &tarNode{path: HostPath(filepath.Join(path.String(), child.Name())), dirEntry: child})
+		}
+	}
+	return nil
+}

--- a/pkg/dockerbuild/tar_prepare_test.go
+++ b/pkg/dockerbuild/tar_prepare_test.go
@@ -1,0 +1,85 @@
+package dockerbuild
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/cockroachdb/errors"
+)
+
+func TestTarPreparationBoundsWorkers(t *testing.T) {
+	for _, workers := range []int{1, 2, 4} {
+		t.Run(fmt.Sprint(workers), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				root := &tarNode{}
+				for range 100 {
+					root.children = append(root.children, &tarNode{})
+				}
+				release := make(chan struct{})
+				finished := make(chan error, 1)
+				var active, entered atomic.Int64
+				go func() {
+					finished <- prepareTarTree(t.Context(), root, workers, func(node *tarNode) {
+						if node == root {
+							return
+						}
+						active.Add(1)
+						entered.Add(1)
+						<-release
+						active.Add(-1)
+					})
+				}()
+				synctest.Wait()
+				if n := active.Load(); n != int64(workers) {
+					t.Fatalf("active workers %d, want %d", n, workers)
+				}
+				if entered.Load() != int64(workers) {
+					t.Fatal("started work beyond the worker limit")
+				}
+				close(release)
+				if err := <-finished; err != nil {
+					t.Fatal(err)
+				}
+				if active.Load() != 0 || entered.Load() != 100 {
+					t.Fatal("workers did not join or skipped files")
+				}
+			})
+		})
+	}
+}
+
+func TestTarPreparationCancellationJoinsWorkers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		root := &tarNode{}
+		for range 100 {
+			root.children = append(root.children, &tarNode{})
+		}
+		finished := make(chan error, 1)
+		var active atomic.Int64
+		go func() {
+			finished <- prepareTarTree(ctx, root, 4, func(node *tarNode) {
+				if node == root {
+					return
+				}
+				active.Add(1)
+				<-ctx.Done()
+				active.Add(-1)
+			})
+		}()
+		synctest.Wait()
+		if active.Load() != 4 {
+			t.Fatal("workers did not start")
+		}
+		cancel()
+		if err := <-finished; !errors.Is(err, context.Canceled) {
+			t.Fatalf("result = %v", err)
+		}
+		if active.Load() != 0 {
+			t.Fatal("returned without joining workers")
+		}
+	})
+}

--- a/pkg/dockerbuild/tarcopy.go
+++ b/pkg/dockerbuild/tarcopy.go
@@ -3,6 +3,7 @@ package dockerbuild
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -20,7 +21,6 @@ import (
 
 	"encr.dev/pkg/option"
 	"encr.dev/pkg/tarstream"
-	"encr.dev/pkg/xos"
 	"encr.dev/v2/compiler/build"
 )
 
@@ -102,14 +102,22 @@ func (lc *layeredTarCopier) Layers() []imageLayer {
 }
 
 type tarCopier struct {
-	fileTimes *time.Time
-	entries   []*tarEntry
-	seenDirs  map[ImagePath]bool
+	ctx                context.Context
+	preparationWorkers int
+	readAheadBytes     int
+	readAheadWorkers   int
+	fileTimes          *time.Time
+	entries            []*tarEntry
+	seenDirs           map[ImagePath]bool
 }
 
 func newTarCopier(opts ...tarCopyOption) *tarCopier {
 	tc := &tarCopier{
-		seenDirs: make(map[ImagePath]bool),
+		seenDirs:           make(map[ImagePath]bool),
+		ctx:                context.Background(),
+		preparationWorkers: min(2, runtime.GOMAXPROCS(0)),
+		readAheadBytes:     256 << 10,
+		readAheadWorkers:   4,
 	}
 	for _, opt := range opts {
 		opt(tc)
@@ -247,93 +255,7 @@ func shouldInclude(desc *dirCopyDesc, path HostPath) bool {
 }
 
 func (tc *tarCopier) CopyDir(desc *dirCopyDesc) error {
-	err := filepath.WalkDir(string(desc.SrcPath), func(pathStr string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		path := HostPath(pathStr)
-
-		// Should we keep this path?
-		if !shouldInclude(desc, path) {
-			if d.IsDir() {
-				return filepath.SkipDir
-			} else {
-				return nil
-			}
-		}
-
-		// Should we skip this path?
-		if desc.ExcludeSrcPaths[path] {
-			if d.IsDir() {
-				return filepath.SkipDir
-			} else {
-				return nil
-			}
-		}
-
-		relPath, err := desc.SrcPath.Rel(path)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		// Skip volatile pnpm bookkeeping files; see volatilePnpmMetadata.
-		if !d.IsDir() && isVolatilePnpmMetadata(relPath) {
-			return nil
-		}
-
-		dstPath := desc.DstPath.Join(string(relPath.ToImage()))
-
-		// Route node_modules trees to the dependency layer's copier, if configured.
-		dst := tc
-		if desc.DepsCopier != nil {
-			if within, isRoot := nodeModulesPath(relPath); within {
-				dst = desc.DepsCopier
-				if isRoot {
-					// Entering a node_modules tree: make sure its parent
-					// directories exist in the dependency layer.
-					if err := dst.MkdirAll(dstPath.Dir(), 0755); err != nil {
-						return errors.Wrap(err, "create deps dirs")
-					}
-				}
-			}
-		}
-
-		// If this is a symlink, compute the link target relative to DstPath.
-		var link ImagePath
-
-		isSymlink := d.Type()&fs.ModeSymlink != 0
-		if !isSymlink && runtime.GOOS == "windows" {
-			// Check if the file is a junction point on Windows.
-			if isJunction, _ := xos.IsWindowsJunctionPoint(pathStr); isJunction {
-				return errors.Newf("%q is a windows junction point and cannot be copied to a docker image. Use symlinks instead.", pathStr)
-			}
-
-		}
-
-		if isSymlink {
-			target, err := os.Readlink(string(path))
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			link, err = tc.rewriteSymlink(desc, path, HostPath(target))
-			if err != nil {
-				return errors.WithStack(err)
-			} else if link == "" {
-				// Drop the symlink
-				return nil
-			}
-		}
-
-		fi, err := d.Info()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		err = dst.CopyFile(dstPath, path, fi, link)
-		return errors.Wrap(err, "add file")
-	})
-
-	return errors.WithStack(err)
+	return tc.copyDir(tc.ctx, desc, tc.preparationWorkers)
 }
 
 // rewriteSymlink rewrites the symlink to the target filesystem.
@@ -433,10 +355,26 @@ func (tc *tarCopier) MkdirAll(dstPath ImagePath, mode fs.FileMode) (err error) {
 	return nil
 }
 
-func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInfo, linkTarget ImagePath) (err error) {
-	header, err := tar.FileInfoHeader(fi, linkTarget.String())
+func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInfo, linkTarget ImagePath) error {
+	entry, err := tc.prepareFile(dstPath, srcPath, fi, linkTarget)
 	if err != nil {
 		return err
+	}
+	tc.appendEntry(entry)
+	return nil
+}
+
+func (tc *tarCopier) appendEntry(entry *tarEntry) {
+	tc.entries = append(tc.entries, entry)
+	if entry.header.Typeflag == tar.TypeDir {
+		tc.seenDirs[entry.dest] = true
+	}
+}
+
+func (tc *tarCopier) prepareFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInfo, linkTarget ImagePath) (*tarEntry, error) {
+	header, err := tar.FileInfoHeader(fi, linkTarget.String())
+	if err != nil {
+		return nil, err
 	}
 	if tc.fileTimes != nil {
 		header.ModTime = *tc.fileTimes
@@ -450,6 +388,11 @@ func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInf
 	header.Gid = 0
 	header.Uname = ""
 	header.Gname = ""
+	// Symlink permission bits are host-specific (0755 on macOS, 0777 on Linux)
+	// and ignored on extraction; pin them so the digest is the same everywhere.
+	if header.Typeflag == tar.TypeSymlink {
+		header.Mode = 0777
+	}
 
 	// HACK: make the linux binary executable when cross compiling from windows as the unix permissions gets lost.
 	if runtime.GOOS == "windows" && fi.Name() == build.BinaryName {
@@ -457,12 +400,10 @@ func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInf
 	}
 
 	header.Name = tarHeaderName(dstPath, fi.IsDir())
-	entry := &tarEntry{header: header}
-	tc.entries = append(tc.entries, entry)
+	entry := &tarEntry{header: header, dest: dstPath}
 
 	if fi.IsDir() {
-		tc.seenDirs[dstPath] = true
-		return nil
+		return encodeEntry(entry)
 	}
 
 	// If this is not a symlink, write the file.
@@ -470,7 +411,7 @@ func (tc *tarCopier) CopyFile(dstPath ImagePath, srcPath HostPath, fi fs.FileInf
 		entry.hostPath = option.Some(srcPath)
 	}
 
-	return nil
+	return encodeEntry(entry)
 }
 
 func (tc *tarCopier) WriteFile(dstPath ImagePath, mode fs.FileMode, data []byte) (err error) {
@@ -492,7 +433,9 @@ func (tc *tarCopier) WriteFile(dstPath ImagePath, mode fs.FileMode, data []byte)
 }
 
 type tarEntry struct {
-	header *tar.Header
+	dest        ImagePath
+	headerBytes []byte
+	header      *tar.Header
 
 	data     option.Option[[]byte]
 	hostPath option.Option[HostPath]
@@ -506,20 +449,15 @@ func (tc *tarCopier) Opener() tarball.Opener {
 	}
 
 	var dvecs []tarstream.Datavec
+	var fileIndices []int
 	for _, e := range tc.entries {
 
-		// create buffer to write tar header to
-		buf := new(bytes.Buffer)
-		tw := tar.NewWriter(buf)
-
-		// write tar header to buffer
-		if err := tw.WriteHeader(e.header); err != nil {
-			return errThunk(errors.Wrap(err, fmt.Sprintf("writing header %v", e)))
+		if e.headerBytes == nil {
+			if _, err := encodeEntry(e); err != nil {
+				return errThunk(err)
+			}
 		}
-
-		memv := tarstream.MemVec{
-			Data: buf.Bytes(),
-		}
+		memv := tarstream.MemVec{Data: e.headerBytes}
 
 		// add the tar header mem buffer to the tarvec
 		dvecs = append(dvecs, memv)
@@ -527,6 +465,9 @@ func (tc *tarCopier) Opener() tarball.Opener {
 		var dataEntry tarstream.Datavec
 		if hostPath, ok := e.hostPath.Get(); ok {
 			fi := e.header.FileInfo()
+			if fi.Mode().IsRegular() && fi.Size() > 0 {
+				fileIndices = append(fileIndices, len(dvecs))
+			}
 			dataEntry = &tarstream.PathVec{
 				Path: hostPath.String(),
 				Info: fi,
@@ -551,11 +492,31 @@ func (tc *tarCopier) Opener() tarball.Opener {
 		}
 	}
 
-	tv := tarstream.NewTarVec(dvecs)
-	return func() (io.ReadCloser, error) {
-		tv2 := tv.Clone()
-		return tv2, nil
+	var size int64
+	for _, vec := range dvecs {
+		size += vec.GetSize()
 	}
+	budget := tc.readAheadBytes
+	// Tiny and entirely in-memory layers cannot usefully overlap filesystem I/O.
+	if len(fileIndices) == 0 || size <= 64<<10 {
+		budget = -1
+	} else if int64(budget) > size {
+		budget = int(size)
+	}
+	return func() (io.ReadCloser, error) {
+		return newFileReadAhead(tc.ctx, dvecs, fileIndices, budget, tc.readAheadWorkers), nil
+	}
+}
+
+func encodeEntry(entry *tarEntry) (*tarEntry, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(entry.header); err != nil {
+		return nil, errors.Wrap(err, "encode tar header")
+	}
+	// This is only a header vector; closing tw would append archive terminators.
+	entry.headerBytes = buf.Bytes()
+	return entry, nil
 }
 
 func tarHeaderName(p ImagePath, isDir bool) string {

--- a/pkg/tarstream/file_changes_test.go
+++ b/pkg/tarstream/file_changes_test.go
@@ -1,0 +1,40 @@
+package tarstream
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+func TestFileSizeChanges(t *testing.T) {
+	for _, content := range []string{"ab", "abcdefgh"} {
+		t.Run(content, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file")
+			if err := os.WriteFile(path, []byte("abcd"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tv := NewTarVec([]Datavec{&PathVec{Path: path, Info: info}, MemVec{Data: []byte("end")}})
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := io.ReadAll(tv)
+			if len(content) < 4 {
+				if string(got) != content || !errors.Is(err, io.ErrUnexpectedEOF) {
+					t.Fatalf("truncated: %q, %v", got, err)
+				}
+			} else if string(got) != "abcdend" || err != nil {
+				t.Fatalf("grown: %q, %v", got, err)
+			}
+			if err := tv.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/tarstream/tarstream.go
+++ b/pkg/tarstream/tarstream.go
@@ -97,6 +97,9 @@ func (tv *TarVec) getReader() (*currReader, error) {
 
 // Read the data represented by the tarvec
 func (tv *TarVec) Read(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
 	cr, err := tv.getReader()
 	if err != nil {
 		return 0, err
@@ -113,16 +116,19 @@ func (tv *TarVec) Read(b []byte) (int, error) {
 		panic("TarVec: zero remaining size but more vecs exist")
 	}
 
+	b = b[:min(int64(len(b)), remaining)]
 	n, err := cr.data.ReadAt(b, off)
 	if err == io.EOF {
-		// Ignore EOF from individual readers.
-		// getReader reports EOF when running out of readers.
-		err = nil
+		if int64(n) < remaining {
+			err = io.ErrUnexpectedEOF
+		} else {
+			err = nil
+		}
+	}
+	if n == 0 && err == nil {
+		err = io.ErrNoProgress
 	}
 
-	if n == 0 && len(b) > 0 && (err == nil || err == io.EOF) {
-		panic("TarVec: empty read from vec, more data remaining")
-	}
 	tv.pos += int64(n)
 
 	return n, err


### PR DESCRIPTION
Parallelize tar writing, both with read-ahead of files and through multiple compression workers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791465901&installation_model_id=427204&pr_number=2576&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2576&signature=ef41f1bd15d1ed3b77930cce485fad4f39d6aa7e4279ff0671ad9f36928a3a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->