### PR TITLE
fix(cli): surface builder stderr in encore build docker

### DIFF
--- a/cli/daemon/export/export.go
+++ b/cli/daemon/export/export.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 	"time"
@@ -68,6 +69,11 @@ func Docker(ctx context.Context, app *apps.Instance, req *daemonpb.ExportRequest
 		Build:      buildInfo,
 		App:        app,
 		WorkingDir: ".",
+		// The builder subprocess writes npm's own output to its stderr. With no
+		// Stderr set it lands on the background daemon's stderr, which the CLI
+		// starts with output discarded - so install failures log nothing. Send
+		// it to the client's log stream instead, like the pre/post-build hooks.
+		Stderr: option.Some[io.Writer](streamLog.Stderr(false)),
 	})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Refs #2578.

## What this fixes

When `encore build docker` runs, the CLI starts the daemon in the background (`cmdutil/daemon.go` `StartDaemonInBackground`: `exec.Command` with nil Stdout/Stderr = output discarded), and the Docker export path (`cli/daemon/export/export.go`) calls `bld.Prepare` without `PrepareParams.Stderr`. The tsbuilder subprocess then defaults its stderr to the daemon's stderr (`v2/tsbuilder/tsbuilder.go:130-134`) - which is `/dev/null`. `package_mgmt.rs` runs npm with `.stdout_to_stderr()`, so npm's real error dies silently and the user sees only "build failed".

The patch passes the client's log stream into the Prepare call:

```go
Stderr: option.Some[io.Writer](streamLog.Stderr(false)),
```

the same writer the pre/post-build hooks already use (`executeHook`, `export.go:361`). With this, the reporter's next failing build prints the actual npm error.

Maintainer note: `ParseParams`/`CompileParams` carry the same unset `Stderr` option - the same one-liner extends there; scoped to `Prepare` because that is where npm runs.

## What this does not claim

This is instrumentation for the reported 1.58.4 -> 1.58.5 npm regression, not a proven fix for the regression itself. By elimination: the only npm-invocation change in the 21-commit range is `package_mgmt.rs` (production-only installs), but in `All` mode - the only mode at 1.58.5 - the command is byte-identical to 1.58.4. Both published 1.58.4/1.58.5 linux_amd64 tarballs were driven through the `tsparser-encore prepare` wire protocol against clean and devDependency fixtures and both succeed identically (npm 10.9.8/Node 22), glibc floor identical. The remaining suspects are the dockerbuild perf commits (parallel layer compression + parallel tar prep/prefetch) - the reporter's ~1s-to-failure on CI (Node 18) fits a timing/prefetch failure more than an npm-behavior change. Their next failing build, with this patch, prints the real error.

## Verification

Chain re-verified in source at `main` (4ad818f): background daemon discards output (`cmdutil/daemon.go:117+`, nil Stdout/Stderr), `PrepareParams.Stderr option.Option[io.Writer]` exists (`pkg/builder/builder.go:106-115`), `runlog.Log.Stderr(buffered bool) io.Writer`, tsbuilder os.Stderr fallback, and the `executeHook` writer shape the patch mirrors. gofmt clean; `go build ./cli/daemon/export/` verified with real module deps on go 1.26.6. **Not run:** the reporter's actual failing build (no docker here, their app unavailable) - disclosed above; the live-repro result (both versions succeed) is part of the issue comment.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791602506&installation_model_id=427204&pr_number=2579&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2579&signature=995395cdd084d66a211b9819b917a5d14ebd84e6e2360c97709e0f0d57bcbdcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->