### PR TITLE
Close leaked resources and reap editor processes

### DIFF
--- a/cli/cmd/encore/app/create_form.go
+++ b/cli/cmd/encore/app/create_form.go
@@ -709,6 +709,7 @@ func fetchTemplates(url string, defaults []templateItem) []templateItem {
 	defer cancel()
 	if req, err := http.NewRequestWithContext(ctx, "GET", url, nil); err == nil {
 		if resp, err := http.DefaultClient.Do(req); err == nil {
+			defer resp.Body.Close()
 			if data, err := io.ReadAll(resp.Body); err == nil {
 				data, err = hujson.Standardize(data)
 				if err == nil {

--- a/cli/cmd/git-remote-encore/main.go
+++ b/cli/cmd/git-remote-encore/main.go
@@ -102,6 +102,7 @@ func connect(args []string, svc string) error {
 		return err
 	}
 	cfgPath := cfg.Name()
+	_ = cfg.Close()
 	defer func() { _ = os.Remove(cfgPath) }()
 
 	// Communicate to Git that the connection is established.

--- a/pkg/editors/launch.go
+++ b/pkg/editors/launch.go
@@ -62,5 +62,10 @@ func LaunchExternalEditor(fullPath string, startLine int, startCol int, editor F
 
 	log.Info().Str("full_path", fullPath).Str("editor", string(editor.Editor)).Str("cmd", cmd.String()).Msg("attempting to open file")
 
-	return errors.Wrap(cmd.Start(), "failed to start editor")
+	if err := cmd.Start(); err != nil {
+		return errors.Wrap(err, "failed to start editor")
+	}
+	// Reap the detached editor process so it doesn't linger as a zombie.
+	go func() { _ = cmd.Wait() }()
+	return nil
 }

--- a/pkg/releaser/steps/tsparserwasm/compile.go
+++ b/pkg/releaser/steps/tsparserwasm/compile.go
@@ -103,6 +103,7 @@ func gzipFileInPlace(path string) error {
 
 	w := gzip.NewWriter(f)
 	if _, err := w.Write(src); err != nil {
+		_ = w.Close()
 		return err
 	}
 	return w.Close()

--- a/runtimes/go/appruntime/exported/config/parse.go
+++ b/runtimes/go/appruntime/exported/config/parse.go
@@ -22,6 +22,7 @@ func gunzip(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer gz.Close()
 	return io.ReadAll(gz)
 }
 

--- a/runtimes/go/appruntime/infrasdk/metrics/prometheus/prometheus.go
+++ b/runtimes/go/appruntime/infrasdk/metrics/prometheus/prometheus.go
@@ -64,10 +64,11 @@ func (x *Exporter) Export(ctx context.Context, collected []metrics.CollectedMetr
 	req.Header.Set("Content-Encoding", "snappy")
 	req.Header.Set("User-Agent", "encore")
 	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
-	_, err = http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("unable to send metrics to Prometheus remote write destination: %v", err)
 	}
+	defer resp.Body.Close()
 
 	return nil
 }


### PR DESCRIPTION
The Prometheus remote-write exporter discards the response from `http.Do`, so every metrics push leaks the response body and its connection. This change closes the response body. It also closes the response body in `fetchTemplates`, the temporary config file handle in `git-remote-encore`, the gzip writer when writing the wasm release artifact fails, and the gzip reader in the runtime config parser.

Editor launches now call `Wait` in the background so detached processes are reaped instead of remaining as zombies on Unix for the daemon's lifetime.

Testing:

- `go build ./cli/cmd/encore`
- `go build ./cli/cmd/git-remote-encore`
- `go test ./cli/cmd/encore/app ./cli/cmd/git-remote-encore ./pkg/editors ./pkg/releaser/steps/tsparserwasm`
- From `runtimes/go`: `go test ./appruntime/exported/config ./appruntime/infrasdk/metrics/prometheus`

I found these issues through a static analysis tool I'm developing called [gohawk](https://github.com/kojah/gohawk). If you're interested, let me know and I can open a separate PR to add gohawk to your linter configuration :) You can view more comprehensive information about the project on the documentation website: [https://gohawk.dev](https://gohawk.dev)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/encoredev/codesmith/encore/pr/2580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791658388&installation_model_id=427204&pr_number=2580&repository=encoredev%2Fencore&return_to=https%3A%2F%2Fgithub.com%2Fencoredev%2Fencore%2Fpull%2F2580&signature=cc265d05e0101647d7ab978e9af3b44d674df1048fd53093062bb43814d1cb5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->